### PR TITLE
Add workflows for images & releases

### DIFF
--- a/.github/actions/build_and_publish_image/action.yaml
+++ b/.github/actions/build_and_publish_image/action.yaml
@@ -1,0 +1,63 @@
+name: Build & publish an image
+
+description: Build an image from source, then publish it to GHCR
+
+inputs:
+  build_args:
+    description: "`ARG=value`s to pass to `docker build`"
+    required: false
+  dockerfile:
+    default: "Dockerfile"
+    description: Image source file name
+    required: false
+  github_personal_access_token:
+    description: GitHub personal access token (PAT), for authentication
+    required: true
+  github_username:
+    description: GitHub username, for authentication
+    required: true
+  image_name:
+    description: The name for the image (i.e. "image" in "ghcr.io/user/repo/image:foo")
+    required: true
+  image_source_directory:
+    description: Image source directory path
+    required: true
+  image_version_1:
+    description: A tag for the image (i.e. "foo" in "ghcr.io/user/repo/image:foo")
+    required: true
+  image_version_2:
+    description: Another tag for the image (i.e. "bar" in "ghcr.io/user/repo/image:bar")
+    required: false
+  use_cache:
+    default: "true"
+    description: Use cached layers from pre-published image with version 1 (true/false)
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        set -x
+        echo ${{ inputs.github_personal_access_token }} | docker login ghcr.io -u ${{ inputs.github_username }} --password-stdin
+        export BUILD_ARGS=""
+        if [[ -n "${{ inputs.build_args }}" ]]; then
+          IFS=";" read -ra args <<< "${{ inputs.build_args }}"
+          for arg in ${args[@]}; do BUILD_ARGS+="--build-arg $arg "; done
+        fi
+
+        export IMAGE_TAG_URL_PREFIX=ghcr.io/selkies-project/selkies-gstreamer/
+        export IMAGE_TAG_1="${IMAGE_TAG_URL_PREFIX}${{ inputs.image_name }}:${{ inputs.image_version_1 }}"
+        if [[ "${{ inputs.use_cache }}" == "true" ]]; then
+          docker pull $IMAGE_TAG_1 || true
+          (cd ${{ inputs.image_source_directory }} && docker build $BUILD_ARGS -f ${{ inputs.dockerfile }} --cache-from $IMAGE_TAG_1 -t $IMAGE_TAG_1 .)
+        else
+          (cd ${{ inputs.image_source_directory }} && docker build $BUILD_ARGS -f ${{ inputs.dockerfile }} -t $IMAGE_TAG_1 .)
+        fi
+        docker push $IMAGE_TAG_1
+
+        if [ '${{ inputs.image_version_2 }}' != '' ]; then
+          export IMAGE_TAG_2="${IMAGE_TAG_URL_PREFIX}${{ inputs.image_name }}:${{ inputs.image_version_2 }}${{ inputs.image_version_suffix }}"
+          docker tag $IMAGE_TAG_1 $IMAGE_TAG_2
+          docker push $IMAGE_TAG_2
+        fi

--- a/.github/actions/build_and_publish_image/action.yaml
+++ b/.github/actions/build_and_publish_image/action.yaml
@@ -46,7 +46,7 @@ runs:
           for arg in ${args[@]}; do BUILD_ARGS+="--build-arg $arg "; done
         fi
 
-        export IMAGE_TAG_URL_PREFIX=ghcr.io/selkies-project/selkies-gstreamer/
+        export IMAGE_TAG_URL_PREFIX=ghcr.io/selkies-project/selkies/
         export IMAGE_TAG_1="${IMAGE_TAG_URL_PREFIX}${{ inputs.image_name }}:${{ inputs.image_version_1 }}"
         if [[ "${{ inputs.use_cache }}" == "true" ]]; then
           docker pull $IMAGE_TAG_1 || true

--- a/.github/workflows/publish_all_images.yaml
+++ b/.github/workflows/publish_all_images.yaml
@@ -1,71 +1,22 @@
 name: Publish all images
 
-on: workflow_dispatch
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/**'
+  workflow_dispatch:
 
 jobs:
   # Note: When modifying this job, copy modifications to all other workflows' image jobs.
-  all_component_images:
+  all_images:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
-          - name: coturn
-            source_directory: addons/coturn
-
-          - name: coturn-web
-            source_directory: addons/coturn-web
-
-          - name: gst-web
-            source_directory: addons/gst-web
-
-          - name: gstreamer
-            version_suffix: -ubuntu18.04
-            build_args: BASE_IMAGE=ubuntu:18.04;
-            source_directory: addons/gstreamer
-
-          - name: gstreamer
-            version_suffix: -ubuntu20.04
-            build_args: BASE_IMAGE=ubuntu:20.04;
-            source_directory: addons/gstreamer
-
-          - name: infra-gcp-installer
-            source_directory: infra/gce/installer-image
-
-          - name: py-build
-            build_args: PACKAGE_VERSION=0.0.0.dev0
-            source_directory: .
-
-    name: ${{ matrix.name }}${{ matrix.version_suffix }} image build & publish
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Build & publish ${{ matrix.name }} image
-        uses: ./.github/actions/build_and_publish_image
-        with:
-          build_args: ${{ matrix.build_args }}
-          github_personal_access_token: ${{ secrets.GITHUB_TOKEN }}
-          github_username: $GITHUB_ACTOR
-          image_name: ${{ matrix.name }}
-          image_source_directory: ${{ matrix.source_directory }}
-          image_version_1: $GITHUB_REF_NAME${{ matrix.version_suffix }}
-
-  # Note: When modifying this job, copy modifications to all other workflows' image jobs.
-  all_example_images:
-    needs: all_component_images
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - name: gst-py-example
-            version_suffix: -ubuntu18.04
-            build_args: PACKAGE_VERSION=0.0.0.dev0;UBUNTU_RELEASE=18.04;GSTREAMER_BASE_IMAGE_RELEASE=${{ github.ref_name }};PY_BUILD_IMAGE=ghcr.io/selkies-project/selkies-gstreamer/py-build:${{ github.ref_name }};WEB_IMAGE=ghcr.io/selkies-project/selkies-gstreamer/gst-web:${{ github.ref_name }}
-            dockerfile: Dockerfile.example
-            source_directory: .
-
-          - name: gst-py-example
-            build_args: PACKAGE_VERSION=0.0.0.dev0;UBUNTU_RELEASE=20.04;GSTREAMER_BASE_IMAGE_RELEASE=${{ github.ref_name }};PY_BUILD_IMAGE=ghcr.io/selkies-project/selkies-gstreamer/py-build:${{ github.ref_name }};WEB_IMAGE=ghcr.io/selkies-project/selkies-gstreamer/gst-web:${{ github.ref_name }}
-            dockerfile: Dockerfile.example
-            source_directory: .
+          - name: PLACEHOLDER
+            source_directory: PLACEHOLDER
 
     name: ${{ matrix.name }}${{ matrix.version_suffix }} image build & publish
     steps:

--- a/.github/workflows/publish_all_images.yaml
+++ b/.github/workflows/publish_all_images.yaml
@@ -3,6 +3,7 @@ name: Publish all images
 on:
   push:
     branches:
+      - dev
       - master
     paths:
       - '.github/**'

--- a/.github/workflows/publish_all_images.yaml
+++ b/.github/workflows/publish_all_images.yaml
@@ -15,8 +15,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: PLACEHOLDER
-            source_directory: PLACEHOLDER
+          - name: broker-installer
+            source_directory: images/installer
+
+          - name: controller
+            source_directory: images/controller
+
+          - name: gce-proxy
+            source_directory: images/gce-proxy
 
     name: ${{ matrix.name }}${{ matrix.version_suffix }} image build & publish
     steps:

--- a/.github/workflows/publish_all_images.yaml
+++ b/.github/workflows/publish_all_images.yaml
@@ -3,5 +3,80 @@ name: Publish all images
 on: workflow_dispatch
 
 jobs:
-  PLACEHOLDER:
+  # Note: When modifying this job, copy modifications to all other workflows' image jobs.
+  all_component_images:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: coturn
+            source_directory: addons/coturn
+
+          - name: coturn-web
+            source_directory: addons/coturn-web
+
+          - name: gst-web
+            source_directory: addons/gst-web
+
+          - name: gstreamer
+            version_suffix: -ubuntu18.04
+            build_args: BASE_IMAGE=ubuntu:18.04;
+            source_directory: addons/gstreamer
+
+          - name: gstreamer
+            version_suffix: -ubuntu20.04
+            build_args: BASE_IMAGE=ubuntu:20.04;
+            source_directory: addons/gstreamer
+
+          - name: infra-gcp-installer
+            source_directory: infra/gce/installer-image
+
+          - name: py-build
+            build_args: PACKAGE_VERSION=0.0.0.dev0
+            source_directory: .
+
+    name: ${{ matrix.name }}${{ matrix.version_suffix }} image build & publish
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build & publish ${{ matrix.name }} image
+        uses: ./.github/actions/build_and_publish_image
+        with:
+          build_args: ${{ matrix.build_args }}
+          github_personal_access_token: ${{ secrets.GITHUB_TOKEN }}
+          github_username: $GITHUB_ACTOR
+          image_name: ${{ matrix.name }}
+          image_source_directory: ${{ matrix.source_directory }}
+          image_version_1: $GITHUB_REF_NAME${{ matrix.version_suffix }}
+
+  # Note: When modifying this job, copy modifications to all other workflows' image jobs.
+  all_example_images:
+    needs: all_component_images
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: gst-py-example
+            version_suffix: -ubuntu18.04
+            build_args: PACKAGE_VERSION=0.0.0.dev0;UBUNTU_RELEASE=18.04;GSTREAMER_BASE_IMAGE_RELEASE=${{ github.ref_name }};PY_BUILD_IMAGE=ghcr.io/selkies-project/selkies-gstreamer/py-build:${{ github.ref_name }};WEB_IMAGE=ghcr.io/selkies-project/selkies-gstreamer/gst-web:${{ github.ref_name }}
+            dockerfile: Dockerfile.example
+            source_directory: .
+
+          - name: gst-py-example
+            build_args: PACKAGE_VERSION=0.0.0.dev0;UBUNTU_RELEASE=20.04;GSTREAMER_BASE_IMAGE_RELEASE=${{ github.ref_name }};PY_BUILD_IMAGE=ghcr.io/selkies-project/selkies-gstreamer/py-build:${{ github.ref_name }};WEB_IMAGE=ghcr.io/selkies-project/selkies-gstreamer/gst-web:${{ github.ref_name }}
+            dockerfile: Dockerfile.example
+            source_directory: .
+
+    name: ${{ matrix.name }}${{ matrix.version_suffix }} image build & publish
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build & publish ${{ matrix.name }} image
+        uses: ./.github/actions/build_and_publish_image
+        with:
+          build_args: ${{ matrix.build_args }}
+          github_personal_access_token: ${{ secrets.GITHUB_TOKEN }}
+          github_username: $GITHUB_ACTOR
+          image_name: ${{ matrix.name }}
+          image_source_directory: ${{ matrix.source_directory }}
+          image_version_1: $GITHUB_REF_NAME${{ matrix.version_suffix }}

--- a/.github/workflows/publish_changed_images.yaml
+++ b/.github/workflows/publish_changed_images.yaml
@@ -4,108 +4,20 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'images/**'
+  workflow_dispatch:
 
 jobs:
   # Note: When modifying this job, copy modifications to all other workflows' image jobs.
-  changed_component_images:
+  changed_images:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
-          - name: coturn
-            source_directory: addons/coturn
-            source_files_for_diff: addons/coturn
-
-          - name: coturn-web
-            source_directory: addons/coturn-web
-            source_files_for_diff: addons/coturn-web
-
-          - name: gst-web
-            source_directory: addons/gst-web
-            source_files_for_diff: addons/gst-web
-
-          - name: gstreamer
-            version_suffix: -ubuntu18.04
-            build_args: BASE_IMAGE=ubuntu:18.04;
-            source_directory: addons/gstreamer
-            source_files_for_diff: addons/streamer
-
-          - name: gstreamer
-            version_suffix: -ubuntu20.04
-            build_args: BASE_IMAGE=ubuntu:20.04;
-            source_directory: addons/gstreamer
-            source_files_for_diff: addons/gstreamer
-
-          - name: infra-gcp-installer
-            source_directory: infra/gce/installer-image
-            source_files_for_diff: infra/gce/installer-image
-
-          - name: py-build
-            build_args: PACKAGE_VERSION=0.0.0.dev0
-            source_directory: .
-            source_files_for_diff: |
-              ^src
-              ^Dockerfile$
-              pyproject.toml
-              setup.cfg
-              .github/workflows/build_and_publish_changed_images.yaml
-
-    name: ${{ matrix.name }}${{ matrix.version_suffix }} image build & publish
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 2 # This is for changed-files.
-
-      - name: Check for changes to image source
-        id: check
-        uses: tj-actions/changed-files@v1.1.2
-        with:
-          files: ${{ matrix.source_files_for_diff }}
-
-      - name: Build & publish ${{ matrix.name }} image
-        if: steps.check.outputs.any_changed == 'true' || steps.check.outputs.any_deleted == 'true'
-        uses: ./.github/actions/build_and_publish_image
-        with:
-          build_args: ${{ matrix.build_args }}
-          github_personal_access_token: ${{ secrets.GITHUB_TOKEN }}
-          github_username: $GITHUB_ACTOR
-          image_name: ${{ matrix.name }}
-          image_source_directory: ${{ matrix.source_directory }}
-          image_version_1: $GITHUB_REF_NAME${{ matrix.version_suffix }}
-
-  # Note: When modifying this job, copy modifications to all other workflows' image jobs.
-  changed_example_images:
-    needs: changed_component_images
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - name: gst-py-example
-            version_suffix: -ubuntu18.04
-            build_args: PACKAGE_VERSION=0.0.0.dev0;UBUNTU_RELEASE=18.04;GSTREAMER_BASE_IMAGE_RELEASE=${{ github.ref_name }};PY_BUILD_IMAGE=ghcr.io/selkies-project/selkies-gstreamer/py-build:${{ github.ref_name }};WEB_IMAGE=ghcr.io/selkies-project/selkies-gstreamer/gst-web:${{ github.ref_name }}
-            dockerfile: Dockerfile.example
-            source_directory: .
-            source_files_for_diff: |
-              addons
-              src
-              Dockerfile
-              Dockerfile.example
-              pyproject.toml
-              setup.cfg
-              .github/workflows/build_and_publish_changed_images.yaml
-
-          - name: gst-py-example
-            build_args: PACKAGE_VERSION=0.0.0.dev0;UBUNTU_RELEASE=20.04;GSTREAMER_BASE_IMAGE_RELEASE=${{ github.ref_name }};PY_BUILD_IMAGE=ghcr.io/selkies-project/selkies-gstreamer/py-build:${{ github.ref_name }};WEB_IMAGE=ghcr.io/selkies-project/selkies-gstreamer/gst-web:${{ github.ref_name }}
-            dockerfile: Dockerfile.example
-            source_directory: .
-            source_files_for_diff: |
-              addons
-              src
-              Dockerfile
-              Dockerfile.example
-              pyproject.toml
-              setup.cfg
-              .github/workflows/build_and_publish_changed_images.yaml
+          - name: PLACEHOLDER
+            source_directory: PLACEHOLDER
+            source_files_for_diff: PLACEHOLDER
 
     name: ${{ matrix.name }}${{ matrix.version_suffix }} image build & publish
     steps:

--- a/.github/workflows/publish_changed_images.yaml
+++ b/.github/workflows/publish_changed_images.yaml
@@ -1,7 +1,131 @@
 name: Publish changed images
 
-on: workflow_dispatch
+on:
+  push:
+    branches:
+      - master
 
 jobs:
-  PLACEHOLDER:
+  # Note: When modifying this job, copy modifications to all other workflows' image jobs.
+  changed_component_images:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: coturn
+            source_directory: addons/coturn
+            source_files_for_diff: addons/coturn
+
+          - name: coturn-web
+            source_directory: addons/coturn-web
+            source_files_for_diff: addons/coturn-web
+
+          - name: gst-web
+            source_directory: addons/gst-web
+            source_files_for_diff: addons/gst-web
+
+          - name: gstreamer
+            version_suffix: -ubuntu18.04
+            build_args: BASE_IMAGE=ubuntu:18.04;
+            source_directory: addons/gstreamer
+            source_files_for_diff: addons/streamer
+
+          - name: gstreamer
+            version_suffix: -ubuntu20.04
+            build_args: BASE_IMAGE=ubuntu:20.04;
+            source_directory: addons/gstreamer
+            source_files_for_diff: addons/gstreamer
+
+          - name: infra-gcp-installer
+            source_directory: infra/gce/installer-image
+            source_files_for_diff: infra/gce/installer-image
+
+          - name: py-build
+            build_args: PACKAGE_VERSION=0.0.0.dev0
+            source_directory: .
+            source_files_for_diff: |
+              ^src
+              ^Dockerfile$
+              pyproject.toml
+              setup.cfg
+              .github/workflows/build_and_publish_changed_images.yaml
+
+    name: ${{ matrix.name }}${{ matrix.version_suffix }} image build & publish
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2 # This is for changed-files.
+
+      - name: Check for changes to image source
+        id: check
+        uses: tj-actions/changed-files@v1.1.2
+        with:
+          files: ${{ matrix.source_files_for_diff }}
+
+      - name: Build & publish ${{ matrix.name }} image
+        if: steps.check.outputs.any_changed == 'true' || steps.check.outputs.any_deleted == 'true'
+        uses: ./.github/actions/build_and_publish_image
+        with:
+          build_args: ${{ matrix.build_args }}
+          github_personal_access_token: ${{ secrets.GITHUB_TOKEN }}
+          github_username: $GITHUB_ACTOR
+          image_name: ${{ matrix.name }}
+          image_source_directory: ${{ matrix.source_directory }}
+          image_version_1: $GITHUB_REF_NAME${{ matrix.version_suffix }}
+
+  # Note: When modifying this job, copy modifications to all other workflows' image jobs.
+  changed_example_images:
+    needs: changed_component_images
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: gst-py-example
+            version_suffix: -ubuntu18.04
+            build_args: PACKAGE_VERSION=0.0.0.dev0;UBUNTU_RELEASE=18.04;GSTREAMER_BASE_IMAGE_RELEASE=${{ github.ref_name }};PY_BUILD_IMAGE=ghcr.io/selkies-project/selkies-gstreamer/py-build:${{ github.ref_name }};WEB_IMAGE=ghcr.io/selkies-project/selkies-gstreamer/gst-web:${{ github.ref_name }}
+            dockerfile: Dockerfile.example
+            source_directory: .
+            source_files_for_diff: |
+              addons
+              src
+              Dockerfile
+              Dockerfile.example
+              pyproject.toml
+              setup.cfg
+              .github/workflows/build_and_publish_changed_images.yaml
+
+          - name: gst-py-example
+            build_args: PACKAGE_VERSION=0.0.0.dev0;UBUNTU_RELEASE=20.04;GSTREAMER_BASE_IMAGE_RELEASE=${{ github.ref_name }};PY_BUILD_IMAGE=ghcr.io/selkies-project/selkies-gstreamer/py-build:${{ github.ref_name }};WEB_IMAGE=ghcr.io/selkies-project/selkies-gstreamer/gst-web:${{ github.ref_name }}
+            dockerfile: Dockerfile.example
+            source_directory: .
+            source_files_for_diff: |
+              addons
+              src
+              Dockerfile
+              Dockerfile.example
+              pyproject.toml
+              setup.cfg
+              .github/workflows/build_and_publish_changed_images.yaml
+
+    name: ${{ matrix.name }}${{ matrix.version_suffix }} image build & publish
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2 # This is for changed-files.
+
+      - id: check
+        name: Check for changes to ${{ matrix.name }} image source
+        uses: tj-actions/changed-files@v1.1.2
+        with:
+          files: ${{ matrix.source_files_for_diff }}
+
+      - name: Build & publish ${{ matrix.name }} image
+        if: steps.check.outputs.any_changed == 'true' || steps.check.outputs.any_deleted == 'true'
+        uses: ./.github/actions/build_and_publish_image
+        with:
+          build_args: ${{ matrix.build_args }}
+          github_personal_access_token: ${{ secrets.GITHUB_TOKEN }}
+          github_username: $GITHUB_ACTOR
+          image_name: ${{ matrix.name }}
+          image_source_directory: ${{ matrix.source_directory }}
+          image_version_1: $GITHUB_REF_NAME${{ matrix.version_suffix }}

--- a/.github/workflows/publish_changed_images.yaml
+++ b/.github/workflows/publish_changed_images.yaml
@@ -15,9 +15,17 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: PLACEHOLDER
-            source_directory: PLACEHOLDER
-            source_files_for_diff: PLACEHOLDER
+          - name: broker-installer
+            source_directory: images/installer
+            source_files_for_diff: images/installer
+
+          - name: controller
+            source_directory: images/controller
+            source_files_for_diff: images/controller
+
+          - name: gce-proxy
+            source_directory: images/gce-proxy
+            source_files_for_diff: images/gce-proxy
 
     name: ${{ matrix.name }}${{ matrix.version_suffix }} image build & publish
     steps:

--- a/.github/workflows/publish_changed_images.yaml
+++ b/.github/workflows/publish_changed_images.yaml
@@ -3,6 +3,7 @@ name: Publish changed images
 on:
   push:
     branches:
+      - dev
       - master
     paths:
       - 'images/**'

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -4,50 +4,17 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 jobs:
-  get_semver:
-    runs-on: ubuntu-latest
-    outputs:
-      semver: ${{ steps.get.outputs.semver }}
-    steps:
-      - id: get
-        env:
-          RELEASE_VERSION: ${{ github.ref_name }}
-        run: echo ::set-output name=semver::${RELEASE_VERSION/v/}
-
   # Note: When modifying this job, copy modifications to all other workflows' image jobs.
-  all_component_images:
-    needs: get_semver
+  all_images:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
-          - name: coturn
-            source_directory: addons/coturn
-
-          - name: coturn-web
-            source_directory: addons/coturn-web
-
-          - name: gst-web
-            source_directory: addons/gst-web
-
-          - name: gstreamer
-            version_suffix: -ubuntu18.04
-            build_args: BASE_IMAGE=ubuntu:18.04;
-            source_directory: addons/gstreamer
-
-          - name: gstreamer
-            version_suffix: -ubuntu20.04
-            build_args: BASE_IMAGE=ubuntu:20.04;
-            source_directory: addons/gstreamer
-
-          - name: infra-gcp-installer
-            source_directory: infra/gce/installer-image
-
-          - name: py-build
-            build_args: PACKAGE_VERSION=${{ needs.get_semver.outputs.semver }}
-            source_directory: .
+          - name: PLACEHOLDER
+            source_directory: PLACEHOLDER
 
     name: ${{ matrix.name }}${{ matrix.version_suffix }} image build & publish
     steps:
@@ -63,173 +30,12 @@ jobs:
           image_source_directory: ${{ matrix.source_directory }}
           image_version_1: $GITHUB_REF_NAME${{ matrix.version_suffix }}
           image_version_2: latest${{ matrix.version_suffix }}
-
-  # Note: When modifying this job, copy modifications to all other workflows' image jobs.
-  all_example_images:
-    needs:
-      - get_semver
-      - all_component_images
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - name: gst-py-example
-            version_suffix: -ubuntu18.04
-            build_args: PACKAGE_VERSION=${{ needs.get_semver.outputs.semver }};UBUNTU_RELEASE=18.04;GSTREAMER_BASE_IMAGE_RELEASE=$GITHUB_REF_NAME;PY_BUILD_IMAGE=ghcr.io/selkies-project/selkies-gstreamer/py-build:$GITHUB_REF_NAME;WEB_IMAGE=ghcr.io/selkies-project/selkies-gstreamer/gst-web:$GITHUB_REF_NAME
-            dockerfile: Dockerfile.example
-            source_directory: .
-
-          - name: gst-py-example
-            build_args: PACKAGE_VERSION=${{ needs.get_semver.outputs.semver }};UBUNTU_RELEASE=20.04;GSTREAMER_BASE_IMAGE_RELEASE=$GITHUB_REF_NAME;PY_BUILD_IMAGE=ghcr.io/selkies-project/selkies-gstreamer/py-build:$GITHUB_REF_NAME;WEB_IMAGE=ghcr.io/selkies-project/selkies-gstreamer/gst-web:$GITHUB_REF_NAME
-            dockerfile: Dockerfile.example
-            source_directory: .
-
-    name: ${{ matrix.name }}${{ matrix.version_suffix }} image build & publish
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Build & publish ${{ matrix.name }} image
-        uses: ./.github/actions/build_and_publish_image
-        with:
-          build_args: ${{ matrix.build_args }}
-          github_personal_access_token: ${{ secrets.GITHUB_TOKEN }}
-          github_username: $GITHUB_ACTOR
-          image_name: ${{ matrix.name }}
-          image_source_directory: ${{ matrix.source_directory }}
-          image_version_1: $GITHUB_REF_NAME${{ matrix.version_suffix }}
-          image_version_2: latest${{ matrix.version_suffix }}
-
-  all_assets:
-    needs:
-      - all_component_images
-      - get_semver
-    runs-on: ubuntu-latest
-    outputs:
-      gst18_cache_key: ${{ steps.extract.outputs.gst18_cache_key }}
-      gst18_mimetype: ${{ steps.extract.outputs.gst18_mimetype }}
-      gst18_name: ${{ steps.extract.outputs.gst18_name }}
-      gst18_path: ${{ steps.extract.outputs.gst18_path }}
-      gst20_cache_key: ${{ steps.extract.outputs.gst20_cache_key }}
-      gst20_mimetype: ${{ steps.extract.outputs.gst20_mimetype }}
-      gst20_name: ${{ steps.extract.outputs.gst20_name }}
-      gst20_path: ${{ steps.extract.outputs.gst20_path }}
-      py_cache_key: ${{ steps.extract.outputs.py_cache_key }}
-      py_mimetype: ${{ steps.extract.outputs.py_mimetype }}
-      py_name: ${{ steps.extract.outputs.py_name }}
-      py_path: ${{ steps.extract.outputs.py_path }}
-      web_cache_key: ${{ steps.extract.outputs.web_cache_key }}
-      web_mimetype: ${{ steps.extract.outputs.web_mimetype }}
-      web_name: ${{ steps.extract.outputs.web_name }}
-      web_path: ${{ steps.extract.outputs.web_path }}
-    strategy:
-      matrix:
-        include:
-          - id: gst18
-            cache_key: gstreamer-asset-ubuntu1804
-            description: Ubuntu 18.04
-            image_tag: ghcr.io/selkies-project/selkies-gstreamer/gstreamer:${{ github.ref_name }}-ubuntu18.04
-            mimetype: application/tar+gzip
-            source_path: /opt/selkies-gstreamer-latest.tgz
-            target_directory: /tmp
-            target_name: selkies-gstreamer-${{ github.ref_name }}-ubuntu18.04.tgz
-            upload_bucket_path: gs://selkies-project-releases/selkies-gstreamer/${{ github.ref_name }}/
-
-          - id: gst20
-            cache_key: gstreamer-asset-ubuntu2004
-            description: Ubuntu 20.04
-            image_tag: ghcr.io/selkies-project/selkies-gstreamer/gstreamer:${{ github.ref_name }}-ubuntu20.04
-            mimetype: application/tar+gzip
-            source_path: /opt/selkies-gstreamer-latest.tgz
-            target_directory: /tmp
-            target_name: selkies-gstreamer-${{ github.ref_name }}-ubuntu20.04.tgz
-            upload_bucket_path: gs://selkies-project-releases/selkies-gstreamer/${{ github.ref_name }}/
-          
-          - id: py
-            cache_key: gst-py-asset
-            description: Python
-            image_tag: ghcr.io/selkies-project/selkies-gstreamer/py-build:${{ github.ref_name }}
-            mimetype: application/x-pywheel+zip
-            source_path: /opt/pypi/dist/selkies_gstreamer-${{ needs.get_semver.outputs.semver }}-py3-none-any.whl
-            target_directory: /tmp
-            target_name: selkies_gstreamer-${{ needs.get_semver.outputs.semver }}-py3-none-any.whl
-            upload_bucket_path: gs://selkies-project-releases/selkies-gstreamer/${{ github.ref_name }}/
-          
-          - id: web
-            cache_key: gst-web-asset
-            description: Web
-            image_tag: ghcr.io/selkies-project/selkies-gstreamer/gst-web:${{ github.ref_name }}
-            mimetype: application/tar+gzip
-            source_path: /usr/share/nginx/html
-            target_directory: /tmp
-            target_name: selkies-gstreamer-web-${{ github.ref_name }}.tgz
-            upload_bucket_path: gs://selkies-project-releases/selkies-gstreamer/${{ github.ref_name }}/
-
-    name: ${{ matrix.description }} asset extraction
-    steps:
-      - id: extract
-        run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-          cat - > /tmp/sa_key.json <<EOF
-          ${{ secrets.GCP_ACTIONS_SA_KEY }}
-          EOF
-          gcloud -q auth activate-service-account --key-file /tmp/sa_key.json
-
-          docker create --name copy ${{ matrix.image_tag }}
-          TARGET_PATH=${{ matrix.target_directory }}/${{ matrix.target_name }}
-          if [[ ${{ matrix.source_path }} == *\.whl || ${{ matrix.source_path }} == *\.tgz ]]
-          then
-            docker cp copy:${{ matrix.source_path }} $TARGET_PATH
-          else
-            (
-              cd ${{ matrix.target_directory }} &&
-              docker cp copy:${{ matrix.source_path }} ./temp &&
-              tar zcvf $TARGET_PATH temp
-            )
-          fi
-          docker rm copy
-          gsutil cp $TARGET_PATH ${{ matrix.upload_bucket_path }}
-
-          echo ::set-output name=${{ matrix.id }}_cache_key::${{ matrix.cache_key }}
-          echo ::set-output name=${{ matrix.id }}_mimetype::${{ matrix.mimetype }}
-          echo ::set-output name=${{ matrix.id }}_name::${{ matrix.target_name }}
-          echo ::set-output name=${{ matrix.id }}_path::$TARGET_PATH
-
-      - uses: actions/cache@v2
-        with:
-          key: ${{ matrix.cache_key }}
-          path: ${{ matrix.target_directory }}/${{ matrix.target_name }}
 
   create_release:
     runs-on: ubuntu-latest
     needs:
-      - all_component_images
-      - all_example_images
-      - all_assets
+      - all_images
     steps:
-      - name: Ubuntu 18.04 cache read
-        uses: actions/cache@v2
-        with:
-          key: ${{ needs.all_assets.outputs.gst18_cache_key }}
-          path: ${{ needs.all_assets.outputs.gst18_path }}
-
-      - name: Ubuntu 20.04 cache read
-        uses: actions/cache@v2
-        with:
-          key: ${{ needs.all_assets.outputs.gst20_cache_key }}
-          path: ${{ needs.all_assets.outputs.gst20_path }}
-
-      - name: Python cache read
-        uses: actions/cache@v2
-        with:
-          key: ${{ needs.all_assets.outputs.py_cache_key }}
-          path: ${{ needs.all_assets.outputs.py_path }}
-
-      - name: Web cache read
-        uses: actions/cache@v2
-        with:
-          key: ${{ needs.all_assets.outputs.web_cache_key }}
-          path: ${{ needs.all_assets.outputs.web_path }}
-
       - id: create_release
         uses: actions/create-release@v1
         env:
@@ -239,43 +45,3 @@ jobs:
           prerelease: false
           release_name: Release ${{ github.ref_name }}
           tag_name: ${{ github.ref_name }}
-
-      - name: Ubuntu 18.04 upload
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          asset_content_type: ${{ needs.all_assets.outputs.gst18_mimetype }}
-          asset_name: ${{ needs.all_assets.outputs.gst18_name }}
-          asset_path: ${{ needs.all_assets.outputs.gst18_path }}
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-
-      - name: Ubuntu 20.04 upload
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          asset_content_type: ${{ needs.all_assets.outputs.gst20_mimetype }}
-          asset_name: ${{ needs.all_assets.outputs.gst20_name }}
-          asset_path: ${{ needs.all_assets.outputs.gst20_path }}
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-
-      - name: Python upload
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          asset_content_type: ${{ needs.all_assets.outputs.py_mimetype }}
-          asset_name: ${{ needs.all_assets.outputs.py_name }}
-          asset_path: ${{ needs.all_assets.outputs.py_path }}
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-
-      - name: Web upload
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          asset_content_type: ${{ needs.all_assets.outputs.web_mimetype }}
-          asset_name: ${{ needs.all_assets.outputs.web_name }}
-          asset_path: ${{ needs.all_assets.outputs.web_path }}
-          upload_url: ${{ steps.create_release.outputs.upload_url }}

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -1,7 +1,281 @@
 name: Publish release
 
-on: workflow_dispatch
+on:
+  push:
+    tags:
+      - "v*"
 
 jobs:
-  PLACEHOLDER:
+  get_semver:
     runs-on: ubuntu-latest
+    outputs:
+      semver: ${{ steps.get.outputs.semver }}
+    steps:
+      - id: get
+        env:
+          RELEASE_VERSION: ${{ github.ref_name }}
+        run: echo ::set-output name=semver::${RELEASE_VERSION/v/}
+
+  # Note: When modifying this job, copy modifications to all other workflows' image jobs.
+  all_component_images:
+    needs: get_semver
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: coturn
+            source_directory: addons/coturn
+
+          - name: coturn-web
+            source_directory: addons/coturn-web
+
+          - name: gst-web
+            source_directory: addons/gst-web
+
+          - name: gstreamer
+            version_suffix: -ubuntu18.04
+            build_args: BASE_IMAGE=ubuntu:18.04;
+            source_directory: addons/gstreamer
+
+          - name: gstreamer
+            version_suffix: -ubuntu20.04
+            build_args: BASE_IMAGE=ubuntu:20.04;
+            source_directory: addons/gstreamer
+
+          - name: infra-gcp-installer
+            source_directory: infra/gce/installer-image
+
+          - name: py-build
+            build_args: PACKAGE_VERSION=${{ needs.get_semver.outputs.semver }}
+            source_directory: .
+
+    name: ${{ matrix.name }}${{ matrix.version_suffix }} image build & publish
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build & publish ${{ matrix.name }} image
+        uses: ./.github/actions/build_and_publish_image
+        with:
+          build_args: ${{ matrix.build_args }}
+          github_personal_access_token: ${{ secrets.GITHUB_TOKEN }}
+          github_username: $GITHUB_ACTOR
+          image_name: ${{ matrix.name }}
+          image_source_directory: ${{ matrix.source_directory }}
+          image_version_1: $GITHUB_REF_NAME${{ matrix.version_suffix }}
+          image_version_2: latest${{ matrix.version_suffix }}
+
+  # Note: When modifying this job, copy modifications to all other workflows' image jobs.
+  all_example_images:
+    needs:
+      - get_semver
+      - all_component_images
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: gst-py-example
+            version_suffix: -ubuntu18.04
+            build_args: PACKAGE_VERSION=${{ needs.get_semver.outputs.semver }};UBUNTU_RELEASE=18.04;GSTREAMER_BASE_IMAGE_RELEASE=$GITHUB_REF_NAME;PY_BUILD_IMAGE=ghcr.io/selkies-project/selkies-gstreamer/py-build:$GITHUB_REF_NAME;WEB_IMAGE=ghcr.io/selkies-project/selkies-gstreamer/gst-web:$GITHUB_REF_NAME
+            dockerfile: Dockerfile.example
+            source_directory: .
+
+          - name: gst-py-example
+            build_args: PACKAGE_VERSION=${{ needs.get_semver.outputs.semver }};UBUNTU_RELEASE=20.04;GSTREAMER_BASE_IMAGE_RELEASE=$GITHUB_REF_NAME;PY_BUILD_IMAGE=ghcr.io/selkies-project/selkies-gstreamer/py-build:$GITHUB_REF_NAME;WEB_IMAGE=ghcr.io/selkies-project/selkies-gstreamer/gst-web:$GITHUB_REF_NAME
+            dockerfile: Dockerfile.example
+            source_directory: .
+
+    name: ${{ matrix.name }}${{ matrix.version_suffix }} image build & publish
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build & publish ${{ matrix.name }} image
+        uses: ./.github/actions/build_and_publish_image
+        with:
+          build_args: ${{ matrix.build_args }}
+          github_personal_access_token: ${{ secrets.GITHUB_TOKEN }}
+          github_username: $GITHUB_ACTOR
+          image_name: ${{ matrix.name }}
+          image_source_directory: ${{ matrix.source_directory }}
+          image_version_1: $GITHUB_REF_NAME${{ matrix.version_suffix }}
+          image_version_2: latest${{ matrix.version_suffix }}
+
+  all_assets:
+    needs:
+      - all_component_images
+      - get_semver
+    runs-on: ubuntu-latest
+    outputs:
+      gst18_cache_key: ${{ steps.extract.outputs.gst18_cache_key }}
+      gst18_mimetype: ${{ steps.extract.outputs.gst18_mimetype }}
+      gst18_name: ${{ steps.extract.outputs.gst18_name }}
+      gst18_path: ${{ steps.extract.outputs.gst18_path }}
+      gst20_cache_key: ${{ steps.extract.outputs.gst20_cache_key }}
+      gst20_mimetype: ${{ steps.extract.outputs.gst20_mimetype }}
+      gst20_name: ${{ steps.extract.outputs.gst20_name }}
+      gst20_path: ${{ steps.extract.outputs.gst20_path }}
+      py_cache_key: ${{ steps.extract.outputs.py_cache_key }}
+      py_mimetype: ${{ steps.extract.outputs.py_mimetype }}
+      py_name: ${{ steps.extract.outputs.py_name }}
+      py_path: ${{ steps.extract.outputs.py_path }}
+      web_cache_key: ${{ steps.extract.outputs.web_cache_key }}
+      web_mimetype: ${{ steps.extract.outputs.web_mimetype }}
+      web_name: ${{ steps.extract.outputs.web_name }}
+      web_path: ${{ steps.extract.outputs.web_path }}
+    strategy:
+      matrix:
+        include:
+          - id: gst18
+            cache_key: gstreamer-asset-ubuntu1804
+            description: Ubuntu 18.04
+            image_tag: ghcr.io/selkies-project/selkies-gstreamer/gstreamer:${{ github.ref_name }}-ubuntu18.04
+            mimetype: application/tar+gzip
+            source_path: /opt/selkies-gstreamer-latest.tgz
+            target_directory: /tmp
+            target_name: selkies-gstreamer-${{ github.ref_name }}-ubuntu18.04.tgz
+            upload_bucket_path: gs://selkies-project-releases/selkies-gstreamer/${{ github.ref_name }}/
+
+          - id: gst20
+            cache_key: gstreamer-asset-ubuntu2004
+            description: Ubuntu 20.04
+            image_tag: ghcr.io/selkies-project/selkies-gstreamer/gstreamer:${{ github.ref_name }}-ubuntu20.04
+            mimetype: application/tar+gzip
+            source_path: /opt/selkies-gstreamer-latest.tgz
+            target_directory: /tmp
+            target_name: selkies-gstreamer-${{ github.ref_name }}-ubuntu20.04.tgz
+            upload_bucket_path: gs://selkies-project-releases/selkies-gstreamer/${{ github.ref_name }}/
+          
+          - id: py
+            cache_key: gst-py-asset
+            description: Python
+            image_tag: ghcr.io/selkies-project/selkies-gstreamer/py-build:${{ github.ref_name }}
+            mimetype: application/x-pywheel+zip
+            source_path: /opt/pypi/dist/selkies_gstreamer-${{ needs.get_semver.outputs.semver }}-py3-none-any.whl
+            target_directory: /tmp
+            target_name: selkies_gstreamer-${{ needs.get_semver.outputs.semver }}-py3-none-any.whl
+            upload_bucket_path: gs://selkies-project-releases/selkies-gstreamer/${{ github.ref_name }}/
+          
+          - id: web
+            cache_key: gst-web-asset
+            description: Web
+            image_tag: ghcr.io/selkies-project/selkies-gstreamer/gst-web:${{ github.ref_name }}
+            mimetype: application/tar+gzip
+            source_path: /usr/share/nginx/html
+            target_directory: /tmp
+            target_name: selkies-gstreamer-web-${{ github.ref_name }}.tgz
+            upload_bucket_path: gs://selkies-project-releases/selkies-gstreamer/${{ github.ref_name }}/
+
+    name: ${{ matrix.description }} asset extraction
+    steps:
+      - id: extract
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          cat - > /tmp/sa_key.json <<EOF
+          ${{ secrets.GCP_ACTIONS_SA_KEY }}
+          EOF
+          gcloud -q auth activate-service-account --key-file /tmp/sa_key.json
+
+          docker create --name copy ${{ matrix.image_tag }}
+          TARGET_PATH=${{ matrix.target_directory }}/${{ matrix.target_name }}
+          if [[ ${{ matrix.source_path }} == *\.whl || ${{ matrix.source_path }} == *\.tgz ]]
+          then
+            docker cp copy:${{ matrix.source_path }} $TARGET_PATH
+          else
+            (
+              cd ${{ matrix.target_directory }} &&
+              docker cp copy:${{ matrix.source_path }} ./temp &&
+              tar zcvf $TARGET_PATH temp
+            )
+          fi
+          docker rm copy
+          gsutil cp $TARGET_PATH ${{ matrix.upload_bucket_path }}
+
+          echo ::set-output name=${{ matrix.id }}_cache_key::${{ matrix.cache_key }}
+          echo ::set-output name=${{ matrix.id }}_mimetype::${{ matrix.mimetype }}
+          echo ::set-output name=${{ matrix.id }}_name::${{ matrix.target_name }}
+          echo ::set-output name=${{ matrix.id }}_path::$TARGET_PATH
+
+      - uses: actions/cache@v2
+        with:
+          key: ${{ matrix.cache_key }}
+          path: ${{ matrix.target_directory }}/${{ matrix.target_name }}
+
+  create_release:
+    runs-on: ubuntu-latest
+    needs:
+      - all_component_images
+      - all_example_images
+      - all_assets
+    steps:
+      - name: Ubuntu 18.04 cache read
+        uses: actions/cache@v2
+        with:
+          key: ${{ needs.all_assets.outputs.gst18_cache_key }}
+          path: ${{ needs.all_assets.outputs.gst18_path }}
+
+      - name: Ubuntu 20.04 cache read
+        uses: actions/cache@v2
+        with:
+          key: ${{ needs.all_assets.outputs.gst20_cache_key }}
+          path: ${{ needs.all_assets.outputs.gst20_path }}
+
+      - name: Python cache read
+        uses: actions/cache@v2
+        with:
+          key: ${{ needs.all_assets.outputs.py_cache_key }}
+          path: ${{ needs.all_assets.outputs.py_path }}
+
+      - name: Web cache read
+        uses: actions/cache@v2
+        with:
+          key: ${{ needs.all_assets.outputs.web_cache_key }}
+          path: ${{ needs.all_assets.outputs.web_path }}
+
+      - id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          draft: true
+          prerelease: false
+          release_name: Release ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+
+      - name: Ubuntu 18.04 upload
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          asset_content_type: ${{ needs.all_assets.outputs.gst18_mimetype }}
+          asset_name: ${{ needs.all_assets.outputs.gst18_name }}
+          asset_path: ${{ needs.all_assets.outputs.gst18_path }}
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+
+      - name: Ubuntu 20.04 upload
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          asset_content_type: ${{ needs.all_assets.outputs.gst20_mimetype }}
+          asset_name: ${{ needs.all_assets.outputs.gst20_name }}
+          asset_path: ${{ needs.all_assets.outputs.gst20_path }}
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+
+      - name: Python upload
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          asset_content_type: ${{ needs.all_assets.outputs.py_mimetype }}
+          asset_name: ${{ needs.all_assets.outputs.py_name }}
+          asset_path: ${{ needs.all_assets.outputs.py_path }}
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+
+      - name: Web upload
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          asset_content_type: ${{ needs.all_assets.outputs.web_mimetype }}
+          asset_name: ${{ needs.all_assets.outputs.web_name }}
+          asset_path: ${{ needs.all_assets.outputs.web_path }}
+          upload_url: ${{ steps.create_release.outputs.upload_url }}

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -13,8 +13,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: PLACEHOLDER
-            source_directory: PLACEHOLDER
+          - name: broker-installer
+            source_directory: images/installer
+
+          - name: controller
+            source_directory: images/controller
+
+          - name: gce-proxy
+            source_directory: images/gce-proxy
 
     name: ${{ matrix.name }}${{ matrix.version_suffix }} image build & publish
     steps:


### PR DESCRIPTION
These are identical to the current selkies-gstreamer workflows, except they're simpler (only 3 component images and 0 release assets) and there are multiple trigger options for each workflow. Is this missing anything?