### PR TITLE
[Fix] Bug with brokerappconfig added to the cluster but not showing up in App Launcher Portal

### DIFF
--- a/images/controller/cmd/app_finder/app_finder.go
+++ b/images/controller/cmd/app_finder/app_finder.go
@@ -260,6 +260,13 @@ func copyConfigMapDataIfChanged(cm broker.ConfigMapObject, tmpDirBase, destDir, 
 	if checksums[cacheKey], err = broker.ChecksumDeploy(tmpDir); err != nil {
 		return fmt.Errorf("failed to checksum build output directory: %v", err)
 	}
+	// Check if working manifests folder exist, if folder does not exist invalidate prevChecksum value
+	if prevChecksum != "" {
+		if _, err := os.Stat(destDir); os.IsNotExist(err) {
+			log.Printf("working manifests folder %s does not exist", destDir)
+			prevChecksum = ""
+		}
+	}
 	if prevChecksum != checksums[cacheKey] {
 		log.Printf("%s manifest checksum: %s", cacheKey, checksums[cacheKey])
 		if err := os.MkdirAll(path.Dir(destDir), os.ModePerm); err != nil {


### PR DESCRIPTION
## Changes:
**[Fix]** Bug with the brokerappconfig added to the cluster but not showing up in App Launcher Portal because the bundle source directory does not exist.

## Workaround
Deleting the pod-broker pod, after it is auto-created, all bundles are downloaded and the app should be visible in the portal.

## How to reproduce it?

### Option 1 - Adding and removing brokerappconfig with the same name

1. Create a brokerappconfig with the name "test" (other text works, too)
2. See the app in the launcher portal
3. Delete the brokerappconfig
4. Don't see the app in the launcher portal
5. Create a new brokerappconfig with the same name & description (either same or different image)
6. Don't see the app in the launcher portal

### Option 2 - Manually deleting bundle source directory

```
CTX="REPLACE_WITH_VALID_CONTEXT"
APP_NAME="REPLACE_WITH_VALID_APP_NAME"
POD=$(kubectl --context $CTX get pod -n pod-broker-system -l app=pod-broker --field-selector=status.phase=Running -o jsonpath='{..metadata.name}')
kubectl --context $CTX exec -c app-finder -n pod-broker-system $POD -- rm -Rf apps/$APP_NAME
```