### PR TITLE
Video and audio in separate webrtcbins

### DIFF
--- a/addons/gst-web/src/index.html
+++ b/addons/gst-web/src/index.html
@@ -274,7 +274,7 @@
               </p>
               <p>
                 <v-select :items="audioBitRateOptions" label="Audio bit rate" menu-props="left" v-model="audioBitRate"
-                  :disabled="!audioEnabled" hint="Dynamic bit rate selection for audio encoder on server"
+                  hint="streaming bit rate selection for audio encoder on server"
                   persistent-hint>
                 </v-select>
               </p>
@@ -311,8 +311,6 @@
               <v-textarea bottom class="scrolly" label="Debug Logs" readonly :value="debugEntries.join('\n\n')">
               </v-textarea>
               <p>
-                <v-btn color="primary" v-if="!audioEnabled" small v-on:click="audioEnabled=true">Enable Audio</v-btn>
-                <v-btn color="primary" v-else small v-on:click="audioEnabled=false">Disable Audio</v-btn>
                 <v-switch v-model="resizeRemote" :label="`Resize remote to fit window: ${resizeRemote.toString()}`"></v-switch>
                 <v-switch v-model="scaleLocal" :label="`Scale to fit window: ${scaleLocal.toString()}`"></v-switch>
               </p>
@@ -354,6 +352,12 @@
           </v-layout>
         </v-container>
       </v-navigation-drawer>
+
+      <div id="audio_container" class="audio-container">
+        <audio id="audio_stream" class="audio" preload="none" playsinline>
+          Your browser doesn't support audio
+        </audio>
+      </div>
 
       <div id="video_container" class="video-container">
         <video id="stream" class="video" preload="none" playsinline>

