### PR TITLE
Update docker commands to utilize coturn properly

### DIFF
--- a/Dockerfile.example
+++ b/Dockerfile.example
@@ -210,7 +210,7 @@ sudo /usr/bin/pulseaudio --daemonize --system --verbose --log-target=file:/tmp/p
 sudo /start-turnserver.sh &\n\
 export WEBRTC_ENCODER=\${WEBRTC_ENCODER:-x264enc}\n\
 export WEBRTC_ENABLE_RESIZE=\${WEBRTC_ENABLE_RESIZE:-true}\n\
-export TURN_HOST=\${TURN_HOST:-localhost}\n\
+export TURN_HOST=\${TURN_HOST:-$(curl checkip.amazonaws.com)}\n\
 export TURN_PORT=\${TURN_PORT:-3478}\n\
 export TURN_USERNAME=\${TURN_USERNAME:-selkies}\n\
 export TURN_PASSWORD=\${TURN_PASSWORD:-selkies}\n\

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ Run the Docker container built from the [`Dockerfile.example`](./Dockerfile.exam
 ```bash
 docker run --pull=always --name selkies -it --rm -p 8080:8080 -p 3478:3478 ghcr.io/selkies-project/selkies-gstreamer/gst-py-example:main-ubuntu${UBUNTU_RELEASE}
 ```
-> **_Note_**: If you've created the above container in a VPN enabled VM and webrtc connection fails, then you may need to add an environment variable `TURN_HOST` to the above command set with **private IP** of that VM. For example: `-e TURN_HOST=192.168.0.105` 
 
 Repositories [`selkies-vdi`](https://github.com/selkies-project/selkies-vdi) or [`selkies-examples`](https://github.com/selkies-project/selkies-examples) from the [Selkies Project](https://github.com/selkies-project) provide containerized virtual desktop infrastructure (VDI) templates.
 
@@ -397,7 +396,7 @@ However, it might be that the parameters for the WebRTC interface, video encoder
 
 ### The HTML5 web interface loads and the signalling connection works, but the WebRTC connection fails and the remote desktop does not start.
 
-Please read [Using a TURN server](#using-a-turn-server). Make sure to also check that you enabled automatic login with your display manager, as the remote desktop cannot access the initial login screen after boot without login.
+Please read [Using a TURN server](#using-a-turn-server). Make sure to also check that you enabled automatic login with your display manager, as the remote desktop cannot access the initial login screen after boot without login. If you created the TURN server or the example container inside a VPN-enabled environment or virtual machine and the WebRTC connection fails, then you may need to add the `TURN_HOST` environment variable to the VPN private IP of the TURN server host, such as `192.168.0.105`.
 
 ### I want to pass multiple screens within a server to another client using the WebRTC HTML5 web interface.
 

--- a/README.md
+++ b/README.md
@@ -327,13 +327,13 @@ In order to deploy a coTURN container, use the following command (consult this [
 For time-limited shared secret TURN authentication:
 
 ```
-docker run -d -p 3478:3478 -p 3478:3478/udp -p 49160-49200:49160-49200/udp coturn/coturn -n --min-port=49160 --max-port=49200 --use-auth-secret --static-auth-secret=(PUT RANDOM 64 BYTE BASE64 KEY HERE) --realm=example.com
+docker run -d -p 3478:3478 -p 3478:3478/udp -p 49160-49200:49160-49200/udp coturn/coturn -n --realm=example.com --min-port=49160 --max-port=49200 --use-auth-secret --static-auth-secret=(PUT RANDOM 64 BYTE BASE64 KEY HERE)
 ```
 
 For legacy long-term TURN authentication:
 
 ```
-docker run -d -p 3478:3478 -p 3478:3478/udp -p 49160-49200:49160-49200/udp coturn/coturn -n --min-port=49160 --max-port=49200 --lt-cred-mech --user=yourusername:yourpassword --realm=example.com
+docker run -d -p 3478:3478 -p 3478:3478/udp -p 49160-49200:49160-49200/udp coturn/coturn -n --realm=example.com --min-port=49160 --max-port=49200 --lt-cred-mech --user=yourusername:yourpassword
 ```
 
 If you want to use TURN over TLS/DTLS, you must have a valid hostname, and also provision a valid certificate issued from a legitimate certificate authority such as [ZeroSSL](https://zerossl.com/features/acme/) (Let's Encrypt may have issues depending on the OS), and provide the certificate and private files to the coTURN container with `-v /mylocalpath/coturncert.pem:/etc/coturncert.pem -v /mylocalpath/coturnkey.pem:/etc/coturnkey.pem`, then add the command-line arguments `-n --cert=/etc/coturncert.pem --pkey=/etc/coturnkey.pem` (the specified paths are an example).

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ Example Google Compute Engine/Google Kubernetes Engine deployment configurations
 
 An example image [`ghcr.io/selkies-project/selkies-gstreamer/gst-py-example`](https://github.com/selkies-project/selkies-gstreamer/pkgs/container/selkies-gstreamer%2Fgst-py-example) from the base [example Dockerfile](./Dockerfile.example) is available.
 
-Run the Docker container built from the [`Dockerfile.example`](./Dockerfile.example), then connect to port **8080** of your Docker host to access the web interface (**change `UBUNTU_RELEASE` to `20.04` or `22.04`, then replace `main` to `latest` for the release build instead of the development build**):
+Run the Docker container built from the [`Dockerfile.example`](./Dockerfile.example), then connect to port **8080** of your Docker host to access the web interface (**change `UBUNTU_RELEASE` to `20.04` or `22.04` and `HOST_ADDRESS` to the IP or domain of the machine where the container is running, then replace `main` to `latest` for the release build instead of the development build**):
 
 ```bash
-docker run --pull=always --name selkies -it --rm -p 8080:8080 -p 3478:3478 ghcr.io/selkies-project/selkies-gstreamer/gst-py-example:main-ubuntu${UBUNTU_RELEASE}
+docker run --pull=always --name selkies -it --rm -p 8080:8080 -p 3478:3478 -e TURN_HOST=${HOST_ADDRESS} ghcr.io/selkies-project/selkies-gstreamer/gst-py-example:main-ubuntu${UBUNTU_RELEASE}
 ```
 
 Repositories [`selkies-vdi`](https://github.com/selkies-project/selkies-vdi) or [`selkies-examples`](https://github.com/selkies-project/selkies-examples) from the [Selkies Project](https://github.com/selkies-project) provide containerized virtual desktop infrastructure (VDI) templates.

--- a/README.md
+++ b/README.md
@@ -38,11 +38,12 @@ Example Google Compute Engine/Google Kubernetes Engine deployment configurations
 
 An example image [`ghcr.io/selkies-project/selkies-gstreamer/gst-py-example`](https://github.com/selkies-project/selkies-gstreamer/pkgs/container/selkies-gstreamer%2Fgst-py-example) from the base [example Dockerfile](./Dockerfile.example) is available.
 
-Run the Docker container built from the [`Dockerfile.example`](./Dockerfile.example), then connect to port **8080** of your Docker host to access the web interface (**change `UBUNTU_RELEASE` to `20.04` or `22.04` and `HOST_ADDRESS` to the IP or domain of the machine where the container is running, then replace `main` to `latest` for the release build instead of the development build**):
+Run the Docker container built from the [`Dockerfile.example`](./Dockerfile.example), then connect to port **8080** of your Docker host to access the web interface (**change `UBUNTU_RELEASE` to `20.04` or `22.04`, then replace `main` to `latest` for the release build instead of the development build**):
 
 ```bash
-docker run --pull=always --name selkies -it --rm -p 8080:8080 -p 3478:3478 -e TURN_HOST=${HOST_ADDRESS} ghcr.io/selkies-project/selkies-gstreamer/gst-py-example:main-ubuntu${UBUNTU_RELEASE}
+docker run --pull=always --name selkies -it --rm -p 8080:8080 -p 3478:3478 ghcr.io/selkies-project/selkies-gstreamer/gst-py-example:main-ubuntu${UBUNTU_RELEASE}
 ```
+> **_Note_**: If you've created the above container in a VPN enabled VM and webrtc connection fails, then you may need to add an environment variable `TURN_HOST` to the above command set with **private IP** of that VM. For example: `-e TURN_HOST=192.168.0.105` 
 
 Repositories [`selkies-vdi`](https://github.com/selkies-project/selkies-vdi) or [`selkies-examples`](https://github.com/selkies-project/selkies-examples) from the [Selkies Project](https://github.com/selkies-project) provide containerized virtual desktop infrastructure (VDI) templates.
 

--- a/README.md
+++ b/README.md
@@ -327,13 +327,13 @@ In order to deploy a coTURN container, use the following command (consult this [
 For time-limited shared secret TURN authentication:
 
 ```
-docker run -d -p 3478:3478 -p 3478:3478/udp -p 49160-49200:49160-49200/udp coturn/coturn -n --min-port=49160 --max-port=49200 --use-auth-secret --static-auth-secret=(PUT RANDOM 64 BYTE BASE64 KEY HERE)
+docker run -d -p 3478:3478 -p 3478:3478/udp -p 49160-49200:49160-49200/udp coturn/coturn -n --min-port=49160 --max-port=49200 --use-auth-secret --static-auth-secret=(PUT RANDOM 64 BYTE BASE64 KEY HERE) --realm=example.com
 ```
 
 For legacy long-term TURN authentication:
 
 ```
-docker run -d -p 3478:3478 -p 3478:3478/udp -p 49160-49200:49160-49200/udp coturn/coturn -n --min-port=49160 --max-port=49200 --lt-cred-mech --user=yourusername:yourpassword
+docker run -d -p 3478:3478 -p 3478:3478/udp -p 49160-49200:49160-49200/udp coturn/coturn -n --min-port=49160 --max-port=49200 --lt-cred-mech --user=yourusername:yourpassword --realm=example.com
 ```
 
 If you want to use TURN over TLS/DTLS, you must have a valid hostname, and also provision a valid certificate issued from a legitimate certificate authority such as [ZeroSSL](https://zerossl.com/features/acme/) (Let's Encrypt may have issues depending on the OS), and provide the certificate and private files to the coTURN container with `-v /mylocalpath/coturncert.pem:/etc/coturncert.pem -v /mylocalpath/coturnkey.pem:/etc/coturnkey.pem`, then add the command-line arguments `-n --cert=/etc/coturncert.pem --pkey=/etc/coturnkey.pem` (the specified paths are an example).


### PR DESCRIPTION
As the coturn is included in the desktop itself, when deploying the container in a VM rather than local env, the `TURN_HOST` variable is supposed to set to the host address of the machine, else the default value `localhost` is applied which in these scenarios fails the webrtc connection.

Also when setting up the coturn server with the provided docker command it requires the realm flag/argument to set for the TURN capability to work https://github.com/coturn/coturn/blob/master/docker/coturn/turnserver.conf#L352.  

This can be verified by doing an [ICETEST](https://icetest.info/). 

```bash 
docker run -d -p 3478:3478 -p 3478:3478/udp -p 49160-49200:49160-49200/udp coturn/coturn -n --min-port=49160 --max-port=49200 --lt-cred-mech --user=yourusername:yourpassword
```

```bash
docker run -d -p 3478:3478 -p 3478:3478/udp -p 49160-49200:49160-49200/udp coturn/coturn -n --min-port=49160 --max-port=49200 --lt-cred-mech --user=yourusername:yourpassword --realm=example.com
```

Run the both containers and test them for ICE candidates at the given site and check for the `relay` candidates. The coturn without the realm flag doesn't return `relay` ICE candidate.