### PR TITLE
Import devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,73 @@
+ARG IMAGE_TAG=jammy
+FROM mcr.microsoft.com/devcontainers/base:${IMAGE_TAG}
+
+# Install base dependencies
+RUN sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    python3-pip \
+    python3-dev \
+    python3-gi \
+    python3-setuptools \
+    python3-wheel \
+    udev \
+    wmctrl \
+    jq \
+    gdebi-core \
+    glib-networking \
+    libopus0 \
+    libgdk-pixbuf2.0-0 \
+    libgtk2.0-bin \
+    libgl-dev \
+    libgles-dev \
+    libglvnd-dev \
+    libgudev-1.0-0 \
+    xclip \
+    x11-utils \
+    xdotool \
+    x11-xserver-utils \
+    xserver-xorg-core \
+    wayland-protocols \
+    libwayland-dev \
+    libwayland-egl-backend-dev \
+    libx11-xcb1 \
+    libxkbcommon0 \
+    libxdamage1 \
+    libxml2-dev \
+    libwebrtc-audio-processing1 \
+    libsrtp2-1 \
+    libcairo-gobject2 \
+    pulseaudio \
+    libpulse0 \
+    libpangocairo-1.0-0 \
+    libgirepository1.0-dev \
+    libjpeg-dev \
+    libwebp-dev \
+    libvpx-dev \
+    zlib1g-dev \
+    x264 \
+    xvfb \
+    coturn
+
+RUN . /etc/lsb-release; if [ "${DISTRIB_RELEASE}" \> "20.04" ]; then apt-get install --no-install-recommends -y xcvt; fi
+
+# Download and extract latest gstreamer component
+RUN cd /opt && . /etc/lsb-release && SELKIES_VERSION=$(curl -fsSL "https://api.github.com/repos/selkies-project/selkies-gstreamer/releases/latest" | jq -r '.tag_name' | sed 's/[^0-9\.\-]*//g') && \
+    curl -fsSL "https://github.com/selkies-project/selkies-gstreamer/releases/download/v${SELKIES_VERSION}/selkies-gstreamer-v${SELKIES_VERSION}-ubuntu${DISTRIB_RELEASE}.tgz" | tar -zxf -
+
+# Install dev dependencies
+RUN sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        nginx \
+        imagemagick \
+        python3-venv && \
+    sudo python3 -m pip install --upgrade build
+
+# Install desktop environment
+ARG DESKTOP=xfce
+COPY ./features/desktop-selkies/src/install-desktop-environment.sh /tmp/
+RUN /tmp/install-desktop-environment.sh ${DESKTOP}
+
+# Install browser
+RUN cd /tmp && sudo apt-get update && \
+    wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
+    sudo DEBIAN_FRONTEND=noninteractive apt install -y xdg-utils ./google-chrome-stable_current_amd64.deb && \
+    sudo rm -f google-chrome-stable_current_amd64.deb && \
+    xdg-settings set default-web-browser google-chrome.desktop

--- a/.devcontainer/features/desktop-selkies/src/devcontainer-feature.json
+++ b/.devcontainer/features/desktop-selkies/src/devcontainer-feature.json
@@ -1,0 +1,41 @@
+{
+    "name": "Selkies GStreamer",
+    "id": "selkies-gstreamer",
+    "version": "1.0.0",
+    "description": "WebRTC Remote Desktop for Linux",
+    "options": {
+        "release": {
+            "type": "string",
+            "default": "latest",
+            "description": "The selkies-gstreamer release tag."
+        },
+        "xserver": {
+            "type": "string",
+            "enum": [
+                "xvfb",
+                "host"
+            ],
+            "default": "xvfb",
+            "description": "type of xserver to use, if xvfb, Xserver will be created automatically "
+        },
+        "desktop": {
+            "type": "string",
+            "enum": [
+                "kdeplasma",
+                "ubuntu",
+                "xfce"
+            ],
+            "default": "xfce",
+            "description": "The desktop environment to install"
+        },
+        "web_port": {
+            "type": "string",
+            "default": "8080",
+            "description": "The port number to listen on to host the web interface and signal server."
+        }
+    },
+    "entrypoint": "/usr/local/bin/start-selkies.sh",
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils"
+    ]
+}

