### PR TITLE
Fix python 3.11+ support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     websockets
     basicauth
     gputil
-    python-uinput
+    python-uinput @ git+https://github.com/marmarek/python-uinput@168bb8734e3722c4fdc24d4d75d07e992c09be53 # Fixes python 3.11+
     prometheus_client
     msgpack
     pynput


### PR DESCRIPTION
`sysconfig.get_config_var("SO")` was used in the python-uinput package but the `SO` variable has been deprecated for a long time and no longer works in python 3.11+. This PR updates the dependency to use a fork that changes the variable to its replacement, `EXT_SUFFIX`.