### PR TITLE
Added support for custom CIDR ranges

### DIFF
--- a/setup/infra/cluster/network.tf
+++ b/setup/infra/cluster/network.tf
@@ -20,7 +20,7 @@ data "google_compute_network" "broker" {
 
 resource "google_compute_subnetwork" "broker" {
   name                     = "${var.name}-${var.region}"
-  ip_cidr_range            = "10.${2 + lookup(local.cluster_regions, var.region)}.0.0/16"
+  ip_cidr_range = var.ip_cidr_range.nodes != "" ?  var.ip_cidr_range.nodes : "10.${2 + lookup(local.cluster_regions, var.region)}.0.0/16"
   region                   = var.region
   network                  = data.google_compute_network.broker.self_link
   private_ip_google_access = true
@@ -28,11 +28,11 @@ resource "google_compute_subnetwork" "broker" {
   secondary_ip_range = [
     {
       range_name    = "${var.region}-pods"
-      ip_cidr_range = "172.${16 + lookup(local.cluster_regions, var.region)}.0.0/16"
+      ip_cidr_range = var.ip_cidr_range.pods != "" ?  var.ip_cidr_range.pods : "172.${16 + lookup(local.cluster_regions, var.region)}.0.0/16"
     },
     {
       range_name    = "${var.region}-services"
-      ip_cidr_range = "192.168.${lookup(local.cluster_regions, var.region)}.0/24"
+      ip_cidr_range = var.ip_cidr_range.services != "" ?  var.ip_cidr_range.services : "192.168.${lookup(local.cluster_regions, var.region)}.0/24"
     },
   ]
 }

--- a/setup/infra/cluster/network.tf
+++ b/setup/infra/cluster/network.tf
@@ -20,7 +20,7 @@ data "google_compute_network" "broker" {
 
 resource "google_compute_subnetwork" "broker" {
   name                     = "${var.name}-${var.region}"
-  ip_cidr_range = var.ip_cidr_range.nodes != "" ?  var.ip_cidr_range.nodes : "10.${2 + lookup(local.cluster_regions, var.region)}.0.0/16"
+  ip_cidr_range            = var.ip_cidr_range.nodes != "" ?  var.ip_cidr_range.nodes : "10.${2 + lookup(local.cluster_regions, var.region)}.0.0/16"
   region                   = var.region
   network                  = data.google_compute_network.broker.self_link
   private_ip_google_access = true

--- a/setup/infra/cluster/variables.tf
+++ b/setup/infra/cluster/variables.tf
@@ -82,7 +82,7 @@ variable turn_pool_disk_type {
 }
 
 variable "ip_cidr_range" {
-  description = "Custom IP CIRD ranges"
+  description = "Custom IP CIDR ranges"
   type = map(string)
   default = {
     nodes = ""

--- a/setup/infra/cluster/variables.tf
+++ b/setup/infra/cluster/variables.tf
@@ -80,3 +80,13 @@ variable turn_pool_disk_size_gb {
 variable turn_pool_disk_type {
   default = "pd-standard"
 }
+
+variable "ip_cidr_range" {
+  description = "Custom IP CIRD ranges"
+  type = map(string)
+  default = {
+    nodes = ""
+    pods = ""
+    services = ""
+  }
+}

--- a/setup/infra/private-cluster/main.tf
+++ b/setup/infra/private-cluster/main.tf
@@ -31,7 +31,7 @@ module "broker" {
   service_account           = length(var.service_account) == 0 ? "broker@${var.project_id}.iam.gserviceaccount.com" : var.service_account
   remove_default_node_pool  = true
   network_policy            = var.network_policy
-  master_ipv4_cidr_block    = "172.${2 + lookup(local.cluster_regions, var.region)}.0.0/28"
+  master_ipv4_cidr_block    = var.ip_cidr_range.master != "" ?  var.ip_cidr_range.master : "172.${2 + lookup(local.cluster_regions, var.region)}.0.0/28"
   enable_private_endpoint   = false
   enable_private_nodes      = true
   default_max_pods_per_node = var.max_pods_per_node

--- a/setup/infra/private-cluster/network.tf
+++ b/setup/infra/private-cluster/network.tf
@@ -20,7 +20,7 @@ data "google_compute_network" "broker" {
 
 resource "google_compute_subnetwork" "broker" {
   name                     = "${var.name}-${var.region}"
-  ip_cidr_range            = "10.${2 + lookup(local.cluster_regions, var.region)}.0.0/16"
+  ip_cidr_range = var.ip_cidr_range.nodes != "" ?  var.ip_cidr_range.nodes : "10.${2 + lookup(local.cluster_regions, var.region)}.0.0/16"
   region                   = var.region
   network                  = data.google_compute_network.broker.self_link
   private_ip_google_access = true
@@ -28,11 +28,11 @@ resource "google_compute_subnetwork" "broker" {
   secondary_ip_range = [
     {
       range_name    = "${var.region}-pods"
-      ip_cidr_range = "172.${16 + lookup(local.cluster_regions, var.region)}.0.0/18"
+      ip_cidr_range = var.ip_cidr_range.pods != "" ?  var.ip_cidr_range.pods : "172.${16 + lookup(local.cluster_regions, var.region)}.0.0/18"
     },
     {
       range_name    = "${var.region}-services"
-      ip_cidr_range = "192.168.${lookup(local.cluster_regions, var.region)}.0/24"
+      ip_cidr_range = var.ip_cidr_range.services != "" ?  var.ip_cidr_range.services : "192.168.${lookup(local.cluster_regions, var.region)}.0/24"
     },
   ]
 }

--- a/setup/infra/private-cluster/network.tf
+++ b/setup/infra/private-cluster/network.tf
@@ -20,7 +20,7 @@ data "google_compute_network" "broker" {
 
 resource "google_compute_subnetwork" "broker" {
   name                     = "${var.name}-${var.region}"
-  ip_cidr_range = var.ip_cidr_range.nodes != "" ?  var.ip_cidr_range.nodes : "10.${2 + lookup(local.cluster_regions, var.region)}.0.0/16"
+  ip_cidr_range            = var.ip_cidr_range.nodes != "" ?  var.ip_cidr_range.nodes : "10.${2 + lookup(local.cluster_regions, var.region)}.0.0/16"
   region                   = var.region
   network                  = data.google_compute_network.broker.self_link
   private_ip_google_access = true

--- a/setup/infra/private-cluster/variables.tf
+++ b/setup/infra/private-cluster/variables.tf
@@ -83,3 +83,14 @@ variable turn_pool_instance_count {
 variable turn_pool_preemptive_nodes {
   default = false
 }
+
+variable "ip_cidr_range" {
+  description = "Custom IP CIRD ranges"
+  type = map(string)
+  default = {
+    nodes = ""
+    pods = ""
+    services = ""
+    master = ""
+  }
+}

--- a/setup/infra/private-cluster/variables.tf
+++ b/setup/infra/private-cluster/variables.tf
@@ -85,7 +85,7 @@ variable turn_pool_preemptive_nodes {
 }
 
 variable "ip_cidr_range" {
-  description = "Custom IP CIRD ranges"
+  description = "Custom IP CIDR ranges"
   type = map(string)
   default = {
     nodes = ""


### PR DESCRIPTION
Added support for custom CIDR range for private and public clusters.

Usage:

Create a file with the custom CIDR ranges, update it with your custom values.

```bash
cat > broker-tfvars-ip_cidr_range.auto.tfvars <<EOF
ip_cidr_range = {nodes="10.11.0.0/16", pods="10.242.0.0/16", services="192.168.9.0/24",master="172.11.0.0/28"}
EOF
```

Create the`broker-tfvars-ip_cidr_range` secret with the `broker-tfvars-ip_cidr_range.auto.tfvars`  content

```bash
gcloud secrets create broker-tfvars-ip_cidr_range \
  --replication-policy=automatic \
  --data-file broker-tfvars-ip_cidr_range.auto.tfvars
```