### PR TITLE
Change default/placeholder regions to `us-central1`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ CLOUDBUILD_SA=$(gcloud projects describe ${PROJECT_ID?} --format='value(projectN
 
 ```bash
 ACCOUNT=$(gcloud config get-value account)
-REGION=us-west1
+REGION=us-central1
 
 gcloud builds submit --project=${PROJECT_ID?} --substitutions=_USER=${ACCOUNT?},_REGION=${REGION?}
 ```
@@ -97,7 +97,7 @@ gcloud secrets create broker-tfvars-selkies-min-ssd \
 * If the load balancer never comes online and you receive 500 errors after the deployment has completed for at least 30 minutes, the autoneg controller annotation may need to be reset:
 
 ```bash
-REGION=us-west1
+REGION=us-central1
 gcloud container clusters get-credentials --region ${REGION?} broker-${REGION?}
 ```
 

--- a/examples/jupyter-notebook/cloudbuild.yaml
+++ b/examples/jupyter-notebook/cloudbuild.yaml
@@ -15,7 +15,7 @@
 timeout: 300s
 
 substitutions:
-  _REGION: us-west1
+  _REGION: us-central1
 
 steps:
   ###

--- a/setup/README.md
+++ b/setup/README.md
@@ -94,7 +94,7 @@ gcloud secrets create broker-cookie-secret --replication-policy=automatic --data
 2. Deploy the cluster for your desired region:
 
 ```bash
-REGION=us-west1
+REGION=us-central1
 ```
 
 ```bash

--- a/setup/infra/cluster/cloudbuild.yaml
+++ b/setup/infra/cluster/cloudbuild.yaml
@@ -16,7 +16,7 @@ timeout: 10800s
 substitutions:
   _ACTION: apply
   _NAME: broker
-  _REGION: us-west1
+  _REGION: us-central1
 tags:
   - selkies-cluster
   - selkies-setup

--- a/setup/infra/node-pool-apps/cloudbuild.yaml
+++ b/setup/infra/node-pool-apps/cloudbuild.yaml
@@ -16,7 +16,7 @@ timeout: 10800s
 substitutions:
   _ACTION: apply
   _NAME: broker
-  _REGION: us-west1
+  _REGION: us-central1
   _TIER1: "true"
   _TIER2: "true"
 tags:

--- a/setup/infra/node-pool-gpu/cloudbuild.yaml
+++ b/setup/infra/node-pool-gpu/cloudbuild.yaml
@@ -16,7 +16,7 @@ timeout: 10800s
 substitutions:
   _ACTION: apply
   _NAME: broker
-  _REGION: us-west1
+  _REGION: us-central1
   _COS: "true"
   _UBUNTU: "true"
 tags:

--- a/setup/infra/private-cluster/cloudbuild.yaml
+++ b/setup/infra/private-cluster/cloudbuild.yaml
@@ -16,7 +16,7 @@ timeout: 10800s
 substitutions:
   _ACTION: apply
   _NAME: broker
-  _REGION: us-west1
+  _REGION: us-central1
 tags:
   - selkies-private-cluster
   - selkies-setup

--- a/setup/infra/regional-lb/cloudbuild.yaml
+++ b/setup/infra/regional-lb/cloudbuild.yaml
@@ -16,7 +16,7 @@ timeout: 10800s
 substitutions:
   _ACTION: apply
   _NAME: broker
-  _REGION: us-west1
+  _REGION: us-central1
 tags:
   - selkies-cluster
   - selkies-setup

--- a/setup/manifests/cloudbuild.yaml
+++ b/setup/manifests/cloudbuild.yaml
@@ -15,7 +15,7 @@
 timeout: 3600s
 substitutions:
   _INFRA_NAME: broker
-  _REGION: us-west1
+  _REGION: us-central1
 tags:
   - selkies-setup
   - selkies-manifests


### PR DESCRIPTION
(Waiting for #22)

`us-central1` is a better default region than `us-west1`,
as it should have better worst-case performance across US users.
Outside of the US, users should be changing the default anyways.