### PR TITLE
Pass region to the NAT Gateway IPs

### DIFF
--- a/setup/infra/private-cluster/network.tf
+++ b/setup/infra/private-cluster/network.tf
@@ -38,8 +38,9 @@ resource "google_compute_subnetwork" "broker" {
 }
 
 resource "google_compute_address" "nat-address" {
-  count = 2
-  name  = "broker-nat-${var.region}-${count.index}"
+  count   = 2
+  name    = "broker-nat-${var.region}-${count.index}"
+  region  = var.region
 }
 
 resource "google_compute_router" "router-nat" {


### PR DESCRIPTION
Passing region value to NAT Gateway IPs, see below error log using the current implementation
```
40: resource "google_compute_address" "nat-address" {
  on network.tf line 40, in resource "google_compute_address" "nat-address":

Error: Cannot determine region: set in this resource, or set provider-level 'region' or 'zone'.
```