### PR TITLE
Use version 0.31 of python-xlib to fix regression

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     watchdog
     Pillow
     python-uinput @ git+https://github.com/selkies-project/python-uinput.git@0.11.3
-    python-xlib
+    python-xlib==0.31
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Hello, congrats on the project! I've been testing Selkies and I'm impressed how well it works. VNC is slow for remote desktops, and this actually demonstrates that it's possible to have a low-latency remote desktop experience using WebRTC :)

As a Spanish user, I've been troubled with some keyboard layout errors, which significantly impacts my experience. Basically, if you press a non english character, the selkies-gstreamer server crash with an exception. This issue appearead multiple times as I can see:

- [Issue 84](https://github.com/selkies-project/selkies-gstreamer/issues/84)
- [Issue 9](https://github.com/selkies-project/selkies-gstreamer/issues/9)

Initially, I suspected that the problem might be due to guacamole keyboard library being outdated, as discussed in these threads:

- [Issue 9 Comment](https://github.com/selkies-project/selkies-gstreamer/issues/9#issuecomment-1705831611)
- [Issue 108](https://github.com/selkies-project/selkies-gstreamer/issues/108)
- [Issue 84 Comment](https://github.com/selkies-project/selkies-gstreamer/issues/84#issuecomment-1705831509)

However, even after updating the guacamole keyboard library, the issue persisted. Further research led me to discover a regression in the xlib python library, specifically since version 0.32:

- [Python-xlib Issue 241](https://github.com/python-xlib/python-xlib/issues/241)
- [Python-xlib Pull Request 242](https://github.com/python-xlib/python-xlib/pull/242)
- [Python-xlib Issue 259](https://github.com/python-xlib/python-xlib/issues/259)

If you execute a `pip list` command, the installed python-xlib version is 0.33. Fortunately, reverting the xlib version to 0.31 resolves the issue, and the server does not crash when a non english character is sent. What I did is basically pin the version 0.31 in the `setup.cfg` config, which could temporarily solve the issue until a new version of python-xlib is released. 

There is a pending pull request ([PR 242](https://github.com/python-xlib/python-xlib/pull/242)) that aims to address this problem in the xlib library, but it looks like the development is paused.
