### PR TITLE
Fix CRD type in schema for CPU properties to allow strings or numbers.

### DIFF
--- a/setup/manifests/base/pod-broker/crd.yaml
+++ b/setup/manifests/base/pod-broker/crd.yaml
@@ -254,11 +254,7 @@ spec:
                             type: object
                             properties:
                               cpu:
-                                type: object
-                                schema:
-                                  oneOf:
-                                    - type: string
-                                    - type: number
+                                x-kubernetes-int-or-string: true
                               memory:
                                 type: string
                               ephemeral-storage:
@@ -267,11 +263,7 @@ spec:
                             type: object
                             properties:
                               cpu:
-                                type: object
-                                schema:
-                                  oneOf:
-                                    - type: string
-                                    - type: number
+                                x-kubernetes-int-or-string: true
                               memory:
                                 type: string
                               ephemeral-storage:


### PR DESCRIPTION
Changes:
 - Update the CRD schema to support CPU properties with string or number values.

References:
- [Extend the Kubernetes API with CustomResourceDefinitions
](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#intorstring)
