### PR TITLE
Configure the max number of pods per node

### DIFF
--- a/setup/infra/cluster/main.tf
+++ b/setup/infra/cluster/main.tf
@@ -31,6 +31,7 @@ module "broker" {
   remove_default_node_pool = true
   network_policy           = var.network_policy
   gce_pd_csi_driver        = true
+  default_max_pods_per_node = var.max_pods_per_node
 
   # Zones must be compatible with the chosen accelerator_type in the gpu-* node pools.
   zones = length(var.zones) == 0 ? lookup(local.cluster_node_zones, var.region) : var.zones

--- a/setup/infra/cluster/variables.tf
+++ b/setup/infra/cluster/variables.tf
@@ -40,6 +40,11 @@ variable network_policy {
   default = true
 }
 
+// Set this to a lower value if your pod cidr is constrained.
+variable max_pods_per_node {
+  default = 110
+}
+
 # Default node pool counts per zone
 variable default_pool_machine_type {
   default = "e2-standard-4"


### PR DESCRIPTION
Adding a variable to `setup/infra/cluster` to configure the max number of pods per node during the cluster creation, might be helpful to set this to a lower value if the pod's CIDR range is constrained.

```
variable max_pods_per_node {
  default = 110
}
```

**Note**: This setting is already included in the private cluster module.