### PR TITLE
Load Balancer Security Policy

### DIFF
--- a/setup/infra/variables.tf
+++ b/setup/infra/variables.tf
@@ -28,7 +28,7 @@ variable "name" {
 
 variable "additional_ssl_certificate_domains" {
   description = "list of additional domains to add to the managed certificate."
-  type        = list
+ type        = list
   default     = []
 }
 
@@ -58,4 +58,31 @@ variable "ssl_policy_custom_features" {
   description = "(optional) - Profile specifies the set of SSL features that can be used by the\nload balancer when negotiating SSL with clients. This can be one of\n'COMPATIBLE', 'MODERN', 'RESTRICTED', or 'CUSTOM'. If using 'CUSTOM',\nthe set of SSL features to enable must be specified in the\n'customFeatures' field.\n\nSee the [official documentation](https://cloud.google.com/compute/docs/load-balancing/ssl-policies#profilefeaturesupport)\nfor which ciphers are available to use. **Note**: this argument\n*must* be present when using the 'CUSTOM' profile. This argument\n*must not* be present when using any other profile."
   type        = set(string)
   default     = null
+}
+
+variable "lb_security_policy_enabled" {
+  description = "Enable Load Balancer Security Policy. A Security Policy defines a policy that protects load balanced Google Cloud services by permitting traffic only from specified IP ranges or geographical locations"
+  type        = bool
+  default     = false
+}
+
+variable "lb_security_policy_delete" {
+  description = "set this in 2-pass security_policy removal after running with lb_security_policy_enabled = false to remove the security_policy resource without dependency issues with the backend service"
+  default     = true
+}
+
+variable "lb_security_policy_rules" {
+  default = [
+    {
+      action      = "allow"
+      priority    = 1000
+      expression  = "inIpRange(origin.ip, '0.0.0.0/0')"
+      description = "Allow all the traffic"
+    }
+  ]
+}
+
+variable "lb_security_policy_default_rule_action" {
+  description = "By default, for each policy you have to configured the default rule that allows/denies all traffic with the lowest priority (2147483647). Possible values allow, deny(403), deny(404), deny(502)"
+  default     = "deny(403)"
 }


### PR DESCRIPTION
Added support for the configuration of a Security Policy for the Google Cloud Load Balancer.

## Example - Enable Security Policy:

Create a file with the Security Policy values, the `lb_security_policy_rules` can be implemented with the [Google Cloud Armor custom rules language](https://cloud.google.com/armor/docs/rules-language-reference)

```bash
cat > selkies-cluster-min.auto.tfvars <<EOF
lb_security_policy_enabled             = true
lb_security_policy_delete              = false
lb_security_policy_default_rule_action = "deny(403)"
lb_security_policy_rules = [
  {
    action      = "deny(403)"
    priority    = 900
    expression  = "origin.region_code == 'IN'"
    description = "Deny access to requests originated from India"
  },
  {
    action      = "allow"
    priority    = 1000
    expression  = "inIpRange(origin.ip, '1.2.3.4/32')"
    description = "Allow traffic from 1.2.3.4/32"
  }
]
EOF
```

Execute `terraform plan` from the `setup/infra` folder to inspect the proposed changes
```bash
(cd setup/infra && gcloud builds submit --project ${PROJECT_ID?} --substitutions=_ACTION=plan )
```

Execute `terraform apply` from the `setup/infra` folder to apply the changes
```bash
(cd setup/infra && gcloud builds submit --project ${PROJECT_ID?} --substitutions=_ACTION=apply )
```

## Inputs

| Name | Description | Type | Default | Required |
|------|-------------|------|---------|:--------:|
|lb\_security\_policy\_enabled | Enable Load Balancer Security Policy. A Security Policy defines a policy that protects load balanced Google Cloud services by permitting traffic only from specified IP ranges or geographical locations | `bool` | false | no |
|lb\_security\_policy\_delete | Set this in 2-pass security_policy removal after running with lb_security_policy_enabled = false to remove the security_policy resource without dependency issues with the backend service | `bool` | true | no |
|lb\_security\_policy\_rules | A security policy contains one or more rules. Rules tell your security policy what to do (action) and when to do it (expression). | `list` | * Allow all rule | no |
|lb\_security\_policy\_default\_rule\_action | By default, for each policy you have to configured the default rule that allows/denies all traffic with the lowest priority (2147483647). Possible values allow, deny(403), deny(404), deny(502) | `string` | `deny(403)` | no |

* Allow all rule

```bash
  [{
      action      = "allow"
      priority    = 1000
      expression  = "inIpRange(origin.ip, '0.0.0.0/0')"
      description = "Allow all the traffic"
    } ]
```