### PR TITLE
Add tfvars to set the cluster release channel

### DIFF
--- a/setup/infra/cluster/main.tf
+++ b/setup/infra/cluster/main.tf
@@ -17,7 +17,7 @@
 module "broker" {
   source                   = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/beta-public-cluster?ref=v9.0.0"
   project_id               = var.project_id
-  release_channel          = "REGULAR"
+  release_channel          = var.release_channel
   name                     = "${var.name}-${var.region}"
   regional                 = true
   region                   = var.region

--- a/setup/infra/cluster/variables.tf
+++ b/setup/infra/cluster/variables.tf
@@ -17,6 +17,11 @@
 variable project_id {}
 variable region {}
 
+variable release_channel {
+  description = "Configuration options for the Release channels https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels"
+  default = "REGULAR"
+}
+
 variable service_account {
   # If not specified, will use: broker@${var.project_id}.iam.gserviceaccount.com
   default = ""

--- a/setup/infra/private-cluster/main.tf
+++ b/setup/infra/private-cluster/main.tf
@@ -18,7 +18,7 @@ module "broker" {
   source = "terraform-google-modules/kubernetes-engine/google//modules/beta-private-cluster-update-variant"
   version = "12.3.0"
   project_id                = var.project_id
-  release_channel           = "REGULAR"
+  release_channel           = var.release_channel
   name                      = "${var.name}-${var.region}"
   regional                  = true
   region                    = var.region

--- a/setup/infra/private-cluster/variables.tf
+++ b/setup/infra/private-cluster/variables.tf
@@ -17,6 +17,11 @@
 variable project_id {}
 variable region {}
 
+variable release_channel {
+  description = "Configuration options for the Release channels https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels"
+  default = "REGULAR"
+}
+
 variable service_account {
   # If not specified, will use: broker@${var.project_id}.iam.gserviceaccount.com
   default = ""


### PR DESCRIPTION
Added support to set cluster release channel through tfvars

```terraform
variable release_channel {
  description = "Configuration options for the Release channels https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels"
  default = "REGULAR"
}

```
