### PR TITLE
Create private clusters by default

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -131,7 +131,7 @@ steps:
   ###
   - name: "gcr.io/cloud-builders/gcloud"
     id: "deploy-cluster-region"
-    dir: "setup/infra/cluster"
+    dir: "setup/infra/private-cluster"
     args:
       - "builds"
       - "submit"


### PR DESCRIPTION
**Recommended**:  Private clusters provide more isolation by only having private IP addresses on nodes, and having private and public endpoints for control plane nodes