--- a/.devcontainer/features/desktop-selkies/src/install-desktop-environment.sh
+++ b/.devcontainer/features/desktop-selkies/src/install-desktop-environment.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -e
+
+function install_fluxbox() {
+    sudo apt-get update
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+            fluxbox \
+            terminator
+}
+
+function install_xfce() {
+    sudo apt-get update
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+            xfce4 \
+            xfce4-terminal \
+            breeze-cursor-theme
+
+    # Configure desktop environment
+    sudo apt remove -y \
+            xfce4-screensaver
+
+    sudo ln -fs /etc/xfce4/defaults.list /usr/share/applications/defaults.list
+}
+
+function install_kde() {
+    sudo apt-get update
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+            kde-plasma-desktop \
+            konsole \
+            breeze-cursor-theme
+}
+
+function install_ubuntu_desktop() {
+    sudo apt-get update
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+            ubuntu-desktop \
+            gnome-terminal \
+            breeze-cursor-theme
+}
+
+case ${1,,} in
+    fluxbox)
+        install_fluxbox
+        ;;
+    xfce)
+        install_xfce
+        ;;
+    kdeplasma)
+        install_kde
+        ;;
+    ubuntu)
+        install_ubuntu_desktop
+        ;;
+    *)
+        echo "ERROR: unsupported desktop environment: $1"
+        exit 1
+        ;;
+esac

--- a/.devcontainer/features/desktop-selkies/src/install.sh
+++ b/.devcontainer/features/desktop-selkies/src/install.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+set -e
+
+echo "Activating feature 'Selkies GStreamer'"
+echo "The provided release version is: ${RELEASE:-missing env}"
+echo "The provided web port is: ${WEB_PORT:-missing env}"
+echo "The provided xserver is: ${XSERVER:-missing env}"
+
+# Install base dependencies
+apt-get update && apt-get install --no-install-recommends -y \
+    python3-pip \
+    python3-dev \
+    python3-gi \
+    python3-setuptools \
+    python3-wheel \
+    udev \
+    wmctrl \
+    jq \
+    gdebi-core \
+    glib-networking \
+    libopus0 \
+    libgdk-pixbuf2.0-0 \
+    libgtk2.0-bin \
+    libgl-dev \
+    libgles-dev \
+    libglvnd-dev \
+    libgudev-1.0-0 \
+    xclip \
+    x11-utils \
+    xdotool \
+    x11-xserver-utils \
+    xserver-xorg-core \
+    wayland-protocols \
+    libwayland-dev \
+    libwayland-egl-backend-dev \
+    libx11-xcb1 \
+    libxkbcommon0 \
+    libxdamage1 \
+    libxml2-dev \
+    libwebrtc-audio-processing1 \
+    libsrtp2-1 \
+    libcairo-gobject2 \
+    pulseaudio \
+    libpulse0 \
+    libpangocairo-1.0-0 \
+    libgirepository1.0-dev \
+    libjpeg-dev \
+    libwebp-dev \
+    libvpx-dev \
+    zlib1g-dev \
+    x264 \
+    xvfb \
+    coturn
+
+. /etc/lsb-release
+if [ "${DISTRIB_RELEASE}" \> "20.04" ]; then apt-get install --no-install-recommends -y xcvt; fi
+
+# Install desktop environment
+./install-desktop-environment.sh ${DESKTOP}
+
+SELKIES_RELEASE_TAG=${RELEASE}
+if [[ "${RELEASE}" == "latest" ]]; then
+    # Automatically fetch the latest selkies-gstreamer version and install the components
+    SELKIES_RELEASE_TAG=$(curl -fsSL "https://api.github.com/repos/selkies-project/selkies-gstreamer/releases/latest" | jq -r '.tag_name' | sed 's/[^0-9\.\-]*//g')
+else
+    # Check for tagged release
+    if ! curl -fsSL -o /dev/null "https://api.github.com/repos/selkies-project/selkies-gstreamer/releases/tags/${RELEASE}"; then
+        echo "ERROR: could not find selkies-gstreamer release ${RELEASE}"
+        exit 1
+    fi
+fi
+# Remove leading 'v' to get semver number.
+SELKIES_VERSION=${SELKIES_RELEASE_TAG:1}
+
+cd /opt
+curl -fsSL "https://github.com/selkies-project/selkies-gstreamer/releases/download/${SELKIES_RELEASE_TAG}/selkies-gstreamer-${SELKIES_RELEASE_TAG}-ubuntu${DISTRIB_RELEASE}.tgz" | tar -zxf -
+curl -O -fsSL "https://github.com/selkies-project/selkies-gstreamer/releases/download/${SELKIES_RELEASE_TAG}/selkies_gstreamer-${SELKIES_VERSION}-py3-none-any.whl" && pip3 install "selkies_gstreamer-${SELKIES_VERSION}-py3-none-any.whl" && rm -f "selkies_gstreamer-${SELKIES_VERSION}-py3-none-any.whl"
+curl -fsSL "https://github.com/selkies-project/selkies-gstreamer/releases/download/${SELKIES_RELEASE_TAG}/selkies-gstreamer-web-${SELKIES_RELEASE_TAG}.tgz" | tar -zxf -
+
+# Link cuda libraries if they are present.
+if [[ -d /usr/local/cuda ]]; then
+    cd /usr/local/cuda/lib64 && sudo find . -maxdepth 1 -type l -name "*libnvrtc.so.*" -exec sh -c 'ln -snf $(basename {}) libnvrtc.so' \;
+fi
+
+# Copy turnserver script
+cp start-turnserver.sh /usr/local/bin/start-turnserver.sh
+chmod +x /usr/local/bin/start-turnserver.sh &
+
+# Copy the startup script
+cp start-selkies.sh /usr/local/bin/start-selkies.sh
+chmod +x /usr/local/bin/start-selkies.sh

