### PR TITLE
exit if either of the two values doesn't exist or empty

### DIFF
--- a/src/selkies_gstreamer/__main__.py
+++ b/src/selkies_gstreamer/__main__.py
@@ -530,7 +530,7 @@ def main():
             data = generate_rtc_config(args.turn_host, args.turn_port, args.turn_shared_secret, args.coturn_web_username, turn_protocol, using_turn_tls)
             stun_servers, turn_servers, rtc_config = parse_rtc_config(data)
         elif args.turn_username and args.turn_password:
-            if not args.turn_host and args.turn_port:
+            if not (args.turn_host and args.turn_port):
                 logger.error("missing turn host and turn port")
                 sys.exit(1)
             logger.warning("using legacy non-HMAC TURN credentials.")


### PR DESCRIPTION
A small fix at the if condition. As we need both values, turn_host and turn_port, we want the negation (not) to be applied to entire expression rather than just for the first variable followed by 'not' keyword.