--- a/addons/gst-web/src/signalling.js
+++ b/addons/gst-web/src/signalling.js
@@ -43,11 +43,8 @@ class WebRTCDemoSignalling {
      *    The URL object of the signalling server to connect to, created with `new URL()`.
      *    Signalling implementation is here:
      *      https://github.com/GStreamer/gstreamer/tree/main/subprojects/gst-examples/webrtc/signalling
-     * @param {number} [peer_id]
-     *    The peer ID established during signalling that the sending peer (server) will connect to.
-     *    This can be anything, but must match what the server will attempt to connect to.
      */
-    constructor(server, peer_id) {
+    constructor(server) {
         /**
          * @private
          * @type {URL}
@@ -58,7 +55,7 @@ class WebRTCDemoSignalling {
          * @private
          * @type {number}
          */
-        this._peer_id = peer_id;
+        this.peer_id = 1;
 
         /**
          * @private
@@ -186,8 +183,8 @@ class WebRTCDemoSignalling {
             "scale": window.devicePixelRatio
         };
         this.state = 'connected';
-        this._ws_conn.send(`HELLO ${this._peer_id} ${btoa(JSON.stringify(meta))}`);
-        this._setStatus("Registering with server, peer ID: " + this._peer_id);
+        this._ws_conn.send(`HELLO ${this.peer_id} ${btoa(JSON.stringify(meta))}`);
+        this._setStatus("Registering with server, peer ID: " + this.peer_id);
         this.retry_count = 0;
     }
 

--- a/addons/gst-web/src/webrtc.js
+++ b/addons/gst-web/src/webrtc.js
@@ -49,7 +49,7 @@ class WebRTCDemo {
      * @param {Element} [element]
      *    video element to attach stream to.
      */
-    constructor(signalling, element) {
+    constructor(signalling, element, peer_id) {
         /**
          * @type {WebRTCDemoSignalling}
          */
@@ -59,6 +59,11 @@ class WebRTCDemo {
          * @type {Element}
          */
         this.element = element;
+
+        /**
+         * @type {Element}
+         */
+        this.peer_id = peer_id;
 
         /**
          * @type {boolean}
@@ -313,7 +318,7 @@ class WebRTCDemo {
         this._setStatus("Received incoming " + event.track.kind + " stream from peer");
         if (!this.streams) this.streams = [];
         this.streams.push([event.track.kind, event.streams]);
-        if (event.track.kind === "video") {
+        if (event.track.kind === "video" || event.track.kind === "audio") {
             this.element.srcObject = event.streams[0];
             this.playVideo();
         }
@@ -667,6 +672,8 @@ class WebRTCDemo {
             config.iceTransportPolicy = "relay";
             this.peerConnection.setConfiguration(config);
         }
+
+        this.signalling.peer_id = this.peer_id;
         this.signalling.connect();
     }
 

--- a/src/selkies_gstreamer/webrtc_input.py
+++ b/src/selkies_gstreamer/webrtc_input.py
@@ -117,8 +117,6 @@ class WebRTCInput:
             'unhandled on_clipboard_read')
         self.on_set_fps = lambda fps: logger.warn(
             'unhandled on_set_fps')
-        self.on_set_enable_audio = lambda enable_audio: logger.warn(
-            'unhandled on_set_enable_audio')
         self.on_set_enable_resize = lambda enable_resize, res: logger.warn(
             'unhandled on_set_enable_resize')
         self.on_client_fps = lambda fps: logger.warn(
@@ -665,11 +663,6 @@ class WebRTCInput:
             fps = int(toks[1])
             logger.info("Setting framerate to: %d" % fps)
             self.on_set_fps(fps)
-        elif toks[0] == "_arg_audio":
-            # Set audio enabled
-            enabled = toks[1].lower() == "true"
-            logger.info("Setting enable_audio to: %s" % str(enabled))
-            self.on_set_enable_audio(enabled)
         elif toks[0] == "_arg_resize":
             if len(toks) != 3:
                 logger.error("invalid _arg_resize command, expected 2 arguments <enabled>,<resolution>")

--- a/src/selkies_gstreamer/webrtc_signalling.py
+++ b/src/selkies_gstreamer/webrtc_signalling.py
@@ -76,7 +76,7 @@ class WebRTCSignalling:
         self.on_sdp = lambda sdp_type, sdp: logger.warn('unhandled sdp event')
         self.on_connect = lambda res, scale: logger.warn('unhandled on_connect callback')
         self.on_disconnect = lambda: logger.warn('unhandled on_disconnect callback')
-        self.on_session = lambda meta: logger.warn('unhandled on_session callback')
+        self.on_session = lambda peer_id, meta: logger.warn('unhandled on_session callback')
         self.on_error = lambda v: logger.warn(
             'unhandled on_error callback: %s', v)
 
@@ -175,7 +175,7 @@ class WebRTCSignalling:
                 if len(toks) > 1:
                     meta = json.loads(base64.b64decode(toks[1]))
                 logger.info("started session with peer: %s, meta: %s", self.peer_id, json.dumps(meta))
-                self.on_session(meta)
+                self.on_session(self.peer_id, (meta))
             elif message.startswith('ERROR'):
                 if message == "ERROR peer '%s' not found" % self.peer_id:
                     await self.on_error(WebRTCSignallingErrorNoPeer("'%s' not found" % self.peer_id))


### PR DESCRIPTION
Fixes #7 

- Reduces latency when streaming with audio enabled.
- AV sync is within reason.
- Client connects separate RTCPeerConnections for audio and video.
- Connections use the same config and STUN/TURN servers.
- Backend signal clients and pipelines are also duplicated.
- Removed option to disable audio from client and cli args.


## Testing

You can test it with the example docker container like this:

Ubuntu 22.04
```
docker run --pull=always --name selkies -it --rm -p 8080:8080 -p 3478:3478 ghcr.io/selkies-project/selkies-gstreamer/gst-py-example:testing-ubuntu22.04
```

For Ubuntu 20.04:
```
docker run --pull=always --name selkies -it --rm -p 8080:8080 -p 3478:3478 ghcr.io/selkies-project/selkies-gstreamer/gst-py-example:testing-ubuntu20.04
```