--- a/.devcontainer/features/desktop-selkies/src/start-selkies.sh
+++ b/.devcontainer/features/desktop-selkies/src/start-selkies.sh
@@ -1,0 +1,72 @@
+export DISPLAY=:0
+unset WAYLAND_DISPLAY
+export XSERVER=${XSERVER:-XVFB}
+
+SCRIPT_DIR=$(dirname $(readlink -f $0))
+
+function cleanup() {
+    kill -9 $(pidof turnserver) 1>/dev/null 2>&1|| true
+    pgrep -af '.*selkies-gstreamer.*' | cut -d' ' -f1 | xargs kill -9 1>/dev/null 2>&1|| true
+    pgrep -afi '.*xfce4.*' | cut -d' ' -f1 | xargs kill -9 1>/dev/null 2>&1|| true
+    pgrep -afi '.*fluxbox.*' | cut -d' ' -f1 | xargs kill -9 1>/dev/null 2>&1|| true
+    sudo /usr/bin/pulseaudio -k 1>/dev/null 2>&1  || true
+    kill -9 $(pidof Xvfb) 1>/dev/null 2>&1 || true
+    exit
+}
+trap cleanup SIGINT SIGKILL EXIT
+
+# Start Xvfb Xserver
+if [[ ${XSERVER} == "XVFB" ]]; then
+    Xvfb -screen :0 8192x4096x24 +extension RANDR +extension GLX +extension MIT-SHM -nolisten tcp -noreset -shmem 2>&1 >/tmp/Xvfb.log &
+fi
+
+# Wait for X11 to start
+echo "Waiting for X socket"
+until [ -S "/tmp/.X11-unix/X${DISPLAY/:/}" ]; do sleep 1; done
+echo "X socket is ready"
+
+# Disable screen saver
+xset s off
+# Disable screen blanking
+xset s noblank
+# Disable power management
+xset -dpms
+
+# Start pulse audio server
+export PULSE_SERVER=tcp:127.0.0.1:4713
+sudo /usr/bin/pulseaudio -k >/dev/null 2>&1
+sudo /usr/bin/pulseaudio --daemonize --system --verbose --log-target=file:/tmp/pulseaudio.log --realtime=true --disallow-exit -L 'module-native-protocol-tcp auth-ip-acl=127.0.0.0/8 port=4713 auth-anonymous=1'
+
+# Start desktop environment
+case ${DESKTOP:-XFCE} in
+    FLUXBOX)
+        startfluxbox &
+        ;;
+    XFCE)
+        xfce4-session &
+        ;;
+    *)
+        echo "WARN: Unsupported DESTKOP: '${DESKTOP}'"
+        ;;
+esac
+
+# Source gstreamer environment
+source /opt/gstreamer/gst-env
+
+# Start turnserver
+${SCRIPT_DIR}/start-turnserver.sh &
+
+# Start Selkies
+selkies-gstreamer-resize 1920x1080
+selkies-gstreamer \
+    --addr="0.0.0.0" \
+    --port="${WEB_PORT:-6080}" \
+    --metrics_port=${WEBRTC_METRICS_PORT:-19090} \
+    --cursor_size=${WEBRTC_CURSOR_SIZE:-"-1"} \
+    --enable_resize=${WEBRTC_ENABLE_RESIZE:-true} \
+    --turn_host=${TURN_HOST:-localhost} \
+    --turn_port=${TURN_PORT:-3478} \
+    --turn_username=${TURN_USERNAME:-selkies} \
+    --turn_password=${TURN_PASSWORD:-selkies} \
+    --turn_protocol=${TURN_PROTOCOL:-tcp} \
+    $@

