### PR TITLE
Updating HPA api version for coturn GKE deployment

### DIFF
--- a/infra/gke/manifests/coturn/coturn-hpa.yaml
+++ b/infra/gke/manifests/coturn/coturn-hpa.yaml
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: coturn


### PR DESCRIPTION
autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler