### PR TITLE
Exclude min_node_count and max_node_count from node pools lifecycle.ignore_changes section

### DIFF
--- a/setup/infra/node-pool-apps/tier1-ubuntu.tf
+++ b/setup/infra/node-pool-apps/tier1-ubuntu.tf
@@ -89,9 +89,7 @@ resource "google_container_node_pool" "tier1-ubuntu" {
   lifecycle {
     ignore_changes = [
       node_config[0].labels,
-      node_config[0].taint,
-      autoscaling[0].min_node_count,
-      autoscaling[0].max_node_count
+      node_config[0].taint
     ]
   }
 }

--- a/setup/infra/node-pool-apps/tier1.tf
+++ b/setup/infra/node-pool-apps/tier1.tf
@@ -89,9 +89,7 @@ resource "google_container_node_pool" "tier1" {
   lifecycle {
     ignore_changes = [
       node_config[0].labels,
-      node_config[0].taint,
-      autoscaling[0].min_node_count,
-      autoscaling[0].max_node_count
+      node_config[0].taint
     ]
   }
 }

--- a/setup/infra/node-pool-apps/tier2.tf
+++ b/setup/infra/node-pool-apps/tier2.tf
@@ -89,9 +89,7 @@ resource "google_container_node_pool" "tier2" {
   lifecycle {
     ignore_changes = [
       node_config[0].labels,
-      node_config[0].taint,
-      autoscaling[0].min_node_count,
-      autoscaling[0].max_node_count
+      node_config[0].taint
     ]
   }
 }

--- a/setup/infra/node-pool-gpu/gpu-cos.tf
+++ b/setup/infra/node-pool-gpu/gpu-cos.tf
@@ -103,9 +103,7 @@ resource "google_container_node_pool" "gpu-cos" {
   lifecycle {
     ignore_changes = [
       node_config[0].labels,
-      node_config[0].taint,
-      autoscaling[0].min_node_count,
-      autoscaling[0].max_node_count
+      node_config[0].taint
     ]
   }
 }


### PR DESCRIPTION
Changes

- Exclude `min_node_count` and `max_node_count` from node pools `lifecycle.ignore_changes` section to allow customizing the min/max number of nodes in the NodePool after this one is first created.