--- a/.devcontainer/features/desktop-selkies/src/start-turnserver.sh
+++ b/.devcontainer/features/desktop-selkies/src/start-turnserver.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+exec turnserver \
+    --verbose \
+    --no-tls \
+    --listening-ip=0.0.0.0 \
+    --listening-port=${TURN_PORT:-3478} \
+    --realm=${TURN_REALM:-example.com} \
+    --channel-lifetime=${TURN_CHANNEL_LIFETIME:-"-1"} \
+    --min-port=${TURN_MIN_PORT:-49152} \
+    --max-port=${TURN_MAX_PORT:-65535} \
+    --user selkies:selkies \
+    --no-cli \
+    --cli-password selkies \
+    --allow-loopback-peers \
+    --db ${HOME}/.config/turndb \
+    ${EXTRA_ARGS} $@

--- a/.devcontainer/focal-fluxbox/devcontainer.json
+++ b/.devcontainer/focal-fluxbox/devcontainer.json
@@ -1,0 +1,55 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "Ubuntu Focal with Fluxbox Desktop",
+	"build": {
+		// Path is relative to the devcontainer.json file.
+		"dockerfile": "../Dockerfile",
+		"args": {
+			"IMAGE_TAG": "focal",
+			"DESKTOP": "fluxbox"
+		}
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+		"ghcr.io/devcontainers/features/github-cli:1": {},
+		"ghcr.io/devcontainers-contrib/features/act:1": {}
+	},
+	// Increase SHM size to help with crashing on Chrome.
+	"runArgs": [
+		"--shm-size=1g"
+	],
+
+	"forwardPorts": [
+		6080, // selkies web port
+		3478, // turnserver
+		19090 // prometheus metrics port
+	],
+	"portsAttributes": {
+		// https://containers.dev/implementors/json_reference/#port-attributes
+		"6080": {
+			"label": "desktop",
+			"onAutoForward": "notify"
+		},
+		"3478": {
+			"label": "turnserver",
+			"onAutoForward": "ignore"
+		},
+		"19090": {
+			"label": "selkies-metrics",
+			"onAutoForward": "ignore"
+		}
+	},
+
+	"remoteEnv": {
+		// desktop environment passed to the start-selkies.sh script
+		"DESKTOP": "FLUXBOX"
+	}
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+	// Configure tool-specific properties.
+	// "customizations": {},
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/focal-fluxbox/devcontainer.json
+++ b/.devcontainer/focal-fluxbox/devcontainer.json
@@ -15,6 +15,8 @@
 		"ghcr.io/devcontainers/features/github-cli:1": {},
 		"ghcr.io/devcontainers-contrib/features/act:1": {}
 	},
+	// Run privileged to run Chrome without --no-sandbox option.
+	"privileged": true,
 	// Increase SHM size to help with crashing on Chrome.
 	"runArgs": [
 		"--shm-size=1g"
@@ -44,6 +46,14 @@
 	"remoteEnv": {
 		// desktop environment passed to the start-selkies.sh script
 		"DESKTOP": "FLUXBOX"
+	},
+
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.python"
+			]
+		}
 	}
 
 	// Use 'postCreateCommand' to run commands after the container is created.

--- a/.devcontainer/focal-xfce/devcontainer.json
+++ b/.devcontainer/focal-xfce/devcontainer.json
@@ -15,6 +15,8 @@
 		"ghcr.io/devcontainers/features/github-cli:1": {},
 		"ghcr.io/devcontainers-contrib/features/act:1": {}
 	},
+	// Run privileged to run Chrome without --no-sandbox option.
+	"privileged": true,
 	// Increase SHM size to help with crashing on Chrome.
 	"runArgs": [
 		"--shm-size=1g"
@@ -44,6 +46,14 @@
 	"remoteEnv": {
 		// desktop environment passed to the start-selkies.sh script
 		"DESKTOP": "XFCE"
+	},
+
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.python"
+			]
+		}
 	}
 
 	// Use 'postCreateCommand' to run commands after the container is created.

