### PR TITLE
Support for Custom GCLB SSL Policy

### DIFF
--- a/setup/infra/lb.tf
+++ b/setup/infra/lb.tf
@@ -129,15 +129,16 @@ resource "google_compute_target_https_proxy" "ingress" {
   name             = "istio-ingressgateway"
   url_map          = google_compute_url_map.ingress.self_link
   ssl_certificates = concat(list(google_compute_managed_ssl_certificate.ingress.self_link), values(google_compute_managed_ssl_certificate.extras).*.self_link)
-  ssl_policy = var.custom_ssl_policy_enabled ? concat(google_compute_ssl_policy.ssl_policy.*.id, [""])[0] : null
+  ssl_policy       = var.custom_ssl_policy_enabled ? concat(google_compute_ssl_policy.ssl_policy.*.id, [""])[0] : null
 }
 
+# SSL Policy
 resource "google_compute_ssl_policy" "ssl_policy" {
   name            = "${var.name}-ssl-policy"
   min_tls_version = var.ssl_policy_min_tls_version
   profile         = var.ssl_policy_profile
   custom_features = var.ssl_policy_profile == "CUSTOM" ? var.ssl_policy_custom_features : null
-  count           = var.custom_ssl_policy_enabled ? 1 : 0
+  count           = var.custom_ssl_policy_delete ? 0 : 1
 }
 
 # Forwarding rule - HTTP

--- a/setup/infra/lb.tf
+++ b/setup/infra/lb.tf
@@ -129,6 +129,15 @@ resource "google_compute_target_https_proxy" "ingress" {
   name             = "istio-ingressgateway"
   url_map          = google_compute_url_map.ingress.self_link
   ssl_certificates = concat(list(google_compute_managed_ssl_certificate.ingress.self_link), values(google_compute_managed_ssl_certificate.extras).*.self_link)
+  ssl_policy = var.custom_ssl_policy_enabled ? concat(google_compute_ssl_policy.ssl_policy.*.id, [""])[0] : null
+}
+
+resource "google_compute_ssl_policy" "ssl_policy" {
+  name            = "${var.name}-ssl-policy"
+  min_tls_version = var.ssl_policy_min_tls_version
+  profile         = var.ssl_policy_profile
+  custom_features = var.ssl_policy_profile == "CUSTOM" ? var.ssl_policy_custom_features : null
+  count           = var.custom_ssl_policy_enabled ? 1 : 0
 }
 
 # Forwarding rule - HTTP

--- a/setup/infra/variables.tf
+++ b/setup/infra/variables.tf
@@ -31,3 +31,26 @@ variable "additional_ssl_certificate_domains" {
   type        = list
   default     = []
 }
+
+variable "custom_ssl_policy_enabled" {
+  description = "Enable custom SSL Policy"
+  default     = true
+}
+
+variable "ssl_policy_min_tls_version" {
+  description = "(optional) - The minimum version of SSL protocol that can be used by the clients\nto establish a connection with the load balancer. Default value: \"TLS_1_0\" Possible values: [\"TLS_1_0\", \"TLS_1_1\", \"TLS_1_2\"]"
+  type        = string
+  default     = "TLS_1_0"
+}
+
+variable "ssl_policy_profile" {
+  description = "(optional) - Profile specifies the set of SSL features that can be used by the\nload balancer when negotiating SSL with clients. If using 'CUSTOM',\nthe set of SSL features to enable must be specified in the\n'customFeatures' field.\n\nSee the [official documentation](https://cloud.google.com/compute/docs/load-balancing/ssl-policies#profilefeaturesupport)\nfor information on what cipher suites each profile provides. If\n'CUSTOM' is used, the 'custom_features' attribute **must be set**. Default value: \"COMPATIBLE\" Possible values: [\"COMPATIBLE\", \"MODERN\", \"RESTRICTED\", \"CUSTOM\"]"
+  type        = string
+  default     = "COMPATIBLE"
+}
+
+variable "ssl_policy_custom_features" {
+  description = "(optional) - Profile specifies the set of SSL features that can be used by the\nload balancer when negotiating SSL with clients. This can be one of\n'COMPATIBLE', 'MODERN', 'RESTRICTED', or 'CUSTOM'. If using 'CUSTOM',\nthe set of SSL features to enable must be specified in the\n'customFeatures' field.\n\nSee the [official documentation](https://cloud.google.com/compute/docs/load-balancing/ssl-policies#profilefeaturesupport)\nfor which ciphers are available to use. **Note**: this argument\n*must* be present when using the 'CUSTOM' profile. This argument\n*must not* be present when using any other profile."
+  type        = set(string)
+  default     = null
+}

--- a/setup/infra/variables.tf
+++ b/setup/infra/variables.tf
@@ -37,6 +37,11 @@ variable "custom_ssl_policy_enabled" {
   default     = true
 }
 
+variable "custom_ssl_policy_delete" {
+  description = "set this in 2-pass ssl_policy removal after running with custom_ssl_policy_enabled = false to remove the ssl_policy resource without dependency issues with the target proxy"
+  default     = true
+}
+
 variable "ssl_policy_min_tls_version" {
   description = "(optional) - The minimum version of SSL protocol that can be used by the clients\nto establish a connection with the load balancer. Default value: \"TLS_1_0\" Possible values: [\"TLS_1_0\", \"TLS_1_1\", \"TLS_1_2\"]"
   type        = string


### PR DESCRIPTION
Added support for custom Google Cloud Load Balance SSL Policies.

Usage:

Example - Disable TLS 1.0 and TLS 1.1. Also disable the following ciphers:
```
TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
TLS_RSA_WITH_3DES_EDE_CBC_SHA
TLS_RSA_WITH_AES_128_CBC_SHA
TLS_RSA_WITH_AES_128_GCM_SHA256
TLS_RSA_WITH_AES_256_CBC_SHA
TLS_RSA_WITH_AES_256_GCM_SHA384
```

Create a file with the custom SSL Policy CIDR ranges, update it with your custom values.

```bash
cat > selkies-cluster-min.auto.tfvars <<EOF
custom_ssl_policy_enabled           = true
custom_ssl_policy_delete            = false
ssl_policy_min_tls_version          = "TLS_1_2"
ssl_policy_profile                  = "CUSTOM"
ssl_policy_custom_features          = ["TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA","TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA","TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256","TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA","TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384","TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256","TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256","TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384","TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"]
EOF
```

Execute `terraform plan` from the `setup/infra` folder to inspect the proposed changes

```bash
(cd setup/infra && gcloud builds submit --project ${PROJECT_ID?} --substitutions=_ACTION=plan )
```

Execute `terraform apply` from the `setup/infra` folder to apply the changes

```
(cd setup/infra && gcloud builds submit --project ${PROJECT_ID?} --substitutions=_ACTION=apply )
```

See below [SSL Server Test](https://www.ssllabs.com/ssltest/analyze.html) output after applying the above configuration


![image](https://user-images.githubusercontent.com/247003/117022686-6dc41080-acc6-11eb-9f26-3e4cd65953bf.png)

