### PR TITLE
Fix the return of odd numbered pixels

### DIFF
--- a/addons/gst-web/src/input.js
+++ b/addons/gst-web/src/input.js
@@ -535,8 +535,8 @@ class Input {
 
     getWindowResolution() {
         return [
-            parseInt((document.body.offsetWidth - document.body.offsetWidth%2) * window.devicePixelRatio),
-            parseInt((document.body.offsetHeight - document.body.offsetHeight%2) * window.devicePixelRatio)
+            parseInt( (() => {var width = document.body.offsetWidth * window.devicePixelRatio; return width - width % 2})() ),
+            parseInt( (() => {var height = document.body.offsetHeight * window.devicePixelRatio; return height - height % 2})() )
         ];
     }
 }

--- a/addons/gst-web/src/input.js
+++ b/addons/gst-web/src/input.js
@@ -535,8 +535,8 @@ class Input {
 
     getWindowResolution() {
         return [
-            parseInt( (() => {var width = document.body.offsetWidth * window.devicePixelRatio; return width - width % 2})() ),
-            parseInt( (() => {var height = document.body.offsetHeight * window.devicePixelRatio; return height - height % 2})() )
+            parseInt( (() => {var offsetRatioWidth = document.body.offsetWidth * window.devicePixelRatio; return offsetRatioWidth - offsetRatioWidth % 2})() ),
+            parseInt( (() => {var offsetRatioHeight = document.body.offsetHeight * window.devicePixelRatio; return offsetRatioHeight - offsetRatioHeight % 2})() )
         ];
     }
 }


### PR DESCRIPTION
The point of subtracting a dimension%2 from its actual dimension is to avoid odd numbered pixels, so due to variation of DPR from device to device the subtraction should be done at the end of pixel calculation.

Fixes #124 