--- a/.devcontainer/focal-xfce/devcontainer.json
+++ b/.devcontainer/focal-xfce/devcontainer.json
@@ -1,0 +1,55 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "Ubuntu Focal with Xfce Desktop",
+	"build": {
+		// Path is relative to the devcontainer.json file.
+		"dockerfile": "../Dockerfile",
+		"args": {
+			"IMAGE_TAG": "focal",
+			"DESKTOP": "xfce"
+		}
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+		"ghcr.io/devcontainers/features/github-cli:1": {},
+		"ghcr.io/devcontainers-contrib/features/act:1": {}
+	},
+	// Increase SHM size to help with crashing on Chrome.
+	"runArgs": [
+		"--shm-size=1g"
+	],
+
+	"forwardPorts": [
+		6080, // selkies web port
+		3478, // turnserver
+		19090 // prometheus metrics port
+	],
+	"portsAttributes": {
+		// https://containers.dev/implementors/json_reference/#port-attributes
+		"6080": {
+			"label": "desktop",
+			"onAutoForward": "notify"
+		},
+		"3478": {
+			"label": "turnserver",
+			"onAutoForward": "ignore"
+		},
+		"19090": {
+			"label": "selkies-metrics",
+			"onAutoForward": "ignore"
+		}
+	},
+
+	"remoteEnv": {
+		// desktop environment passed to the start-selkies.sh script
+		"DESKTOP": "XFCE"
+	}
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+	// Configure tool-specific properties.
+	// "customizations": {},
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/jammy-fluxbox/devcontainer.json
+++ b/.devcontainer/jammy-fluxbox/devcontainer.json
@@ -1,0 +1,55 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "Ubuntu Jammy with Fluxbox Desktop",
+	"build": {
+		// Path is relative to the devcontainer.json file.
+		"dockerfile": "../Dockerfile",
+		"args": {
+			"IMAGE_TAG": "jammy",
+			"DESKTOP": "fluxbox"
+		}
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+		"ghcr.io/devcontainers/features/github-cli:1": {},
+		"ghcr.io/devcontainers-contrib/features/act:1": {}
+	},
+	// Increase SHM size to help with crashing on Chrome.
+	"runArgs": [
+		"--shm-size=1g"
+	],
+
+	"forwardPorts": [
+		6080, // selkies web port
+		3478, // turnserver
+		19090 // prometheus metrics port
+	],
+	"portsAttributes": {
+		// https://containers.dev/implementors/json_reference/#port-attributes
+		"6080": {
+			"label": "desktop",
+			"onAutoForward": "notify"
+		},
+		"3478": {
+			"label": "turnserver",
+			"onAutoForward": "ignore"
+		},
+		"19090": {
+			"label": "selkies-metrics",
+			"onAutoForward": "ignore"
+		}
+	},
+
+	"remoteEnv": {
+		// desktop environment passed to the start-selkies.sh script
+		"DESKTOP": "FLUXBOX"
+	}
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+	// Configure tool-specific properties.
+	// "customizations": {},
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/jammy-fluxbox/devcontainer.json
+++ b/.devcontainer/jammy-fluxbox/devcontainer.json
@@ -15,6 +15,8 @@
 		"ghcr.io/devcontainers/features/github-cli:1": {},
 		"ghcr.io/devcontainers-contrib/features/act:1": {}
 	},
+	// Run privileged to run Chrome without --no-sandbox option.
+	"privileged": true,
 	// Increase SHM size to help with crashing on Chrome.
 	"runArgs": [
 		"--shm-size=1g"
@@ -44,6 +46,14 @@
 	"remoteEnv": {
 		// desktop environment passed to the start-selkies.sh script
 		"DESKTOP": "FLUXBOX"
+	},
+
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.python"
+			]
+		}
 	}
 
 	// Use 'postCreateCommand' to run commands after the container is created.

--- a/.devcontainer/jammy-xfce/devcontainer.json
+++ b/.devcontainer/jammy-xfce/devcontainer.json
@@ -1,0 +1,54 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "Ubuntu Jammy with Xfce Desktop",
+	"build": {
+		// Path is relative to the devcontainer.json file.
+		"dockerfile": "../Dockerfile",
+		"args": {
+			"IMAGE_TAG": "jammy",
+			"DESKTOP": "xfce"
+		}
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+		"ghcr.io/devcontainers/features/github-cli:1": {},
+		"ghcr.io/devcontainers-contrib/features/act:1": {}
+	},
+	// Increase SHM size to help with crashing on Chrome.
+	"runArgs": [
+		"--shm-size=1g"
+	],
+
+	"forwardPorts": [
+		6080, // selkies web port
+		3478, // turnserver
+		19090 // prometheus metrics port
+	],
+	"portsAttributes": {
+		// https://containers.dev/implementors/json_reference/#port-attributes
+		"6080": {
+			"label": "desktop",
+			"onAutoForward": "notify"
+		},
+		"3478": {
+			"label": "turnserver",
+			"onAutoForward": "ignore"
+		},
+		"19090": {
+			"label": "selkies-metrics",
+			"onAutoForward": "ignore"
+		}
+	},
+
+	"remoteEnv": {
+		"DESKTOP": "XFCE"
+	}
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+	// Configure tool-specific properties.
+	// "customizations": {},
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/jammy-xfce/devcontainer.json
+++ b/.devcontainer/jammy-xfce/devcontainer.json
@@ -15,6 +15,8 @@
 		"ghcr.io/devcontainers/features/github-cli:1": {},
 		"ghcr.io/devcontainers-contrib/features/act:1": {}
 	},
