### PR TITLE
Handle bus_call messages.

### DIFF
--- a/src/selkies_gstreamer/__main__.py
+++ b/src/selkies_gstreamer/__main__.py
@@ -569,7 +569,7 @@ def main():
                     on_resize_handler(meta["res"])
                 if meta["scale"]:
                     on_scaling_ratio_handler(meta["scale"])
-        app.start_pipeline()
+        loop.run_in_executor(None, lambda: app.start_pipeline())
     signalling.on_session = on_session_handler
 
     # Initialize the Xinput instance


### PR DESCRIPTION
Fixes #89 

- Add bus_call handler to `start_pipeline` which calls `self.pipeline.recalculate_latency()` for `LATENCY` type Gst messages.

While the large stream of `rtpsession` messages with `GST_DEBUG:*2` and greater are gone, these messages appear once when the pipeline is first started. They don't seem to affect the pipeline and turning off `GST_DEBUG` makes them go away, just like the other messages.

```
0:00:14.825607089 25768 0x7f46980d3840 ERROR               GST_PADS gstpad.c:3434:gst_pad_query_latency_default:<rtpfunnel0:src> minimum latency bigger than maximum latency
0:00:14.825625584 25768 0x7f46980d3840 ERROR               GST_PADS gstpad.c:3434:gst_pad_query_latency_default:<send_rtp_sink_0:proxypad23> minimum latency bigger than maximum latency
0:00:14.825631635 25768 0x7f46980d3840 ERROR               GST_PADS gstpad.c:3434:gst_pad_query_latency_default:<sink_0:proxypad21> minimum latency bigger than maximum latency
0:00:14.825640932 25768 0x7f46980d3840 ERROR               GST_PADS gstpad.c:3434:gst_pad_query_latency_default:<rtprtxsend0:src> minimum latency bigger than maximum latency
0:00:14.825646383 25768 0x7f46980d3840 ERROR               GST_PADS gstpad.c:3434:gst_pad_query_latency_default:<bin0:src_0> minimum latency bigger than maximum latency
0:00:14.825651823 25768 0x7f46980d3840 ERROR               GST_PADS gstpad.c:3434:gst_pad_query_latency_default:<rtpsession0:send_rtp_src> minimum latency bigger than maximum latency
0:00:14.825657563 25768 0x7f46980d3840 ERROR               GST_PADS gstpad.c:3434:gst_pad_query_latency_default:<rtpbin:send_rtp_src_0> minimum latency bigger than maximum latency
0:00:14.825663484 25768 0x7f46980d3840 ERROR               GST_PADS gstpad.c:3434:gst_pad_query_latency_default:<rtp_sink:proxypad9> minimum latency bigger than maximum latency
0:00:14.825668504 25768 0x7f46980d3840 ERROR               GST_PADS gstpad.c:3434:gst_pad_query_latency_default:<rtp_sink_0:proxypad8> minimum latency bigger than maximum latency
0:00:14.825673383 25768 0x7f46980d3840 ERROR               GST_PADS gstpad.c:3434:gst_pad_query_latency_default:<srtpenc0:rtp_src_0> minimum latency bigger than maximum latency
0:00:14.825678733 25768 0x7f46980d3840 ERROR               GST_PADS gstpad.c:3434:gst_pad_query_latency_default:<clocksync_0:src> minimum latency bigger than maximum latency
0:00:14.825691336 25768 0x7f46980d3840 ERROR               GST_PADS gstpad.c:3434:gst_pad_query_latency_default:<funnel0:src> minimum latency bigger than maximum latency
0:00:14.825699351 25768 0x7f46980d3840 ERROR               GST_PADS gstpad.c:3434:gst_pad_query_latency_default:<dtlssrtpenc0:src> minimum latency bigger than maximum latency
```