### PR TITLE
Fix small typo

### DIFF
--- a/src/selkies_gstreamer/__main__.py
+++ b/src/selkies_gstreamer/__main__.py
@@ -159,8 +159,8 @@ def make_turn_rtc_config_json(host, port, username, password, protocol='udp', tl
   "iceServers": [
     {
       "urls": [
-        "stun:%s:%s"
-        "stun:stun.l.google.com:19302",
+        "stun:%s:%s",
+        "stun:stun.l.google.com:19302"
       ]
     },
     {


### PR DESCRIPTION
There's a small typo at the generation of JSON of RTC config