+	// Run privileged to run Chrome without --no-sandbox option.
+	"privileged": true,
 	// Increase SHM size to help with crashing on Chrome.
 	"runArgs": [
 		"--shm-size=1g"
@@ -43,6 +45,14 @@
 
 	"remoteEnv": {
 		"DESKTOP": "XFCE"
+	},
+
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.python"
+			]
+		}
 	}
 
 	// Use 'postCreateCommand' to run commands after the container is created.

--- a/.github/workflows/devcontainer_feature_release.yaml
+++ b/.github/workflows/devcontainer_feature_release.yaml
@@ -1,0 +1,24 @@
+name: "Release dev container features & Generate Documentation"
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    # if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: "Publish Features"
+        uses: devcontainers/action@v1
+        with:
+          publish-features: "true"
+          base-path-to-features: ".devcontainer/features/desktop-selkies"
+          generate-docs: "false"
+          
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/devcontainer_feature_validate.yaml
+++ b/.github/workflows/devcontainer_feature_validate.yaml
@@ -1,0 +1,16 @@
+name: "Validate devcontainer-feature.json files"
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: "Validate devcontainer-feature.json files"
+        uses: devcontainers/action@v1
+        with:
+          validate-only: "true"
+          base-path-to-features: ".devcontainer/features/desktop-selkies"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Attach using Process Id",
+            "type": "python",
+            "request": "attach",
+            "processId": "${command:pickProcess}",
+            "justMyCode": false
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,61 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "[build] build python package",
+            "type": "shell",
+            "command": "python3 -m build",
+            "problemMatcher": [],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            }
+        },
+        {
+            "label": "[install] re-install python package",
+            "type": "shell",
+            "command": " sudo python3 -m pip install --force-reinstall --upgrade ${workspaceFolder}/dist/selkies_gstreamer-0.0.1-py3-none-any.whl",
+            "problemMatcher": []
+        },
+        {
+            "label": "[run] Start selkies-gstreamer",
+            "type": "shell",
+            "command": "${workspaceFolder}/.devcontainer/features/desktop-selkies/src/start-selkies.sh",
+            "problemMatcher": [],
+            "options": {
+                "env": {
+                    "WEB_ROOT": "${workspaceFolder}/addons/gst-web/src"
+                }
+            }
+        },
+        {
+            "label": "[run] re-build, re-install and run selkies-gstreamer",
+            "problemMatcher": [],
+            "dependsOrder": "sequence",
+            "dependsOn": [
+                "[build] build python package",
+                "[install] re-install python package",
+                "[run] Start selkies-gstreamer"
+            ]
+        },
+        {
+            "label": "[workflow] local run devcontainer_feature_validate",
+            "type": "shell",
+            "command": "act -W .github/workflows/devcontainer_feature_validate.yaml workflow_dispatch",
+            "problemMatcher": []
+        },
+        {
+            "label": "[workflow] local run devcontainer_feature_test",
+            "type": "shell",
+            "command": "act -W .github/workflows/devcontainer_feature_test.yaml workflow_dispatch",
+            "problemMatcher": []
+        },
+        {
+            "label": "[workflow] local run devcontainer_feature_release",
+            "type": "shell",
+            "command": "act -W .github/workflows/devcontainer_feature_release.yaml workflow_dispatch",
+            "problemMatcher": []
+        }
+    ]
+}


### PR DESCRIPTION
Support VS Code Dev Containers.

- Create a selkies build and test environment in a dev container to quickly build and test.
- Configurations for Ubuntu Focal and Jammy, XFCE and Fluxbox desktop environments.
- Initial work in progress import of VS Code Dev Container feature to integrate selkies with any other dev container.