### PR TITLE
Install gke-gcloud-auth-plugin to manage authentication between kubectl and GKE

### DIFF
--- a/images/installer/Dockerfile
+++ b/images/installer/Dockerfile
@@ -50,6 +50,9 @@ COPY --from=gke-deploy /gke-deploy /usr/local/bin/
 # Install kubectl
 COPY --from=kubectl /builder/google-cloud-sdk/bin/kubectl /usr/local/bin/kubectl
 
+# Install gke-gcloud-auth-plugin
+RUN gcloud components install gke-gcloud-auth-plugin --quiet
+
 # Download the istio operator release
 RUN mkdir -p /opt/istio-operator && cd /opt/istio-operator && \
     wget --timeout 2 --tries 5 -qO- https://github.com/istio/operator/archive/${ISTIO_OPERATOR_VERSION}.tar.gz | tar --strip-components=1 -zxf - 


### PR DESCRIPTION
**Changes**: 
- Install `gke-gcloud-auth-plugin` to manage authentication between `kubectl` and GKE
`Note`: the gcp auth plugin is deprecated in v1.22+, unavailable in v1.25+

**References**
- [Important changes to Kubectl authentication are coming in GKE v1.25](https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke)