### PR TITLE
Use private cluster module v12.3.0

### DIFF
--- a/setup/infra/private-cluster/main.tf
+++ b/setup/infra/private-cluster/main.tf
@@ -16,7 +16,7 @@
 
 module "broker" {
   source = "terraform-google-modules/kubernetes-engine/google//modules/beta-private-cluster-update-variant"
-
+  version = "12.3.0"
   project_id                = var.project_id
   release_channel           = "REGULAR"
   name                      = "${var.name}-${var.region}"


### PR DESCRIPTION
User an earlier version of the private cluster module because of incompatibilities issues with the current terraform version.

Error log reported on cloud build after attempting to deploy a private cluster
```
Step #4 - "deploy-cluster-region": Warning: Provider source not supported in Terraform v0.12
Step #4 - "deploy-cluster-region": 
Step #4 - "deploy-cluster-region":   on .terraform/modules/broker/modules/beta-private-cluster-update-variant/versions.tf line 22, in terraform:
Step #4 - "deploy-cluster-region":   22:     google-beta = {
Step #4 - "deploy-cluster-region":   23:       source  = "hashicorp/google-beta"
Step #4 - "deploy-cluster-region":   24:       version = ">= 3.49.0, <4.0.0"
Step #4 - "deploy-cluster-region":   25:     }
Step #4 - "deploy-cluster-region": 
Step #4 - "deploy-cluster-region": A source was declared for provider google-beta. Terraform v0.12 does not
Step #4 - "deploy-cluster-region": support the provider source attribute. It will be ignored.
Step #4 - "deploy-cluster-region": 
Step #4 - "deploy-cluster-region": (and one more similar warning elsewhere)
Step #4 - "deploy-cluster-region": 
Step #4 - "deploy-cluster-region": 
Step #4 - "deploy-cluster-region": Error: Unsupported block type
Step #4 - "deploy-cluster-region": 
Step #4 - "deploy-cluster-region":   on .terraform/modules/broker/modules/beta-private-cluster-update-variant/versions.tf line 31, in terraform:
Step #4 - "deploy-cluster-region":   31:   provider_meta "google-beta" {
Step #4 - "deploy-cluster-region": 
Step #4 - "deploy-cluster-region": Blocks of type "provider_meta" are not expected here.
```