### PR TITLE
Create istio-system namespace if it doesn't exist

### DIFF
--- a/setup/manifests/install_istio_1.14.sh
+++ b/setup/manifests/install_istio_1.14.sh
@@ -27,6 +27,7 @@ function log_red() { echo -e "${RED}$@${NC}"; }
 [[ -z "${ISTIOCTL}" ]] && log_red "Missing ISTIOCTL env var." && exit 1
 
 log_cyan "Installing Istio control plane..."
+kubectl get namespace istio-system || kubectl create ns istio-system
 ${ISTIOCTL} manifest generate --set profile=default | kubectl apply -f -
 ## wait for EnvoyFilter crd to be ready and reapply 
 sleep 60


### PR DESCRIPTION
istioctl expects the istio-system namespace to be created before generating the manifest and applying it.
This issue is referenced in #53.