### PR TITLE
fix the split method

### DIFF
--- a/src/selkies_gstreamer/webrtc_signalling.py
+++ b/src/selkies_gstreamer/webrtc_signalling.py
@@ -170,7 +170,7 @@ class WebRTCSignalling:
                 logger.info("connected")
                 await self.on_connect()
             elif message.startswith('SESSION_OK'):
-                toks = message.split(" ")
+                toks = message.split()
                 meta = {}
                 if len(toks) > 1:
                     meta = json.loads(base64.b64decode(toks[1]))


### PR DESCRIPTION
A small fix at the split method. If the variable [meta](https://github.com/selkies-project/selkies-gstreamer/blob/main/src/selkies_gstreamer/signalling_web.py#L356) is None then splitting the [message](https://github.com/selkies-project/selkies-gstreamer/blob/main/src/selkies_gstreamer/webrtc_signalling.py#L173) with `split(" ")` would return a list of length two with second variable as empty string `""`, thus raising the json decode error.

<img width="759" alt="Screenshot 2023-10-04 at 3 52 41 PM" src="https://github.com/selkies-project/selkies-gstreamer/assets/57227290/f6306535-8746-459d-b353-30fb9dca5bb6">

I've tested this change by creating a python build and now the error is gone.
