### PR TITLE
Logging webrtc statistics on host received over datachannel

### DIFF
--- a/addons/gst-web/src/app.js
+++ b/addons/gst-web/src/app.js
@@ -474,8 +474,11 @@ function onBothStreamConnected() {
 
                 statsStart = now;
 
-                var jsonString = JSON.stringify(stats.allReports);
-                webrtc.sendDataChannelMessage("_stats," + jsonString)
+                var videoStatsString = JSON.stringify(stats.allReports);
+                var audioStatsString = JSON.stringify(audioStats.allReports);
+
+                webrtc.sendDataChannelMessage("_stats_video," + videoStatsString);
+                webrtc.sendDataChannelMessage("_stats_audio," + audioStatsString);
 
                 // Stats refresh loop.
                 setTimeout(statsLoop, 1000);

--- a/addons/gst-web/src/app.js
+++ b/addons/gst-web/src/app.js
@@ -474,6 +474,9 @@ function onBothStreamConnected() {
 
                 statsStart = now;
 
+                var jsonString = JSON.stringify(stats.allReports);
+                webrtc.sendDataChannelMessage("_stats," + jsonString)
+
                 // Stats refresh loop.
                 setTimeout(statsLoop, 1000);
             });

--- a/addons/gst-web/src/app.js
+++ b/addons/gst-web/src/app.js
@@ -474,11 +474,8 @@ function onBothStreamConnected() {
 
                 statsStart = now;
 
-                var videoStatsString = JSON.stringify(stats.allReports);
-                var audioStatsString = JSON.stringify(audioStats.allReports);
-
-                webrtc.sendDataChannelMessage("_stats_video," + videoStatsString);
-                webrtc.sendDataChannelMessage("_stats_audio," + audioStatsString);
+                webrtc.sendDataChannelMessage("_stats_video," + JSON.stringify(stats.allReports));
+                webrtc.sendDataChannelMessage("_stats_audio," + JSON.stringify(audioStats.allReports));
 
                 // Stats refresh loop.
                 setTimeout(statsLoop, 1000);

--- a/src/selkies_gstreamer/__main__.py
+++ b/src/selkies_gstreamer/__main__.py
@@ -570,8 +570,8 @@ def main():
     enable_cursors = args.enable_cursors.lower() == "true"
     cursor_debug = args.debug_cursors.lower() == "true"
     cursor_size = int(args.cursor_size)
-    keyframe_distance = int(args.keyframe_distance)
-    packetloss_percent = int(args.packetloss_percent)
+    keyframe_distance = float(args.keyframe_distance)
+    packetloss_percent = float(args.packetloss_percent)
 
     # Create instance of app
     app = GSTWebRTCApp(stun_servers, turn_servers, audio_channels, curr_fps, args.encoder, curr_video_bitrate, curr_audio_bitrate, keyframe_distance, packetloss_percent)

--- a/src/selkies_gstreamer/__main__.py
+++ b/src/selkies_gstreamer/__main__.py
@@ -820,6 +820,7 @@ def main():
         loop.run_in_executor(None, lambda: system_mon.start())
 
         while True:
+            webrtc_input.initialize_webrtc_stats_files()
             asyncio.ensure_future(app.handle_bus_calls(), loop=loop)
             asyncio.ensure_future(audio_app.handle_bus_calls(), loop=loop)
 

--- a/src/selkies_gstreamer/__main__.py
+++ b/src/selkies_gstreamer/__main__.py
@@ -423,11 +423,11 @@ def main():
     parser.add_argument('--cursor_size',
                         default=os.environ.get('SELKIES_CURSOR_SIZE', os.environ.get('XCURSOR_SIZE', '-1')),
                         help='Cursor size in points for the local cursor, set instead XCURSOR_SIZE without of this argument to configure the cursor size for both the local and remote cursors')
-    parser.add_argument('--enable_webrtc_csv',
-                        default=os.environ.get('SELKIES_ENABLE_WEBRTC_CSV, 'false'),
+    parser.add_argument('--enable_webrtc_statistics',
+                        default=os.environ.get('SELKIES_ENABLE_WEBRTC_STATISTICS', 'false'),
                         help='Enable WebRTC Statistics CSV dumping to the directory --webrtc_statistics_dir with filenames selkies-stats-video-[timestamp].csv and selkies-stats-audio-[timestamp].csv')
-    parser.add_argument('--webrtc_csv_dir',
-                        default=os.environ.get('SELKIES_WEBRTC_CSV_DIR, '/tmp'),
+    parser.add_argument('--webrtc_statistics_dir',
+                        default=os.environ.get('SELKIES_WEBRTC_STATISTICS_DIR', '/tmp'),
                         help='Directory to save WebRTC Statistics CSV from client with filenames selkies-stats-video-[timestamp].csv and selkies-stats-audio-[timestamp].csv')
     parser.add_argument('--enable_metrics_http',
                         default=os.environ.get('SELKIES_ENABLE_METRICS_HTTP', 'false'),
@@ -477,7 +477,7 @@ def main():
 
     # Initialize metrics server.
     using_metrics_http = args.enable_metrics_http.lower() == 'true'
-    using_webrtc_csv = args.enable_webrtc_csv.lower() == 'true'
+    using_webrtc_csv = args.enable_webrtc_statistics.lower() == 'true'
     metrics = Metrics(int(args.metrics_http_port), using_webrtc_csv)
 
     # Initialize the signalling client
@@ -839,7 +839,7 @@ def main():
 
         while True:
             if using_webrtc_csv:
-                metrics.initialize_webrtc_csv_file(args.webrtc_csv_dir)
+                metrics.initialize_webrtc_csv_file(args.webrtc_statistics_dir)
             asyncio.ensure_future(app.handle_bus_calls(), loop=loop)
             asyncio.ensure_future(audio_app.handle_bus_calls(), loop=loop)
 

--- a/src/selkies_gstreamer/__main__.py
+++ b/src/selkies_gstreamer/__main__.py
@@ -400,7 +400,7 @@ def main():
                         default=os.environ.get('SELKIES_KEYFRAME_DISTANCE', '3'),
                         help='Distance between video GOP frames/Keyframes in seconds, use "-1" for infinite distance')
     parser.add_argument('--packetloss_percent',
-                        default=os.environ.get('SELKIES_PACKETLOSS_PERCENT, '5'),
+                        default=os.environ.get('SELKIES_PACKETLOSS_PERCENT', '5'),
                         help='Expected packet loss percentage (%) for ULP/RED Forward Error Correction (FEC) in video and audio, use "0" to disable FEC')
     parser.add_argument('--audio_bitrate',
                         default=os.environ.get('SELKIES_AUDIO_BITRATE', '48000'),

--- a/src/selkies_gstreamer/gstwebrtc_app.py
+++ b/src/selkies_gstreamer/gstwebrtc_app.py
@@ -782,6 +782,7 @@ class GSTWebRTCApp:
         opusenc.set_property("audio-type", "restricted-lowdelay")
         opusenc.set_property("bandwidth", "fullband")
         opusenc.set_property("bitrate-type", "cbr")
+        opusenc.set_property("dtx", True)
         # Browser-side SDP munging for minptime=3 in Chrome is required for effect
         opusenc.set_property("frame-size", "2.5")
         opusenc.set_property("inband-fec", self.packetloss_percent > 0)
@@ -797,25 +798,26 @@ class GSTWebRTCApp:
         # RTP packets that are sent over the connection transport.
         rtpopuspay = Gst.ElementFactory.make("rtpopuspay")
         rtpopuspay.set_property("mtu", 1200)
+        rtpopuspay.set_property("dtx", True)
 
         # Insert a queue for the RTP packets.
-        rtpopuspay_queue = Gst.ElementFactory.make("queue", "rtpopuspay_queue")
+        # rtpopuspay_queue = Gst.ElementFactory.make("queue", "rtpopuspay_queue")
 
         # Make the queue leaky in the downstream direction, drop packets if the queue is behind.
-        rtpopuspay_queue.set_property("leaky", "downstream")
+        # rtpopuspay_queue.set_property("leaky", "downstream")
 
         # Discard all data in the queue when an EOS event is received
-        rtpopuspay_queue.set_property("flush-on-eos", True)
+        # rtpopuspay_queue.set_property("flush-on-eos", True)
 
         # Set the queue max time to 16ms (16000000ns)
         # If the pipeline is behind by more than 1s, the packets
         # will be dropped.
         # This helps buffer out latency in the audio source.
-        rtpopuspay_queue.set_property("max-size-time", 16000000)
+        # rtpopuspay_queue.set_property("max-size-time", 16000000)
 
         # Set the other queue sizes to 0 to make it only time-based.
-        rtpopuspay_queue.set_property("max-size-buffers", 0)
-        rtpopuspay_queue.set_property("max-size-bytes", 0)
+        # rtpopuspay_queue.set_property("max-size-buffers", 0)
+        # rtpopuspay_queue.set_property("max-size-bytes", 0)
 
         # Set the capabilities for the rtpopuspay element.
         rtpopuspay_caps = Gst.caps_from_string("application/x-rtp")
@@ -838,7 +840,7 @@ class GSTWebRTCApp:
         rtpopuspay_capsfilter.set_property("caps", rtpopuspay_caps)
 
         # Add all elements to the pipeline.
-        pipeline_elements = [pulsesrc, pulsesrc_capsfilter, opusenc, rtpopuspay, rtpopuspay_queue, rtpopuspay_capsfilter]
+        pipeline_elements = [pulsesrc, pulsesrc_capsfilter, opusenc, rtpopuspay, rtpopuspay_capsfilter] # rtpopuspay_queue
 
         for pipeline_element in pipeline_elements:
             self.pipeline.add(pipeline_element)

--- a/src/selkies_gstreamer/gstwebrtc_app.py
+++ b/src/selkies_gstreamer/gstwebrtc_app.py
@@ -61,7 +61,7 @@ class GSTWebRTCAppError(Exception):
     pass
 
 class GSTWebRTCApp:
-    def __init__(self, stun_servers=None, turn_servers=None, audio_channels=2, framerate=30, encoder=None, video_bitrate=2000, audio_bitrate=64000, keyframe_distance=3, packetloss_percent=5):
+    def __init__(self, stun_servers=None, turn_servers=None, audio_channels=2, framerate=30, encoder=None, video_bitrate=2000, audio_bitrate=64000, keyframe_distance=3.0, packetloss_percent=5.0):
         """Initialize GStreamer WebRTC app.
 
         Initializes GObjects and checks for required plugins.
@@ -284,7 +284,7 @@ class GSTWebRTCApp:
             # A negative consequence when using infinite GOP size is that
             # when packets are lost, the decoder may never recover.
             # NVENC supports infinite GOP by setting this to -1.
-            nvh264enc.set_property("gop-size", int(self.framerate * self.keyframe_distance))
+            nvh264enc.set_property("gop-size", -1 if self.keyframe_distance == -1.0 else int(self.framerate * self.keyframe_distance))
 
             # Instructs encoder to handle Quality of Service (QOS) events from
             # the rest of the pipeline. Setting this to true increases
@@ -344,7 +344,7 @@ class GSTWebRTCApp:
             else:
                 nvh265enc.set_property("rc-mode", "cbr")
 
-            nvh265enc.set_property("gop-size", int(self.framerate * self.keyframe_distance))
+            nvh265enc.set_property("gop-size", -1 if self.keyframe_distance == -1.0 else int(self.framerate * self.keyframe_distance))
             nvh265enc.set_property("qos", True)
             nvh265enc.set_property("aud", True)
             nvh265enc.set_property("b-adapt", False)
@@ -382,7 +382,7 @@ class GSTWebRTCApp:
             vah264enc.set_property("aud", True)
             vah264enc.set_property("b-frames", 0)
             vah264enc.set_property("dct8x8", False)
-            vah264enc.set_property("key-int-max", int(self.framerate * self.keyframe_distance))
+            vah264enc.set_property("key-int-max", 0 if self.keyframe_distance == -1.0 else int(self.framerate * self.keyframe_distance))
             vah264enc.set_property("rate-control", "cbr")
             vah264enc.set_property("target-usage", 6)
             vah264enc.set_property("qos", True)
@@ -405,7 +405,7 @@ class GSTWebRTCApp:
                 self.encoder = "vah265lpenc"
             vah265enc.set_property("aud", True)
             vah265enc.set_property("b-frames", 0)
-            vah265enc.set_property("key-int-max", int(self.framerate * self.keyframe_distance))
+            vah265enc.set_property("key-int-max", 0 if self.keyframe_distance == -1.0 else int(self.framerate * self.keyframe_distance))
             vah265enc.set_property("rate-control", "cbr")
             vah265enc.set_property("target-usage", 6)
             vah265enc.set_property("qos", True)
@@ -426,7 +426,7 @@ class GSTWebRTCApp:
             if vavp9enc is None:
                 vavp9enc = Gst.ElementFactory.make("vavp9lpenc", "vaenc")
                 self.encoder = "vavp9lpenc"
-            vavp9enc.set_property("key-int-max", int(self.framerate * self.keyframe_distance))
+            vavp9enc.set_property("key-int-max", 0 if self.keyframe_distance == -1.0 else int(self.framerate * self.keyframe_distance))
             vavp9enc.set_property("rate-control", "cbr")
             vavp9enc.set_property("target-usage", 6)
             vavp9enc.set_property("qos", True)
@@ -447,7 +447,7 @@ class GSTWebRTCApp:
             if vaav1enc is None:
                 vaav1enc = Gst.ElementFactory.make("vaav1lpenc", "vaenc")
                 self.encoder = "vaav1lpenc"
-            vaav1enc.set_property("key-int-max", int(self.framerate * self.keyframe_distance))
+            vaav1enc.set_property("key-int-max", 0 if self.keyframe_distance == -1.0 else int(self.framerate * self.keyframe_distance))
             vaav1enc.set_property("rate-control", "cbr")
             vaav1enc.set_property("target-usage", 6)
             vaav1enc.set_property("qos", True)
@@ -470,7 +470,7 @@ class GSTWebRTCApp:
             x264enc.set_property("b-adapt", False)
             x264enc.set_property("bframes", 0)
             x264enc.set_property("insert-vui", True)
-            x264enc.set_property("key-int-max", int(self.framerate * self.keyframe_distance))
+            x264enc.set_property("key-int-max", 2147483647 if self.keyframe_distance == -1.0 else int(self.framerate * self.keyframe_distance))
             x264enc.set_property("rc-lookahead", 0)
             x264enc.set_property("vbv-buf-capacity", 120)
             x264enc.set_property("sliced-threads", True)
@@ -498,7 +498,7 @@ class GSTWebRTCApp:
             openh264enc.set_property("scene-change-detection", False)
             openh264enc.set_property("usage-type", "screen")
             openh264enc.set_property("complexity", "low")
-            openh264enc.set_property("gop-size", int(self.framerate * self.keyframe_distance))
+            openh264enc.set_property("gop-size", 2147483647 if self.keyframe_distance == -1.0 else int(self.framerate * self.keyframe_distance))
             # TODO: Chromium cannot decode more than 4 slices, fix when it changes
             openh264enc.set_property("multi-thread", min(4, max(1, len(os.sched_getaffinity(0)) - 1)))
             openh264enc.set_property("slice-mode", "n-slices")
@@ -518,7 +518,7 @@ class GSTWebRTCApp:
             # encoder
             x265enc = Gst.ElementFactory.make("x265enc", "x265enc")
             x265enc.set_property("option-string", "b-adapt=0:bframes=0:rc-lookahead=0:aud:repeat-headers:pmode:wpp")
-            x265enc.set_property("key-int-max", int(self.framerate * self.keyframe_distance))
+            x265enc.set_property("key-int-max", 2147483647 if self.keyframe_distance == -1.0 else int(self.framerate * self.keyframe_distance))
             x265enc.set_property("qos", True)
             x265enc.set_property("speed-preset", "ultrafast")
             x265enc.set_property("tune", "zerolatency")
@@ -551,7 +551,7 @@ class GSTWebRTCApp:
             vpenc.set_property("end-usage", "cbr")
             vpenc.set_property("error-resilient", "default")
             vpenc.set_property("keyframe-mode", "disabled")
-            vpenc.set_property("keyframe-max-dist", int(self.framerate * self.keyframe_distance))
+            vpenc.set_property("keyframe-max-dist", 2147483647 if self.keyframe_distance == -1.0 else int(self.framerate * self.keyframe_distance))
             vpenc.set_property("lag-in-frames", 0)
             vpenc.set_property("qos", True)
             vpenc.set_property("target-bitrate", self.fec_video_bitrate * 1000)
@@ -566,7 +566,7 @@ class GSTWebRTCApp:
 
             rav1enc = Gst.ElementFactory.make("rav1enc", "rav1enc")
             rav1enc.set_property("low-latency", True)
-            rav1enc.set_property("max-key-frame-interval", int(self.framerate * self.keyframe_distance))
+            rav1enc.set_property("max-key-frame-interval", 715827882 if self.keyframe_distance == -1.0 else int(self.framerate * self.keyframe_distance))
             rav1enc.set_property("rdo-lookahead-frames", 0)
             rav1enc.set_property("speed-preset", 10)
             rav1enc.set_property("tiles", 16)
@@ -954,29 +954,30 @@ class GSTWebRTCApp:
         logger.info("framerate set to: %d" % framerate)
 
         # ADD_ENCODER: GOP/IDR Keyframe distance to keep the stream from freezing (in keyframe_dist seconds)
-        if self.encoder.startswith("nv"):
-            element = Gst.Bin.get_by_name(self.pipeline, "nvenc")
-            element.set_property("gop-size", int(self.framerate * self.keyframe_distance))
-        elif self.encoder.startswith("va"):
-            element = Gst.Bin.get_by_name(self.pipeline, "vaenc")
-            element.set_property("key-int-max", int(self.framerate * self.keyframe_distance))
-        elif self.encoder in ["x264enc"]:
-            element = Gst.Bin.get_by_name(self.pipeline, "x264enc")
-            element.set_property("key-int-max", int(self.framerate * self.keyframe_distance))
-        elif self.encoder in ["openh264enc"]:
-            element = Gst.Bin.get_by_name(self.pipeline, "openh264enc")
-            element.set_property("gop-size", int(self.framerate * self.keyframe_distance))
-        elif self.encoder in ["x265enc"]:
-            element = Gst.Bin.get_by_name(self.pipeline, "x265enc")
-            element.set_property("key-int-max", int(self.framerate * self.keyframe_distance))
-        elif self.encoder.startswith("vp"):
-            element = Gst.Bin.get_by_name(self.pipeline, "vpenc")
-            element.set_property("keyframe-max-dist", int(self.framerate * self.keyframe_distance))
-        elif self.encoder in ["rav1enc"]:
-            element = Gst.Bin.get_by_name(self.pipeline, "rav1enc")
-            element.set_property("max-key-frame-interval", int(self.framerate * self.keyframe_distance))
-        else:
-            logger.warning("setting keyframe interval (GOP size) not supported with encoder: %s" % self.encoder)
+        if self.keyframe_distance != -1.0:
+            if self.encoder.startswith("nv"):
+                element = Gst.Bin.get_by_name(self.pipeline, "nvenc")
+                element.set_property("gop-size", -1 if self.keyframe_distance == -1.0 else int(self.framerate * self.keyframe_distance))
+            elif self.encoder.startswith("va"):
+                element = Gst.Bin.get_by_name(self.pipeline, "vaenc")
+                element.set_property("key-int-max", 0 if self.keyframe_distance == -1.0 else int(self.framerate * self.keyframe_distance))
+            elif self.encoder in ["x264enc"]:
+                element = Gst.Bin.get_by_name(self.pipeline, "x264enc")
+                element.set_property("key-int-max", 2147483647 if self.keyframe_distance == -1.0 else int(self.framerate * self.keyframe_distance))
+            elif self.encoder in ["openh264enc"]:
+                element = Gst.Bin.get_by_name(self.pipeline, "openh264enc")
+                element.set_property("gop-size", 2147483647 if self.keyframe_distance == -1.0 else int(self.framerate * self.keyframe_distance))
+            elif self.encoder in ["x265enc"]:
+                element = Gst.Bin.get_by_name(self.pipeline, "x265enc")
+                element.set_property("key-int-max", 2147483647 if self.keyframe_distance == -1.0 else int(self.framerate * self.keyframe_distance))
+            elif self.encoder.startswith("vp"):
+                element = Gst.Bin.get_by_name(self.pipeline, "vpenc")
+                element.set_property("keyframe-max-dist", 2147483647 if self.keyframe_distance == -1.0 else int(self.framerate * self.keyframe_distance))
+            elif self.encoder in ["rav1enc"]:
+                element = Gst.Bin.get_by_name(self.pipeline, "rav1enc")
+                element.set_property("max-key-frame-interval", 715827882 if self.keyframe_distance == -1.0 else int(self.framerate * self.keyframe_distance))
+            else:
+                logger.warning("setting keyframe interval (GOP size) not supported with encoder: %s" % self.encoder)
 
     def set_video_bitrate(self, bitrate):
         """Set video encoder target bitrate in bps

--- a/src/selkies_gstreamer/gstwebrtc_app.py
+++ b/src/selkies_gstreamer/gstwebrtc_app.py
@@ -799,23 +799,23 @@ class GSTWebRTCApp:
         rtpopuspay.set_property("mtu", 1200)
 
         # Insert a queue for the RTP packets.
-        # rtpopuspay_queue = Gst.ElementFactory.make("queue", "rtpopuspay_queue")
+        rtpopuspay_queue = Gst.ElementFactory.make("queue", "rtpopuspay_queue")
 
         # Make the queue leaky in the downstream direction, drop packets if the queue is behind.
-        # rtpopuspay_queue.set_property("leaky", "downstream")
+        rtpopuspay_queue.set_property("leaky", "downstream")
 
         # Discard all data in the queue when an EOS event is received
-        # rtpopuspay_queue.set_property("flush-on-eos", True)
+        rtpopuspay_queue.set_property("flush-on-eos", True)
 
         # Set the queue max time to 16ms (16000000ns)
         # If the pipeline is behind by more than 1s, the packets
         # will be dropped.
         # This helps buffer out latency in the audio source.
-        # rtpopuspay_queue.set_property("max-size-time", 16000000)
+        rtpopuspay_queue.set_property("max-size-time", 16000000)
 
         # Set the other queue sizes to 0 to make it only time-based.
-        # rtpopuspay_queue.set_property("max-size-buffers", 0)
-        # rtpopuspay_queue.set_property("max-size-bytes", 0)
+        rtpopuspay_queue.set_property("max-size-buffers", 0)
+        rtpopuspay_queue.set_property("max-size-bytes", 0)
 
         # Set the capabilities for the rtpopuspay element.
         rtpopuspay_caps = Gst.caps_from_string("application/x-rtp")
@@ -838,7 +838,7 @@ class GSTWebRTCApp:
         rtpopuspay_capsfilter.set_property("caps", rtpopuspay_caps)
 
         # Add all elements to the pipeline.
-        pipeline_elements = [pulsesrc, pulsesrc_capsfilter, opusenc, rtpopuspay, rtpopuspay_capsfilter] # rtpopuspay_queue
+        pipeline_elements = [pulsesrc, pulsesrc_capsfilter, opusenc, rtpopuspay, rtpopuspay_queue, rtpopuspay_capsfilter]
 
         for pipeline_element in pipeline_elements:
             self.pipeline.add(pipeline_element)

--- a/src/selkies_gstreamer/gstwebrtc_app.py
+++ b/src/selkies_gstreamer/gstwebrtc_app.py
@@ -799,23 +799,23 @@ class GSTWebRTCApp:
         rtpopuspay.set_property("mtu", 1200)
 
         # Insert a queue for the RTP packets.
-        rtpopuspay_queue = Gst.ElementFactory.make("queue", "rtpopuspay_queue")
+        # rtpopuspay_queue = Gst.ElementFactory.make("queue", "rtpopuspay_queue")
 
         # Make the queue leaky in the downstream direction, drop packets if the queue is behind.
-        rtpopuspay_queue.set_property("leaky", "downstream")
+        # rtpopuspay_queue.set_property("leaky", "downstream")
 
         # Discard all data in the queue when an EOS event is received
-        rtpopuspay_queue.set_property("flush-on-eos", True)
+        # rtpopuspay_queue.set_property("flush-on-eos", True)
 
         # Set the queue max time to 16ms (16000000ns)
         # If the pipeline is behind by more than 1s, the packets
         # will be dropped.
         # This helps buffer out latency in the audio source.
-        rtpopuspay_queue.set_property("max-size-time", 16000000)
+        # rtpopuspay_queue.set_property("max-size-time", 16000000)
 
         # Set the other queue sizes to 0 to make it only time-based.
-        rtpopuspay_queue.set_property("max-size-buffers", 0)
-        rtpopuspay_queue.set_property("max-size-bytes", 0)
+        # rtpopuspay_queue.set_property("max-size-buffers", 0)
+        # rtpopuspay_queue.set_property("max-size-bytes", 0)
 
         # Set the capabilities for the rtpopuspay element.
         rtpopuspay_caps = Gst.caps_from_string("application/x-rtp")
@@ -838,7 +838,7 @@ class GSTWebRTCApp:
         rtpopuspay_capsfilter.set_property("caps", rtpopuspay_caps)
 
         # Add all elements to the pipeline.
-        pipeline_elements = [pulsesrc, pulsesrc_capsfilter, opusenc, rtpopuspay, rtpopuspay_queue, rtpopuspay_capsfilter]
+        pipeline_elements = [pulsesrc, pulsesrc_capsfilter, opusenc, rtpopuspay, rtpopuspay_capsfilter] # rtpopuspay_queue
 
         for pipeline_element in pipeline_elements:
             self.pipeline.add(pipeline_element)

--- a/src/selkies_gstreamer/gstwebrtc_app.py
+++ b/src/selkies_gstreamer/gstwebrtc_app.py
@@ -381,7 +381,6 @@ class GSTWebRTCApp:
                 self.encoder = "vah264lpenc"
             vah264enc.set_property("aud", True)
             vah264enc.set_property("b-frames", 0)
-            vah264enc.set_property("dct8x8", False)
             vah264enc.set_property("key-int-max", 0 if self.keyframe_distance == -1.0 else int(self.framerate * self.keyframe_distance))
             vah264enc.set_property("rate-control", "cbr")
             vah264enc.set_property("target-usage", 6)

--- a/src/selkies_gstreamer/gstwebrtc_app.py
+++ b/src/selkies_gstreamer/gstwebrtc_app.py
@@ -61,7 +61,7 @@ class GSTWebRTCAppError(Exception):
     pass
 
 class GSTWebRTCApp:
-    def __init__(self, stun_servers=None, turn_servers=None, audio_channels=2, framerate=30, encoder=None, video_bitrate=2000, audio_bitrate=64000):
+    def __init__(self, stun_servers=None, turn_servers=None, audio_channels=2, framerate=30, encoder=None, video_bitrate=2000, audio_bitrate=64000, keyframe_distance=3, packetloss_percent=5):
         """Initialize GStreamer WebRTC app.
 
         Initializes GObjects and checks for required plugins.
@@ -86,9 +86,9 @@ class GSTWebRTCApp:
         self.audio_bitrate = audio_bitrate
 
         # Keyframe distance in seconds
-        self.keyframe_dist = 3
+        self.keyframe_distance = keyframe_distance
         # Packet loss base percentage
-        self.packetloss_percent = 5
+        self.packetloss_percent = packetloss_percent
         # Prevent bitrate from overshooting because of FEC
         self.fec_video_bitrate = int(self.video_bitrate / (1.0 + (self.packetloss_percent / 100.0)))
         self.fec_audio_bitrate = int(self.audio_bitrate / (1.0 + (self.packetloss_percent / 100.0)))
@@ -284,7 +284,7 @@ class GSTWebRTCApp:
             # A negative consequence when using infinite GOP size is that
             # when packets are lost, the decoder may never recover.
             # NVENC supports infinite GOP by setting this to -1.
-            nvh264enc.set_property("gop-size", int(self.framerate * self.keyframe_dist))
+            nvh264enc.set_property("gop-size", int(self.framerate * self.keyframe_distance))
 
             # Instructs encoder to handle Quality of Service (QOS) events from
             # the rest of the pipeline. Setting this to true increases
@@ -344,7 +344,7 @@ class GSTWebRTCApp:
             else:
                 nvh265enc.set_property("rc-mode", "cbr")
 
-            nvh265enc.set_property("gop-size", int(self.framerate * self.keyframe_dist))
+            nvh265enc.set_property("gop-size", int(self.framerate * self.keyframe_distance))
             nvh265enc.set_property("qos", True)
             nvh265enc.set_property("aud", True)
             nvh265enc.set_property("b-adapt", False)
@@ -382,7 +382,7 @@ class GSTWebRTCApp:
             vah264enc.set_property("aud", True)
             vah264enc.set_property("b-frames", 0)
             vah264enc.set_property("dct8x8", False)
-            vah264enc.set_property("key-int-max", int(self.framerate * self.keyframe_dist))
+            vah264enc.set_property("key-int-max", int(self.framerate * self.keyframe_distance))
             vah264enc.set_property("rate-control", "cbr")
             vah264enc.set_property("target-usage", 6)
             vah264enc.set_property("qos", True)
@@ -405,7 +405,7 @@ class GSTWebRTCApp:
                 self.encoder = "vah265lpenc"
             vah265enc.set_property("aud", True)
             vah265enc.set_property("b-frames", 0)
-            vah265enc.set_property("key-int-max", int(self.framerate * self.keyframe_dist))
+            vah265enc.set_property("key-int-max", int(self.framerate * self.keyframe_distance))
             vah265enc.set_property("rate-control", "cbr")
             vah265enc.set_property("target-usage", 6)
             vah265enc.set_property("qos", True)
@@ -426,7 +426,7 @@ class GSTWebRTCApp:
             if vavp9enc is None:
                 vavp9enc = Gst.ElementFactory.make("vavp9lpenc", "vaenc")
                 self.encoder = "vavp9lpenc"
-            vavp9enc.set_property("key-int-max", int(self.framerate * self.keyframe_dist))
+            vavp9enc.set_property("key-int-max", int(self.framerate * self.keyframe_distance))
             vavp9enc.set_property("rate-control", "cbr")
             vavp9enc.set_property("target-usage", 6)
             vavp9enc.set_property("qos", True)
@@ -447,7 +447,7 @@ class GSTWebRTCApp:
             if vaav1enc is None:
                 vaav1enc = Gst.ElementFactory.make("vaav1lpenc", "vaenc")
                 self.encoder = "vaav1lpenc"
-            vaav1enc.set_property("key-int-max", int(self.framerate * self.keyframe_dist))
+            vaav1enc.set_property("key-int-max", int(self.framerate * self.keyframe_distance))
             vaav1enc.set_property("rate-control", "cbr")
             vaav1enc.set_property("target-usage", 6)
             vaav1enc.set_property("qos", True)
@@ -470,7 +470,7 @@ class GSTWebRTCApp:
             x264enc.set_property("b-adapt", False)
             x264enc.set_property("bframes", 0)
             x264enc.set_property("insert-vui", True)
-            x264enc.set_property("key-int-max", int(self.framerate * self.keyframe_dist))
+            x264enc.set_property("key-int-max", int(self.framerate * self.keyframe_distance))
             x264enc.set_property("rc-lookahead", 0)
             x264enc.set_property("vbv-buf-capacity", 120)
             x264enc.set_property("sliced-threads", True)
@@ -498,7 +498,7 @@ class GSTWebRTCApp:
             openh264enc.set_property("scene-change-detection", False)
             openh264enc.set_property("usage-type", "screen")
             openh264enc.set_property("complexity", "low")
-            openh264enc.set_property("gop-size", int(self.framerate * self.keyframe_dist))
+            openh264enc.set_property("gop-size", int(self.framerate * self.keyframe_distance))
             # TODO: Chromium cannot decode more than 4 slices, fix when it changes
             openh264enc.set_property("multi-thread", min(4, max(1, len(os.sched_getaffinity(0)) - 1)))
             openh264enc.set_property("slice-mode", "n-slices")
@@ -518,7 +518,7 @@ class GSTWebRTCApp:
             # encoder
             x265enc = Gst.ElementFactory.make("x265enc", "x265enc")
             x265enc.set_property("option-string", "b-adapt=0:bframes=0:rc-lookahead=0:aud:repeat-headers:pmode:wpp")
-            x265enc.set_property("key-int-max", int(self.framerate * self.keyframe_dist))
+            x265enc.set_property("key-int-max", int(self.framerate * self.keyframe_distance))
             x265enc.set_property("qos", True)
             x265enc.set_property("speed-preset", "ultrafast")
             x265enc.set_property("tune", "zerolatency")
@@ -551,7 +551,7 @@ class GSTWebRTCApp:
             vpenc.set_property("end-usage", "cbr")
             vpenc.set_property("error-resilient", "default")
             vpenc.set_property("keyframe-mode", "disabled")
-            vpenc.set_property("keyframe-max-dist", int(self.framerate * self.keyframe_dist))
+            vpenc.set_property("keyframe-max-dist", int(self.framerate * self.keyframe_distance))
             vpenc.set_property("lag-in-frames", 0)
             vpenc.set_property("qos", True)
             vpenc.set_property("target-bitrate", self.fec_video_bitrate * 1000)
@@ -566,7 +566,7 @@ class GSTWebRTCApp:
 
             rav1enc = Gst.ElementFactory.make("rav1enc", "rav1enc")
             rav1enc.set_property("low-latency", True)
-            rav1enc.set_property("max-key-frame-interval", int(self.framerate * self.keyframe_dist))
+            rav1enc.set_property("max-key-frame-interval", int(self.framerate * self.keyframe_distance))
             rav1enc.set_property("rdo-lookahead-frames", 0)
             rav1enc.set_property("speed-preset", 10)
             rav1enc.set_property("tiles", 16)
@@ -956,25 +956,25 @@ class GSTWebRTCApp:
         # ADD_ENCODER: GOP/IDR Keyframe distance to keep the stream from freezing (in keyframe_dist seconds)
         if self.encoder.startswith("nv"):
             element = Gst.Bin.get_by_name(self.pipeline, "nvenc")
-            element.set_property("gop-size", int(self.framerate * self.keyframe_dist))
+            element.set_property("gop-size", int(self.framerate * self.keyframe_distance))
         elif self.encoder.startswith("va"):
             element = Gst.Bin.get_by_name(self.pipeline, "vaenc")
-            element.set_property("key-int-max", int(self.framerate * self.keyframe_dist))
+            element.set_property("key-int-max", int(self.framerate * self.keyframe_distance))
         elif self.encoder in ["x264enc"]:
             element = Gst.Bin.get_by_name(self.pipeline, "x264enc")
-            element.set_property("key-int-max", int(self.framerate * self.keyframe_dist))
+            element.set_property("key-int-max", int(self.framerate * self.keyframe_distance))
         elif self.encoder in ["openh264enc"]:
             element = Gst.Bin.get_by_name(self.pipeline, "openh264enc")
-            element.set_property("gop-size", int(self.framerate * self.keyframe_dist))
+            element.set_property("gop-size", int(self.framerate * self.keyframe_distance))
         elif self.encoder in ["x265enc"]:
             element = Gst.Bin.get_by_name(self.pipeline, "x265enc")
-            element.set_property("key-int-max", int(self.framerate * self.keyframe_dist))
+            element.set_property("key-int-max", int(self.framerate * self.keyframe_distance))
         elif self.encoder.startswith("vp"):
             element = Gst.Bin.get_by_name(self.pipeline, "vpenc")
-            element.set_property("keyframe-max-dist", int(self.framerate * self.keyframe_dist))
+            element.set_property("keyframe-max-dist", int(self.framerate * self.keyframe_distance))
         elif self.encoder in ["rav1enc"]:
             element = Gst.Bin.get_by_name(self.pipeline, "rav1enc")
-            element.set_property("max-key-frame-interval", int(self.framerate * self.keyframe_dist))
+            element.set_property("max-key-frame-interval", int(self.framerate * self.keyframe_distance))
         else:
             logger.warning("setting keyframe interval (GOP size) not supported with encoder: %s" % self.encoder)
 

--- a/src/selkies_gstreamer/metrics.py
+++ b/src/selkies_gstreamer/metrics.py
@@ -173,14 +173,14 @@ class Metrics:
                 if len(headers) < len(prev_headers):
                     for i in prev_headers:
                         if i not in headers:
-                            values.insert(prev_headers.index(i), -1)
+                            values.insert(prev_headers.index(i), "NaN")
                 else:
                     i, j, k = 0, 0, 0
                     while i < len(headers):
                         if headers[i] != prev_headers[j]:
-                            # If there is a mismatch, update all previous rows with a placeholder to represent an empty value, using `-1` here
+                            # If there is a mismatch, update all previous rows with a placeholder to represent an empty value, using `NaN` here
                             for row in prev_values:
-                                row.insert(i, -1)
+                                row.insert(i, "NaN")
                             i += 1
                             k += 1  # track number of values added
                         else:
@@ -191,7 +191,7 @@ class Metrics:
                     # When new fields are at the end
                     while j < i:
                         for row in prev_values:
-                            row.insert(j, -1)
+                            row.insert(j, "NaN")
                         j += 1
 
                 # Validation check to confirm modified rows are of same length

--- a/src/selkies_gstreamer/metrics.py
+++ b/src/selkies_gstreamer/metrics.py
@@ -44,24 +44,24 @@ class Metrics:
 
     def set_gpu_utilization(self, utilization):
         self.gpu_utilization.set(utilization)
-    
+
     def set_latency(self, latency_ms):
         self.latency.set(latency_ms)
-    
-    def start(self):
+
+    def start_http(self):
         start_http_server(self.port)
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO)
-    
+
     port = 8000
 
     m = Metrics(port)
     m.start()
 
     logger.info("Started metrics server on port %d" % port)
-    
-    # Generate some metrics.
+
+    # Generate random metrics
     while True:
         m.set_fps(int(random.random() * 100 % 60))
         m.set_gpu_utilization(int(random.random() * 100))

--- a/src/selkies_gstreamer/webrtc_input.py
+++ b/src/selkies_gstreamer/webrtc_input.py
@@ -139,7 +139,7 @@ class WebRTCInput:
         self.on_cursor_change = lambda msg: logger.warn(
             'unhandled on_cursor_change')
         self.on_client_webrtc_stats = lambda type, stats: logger.warn(
-            'unhandled on_webrtc_stats')
+            'unhandled on_client_webrtc_stats')
 
     def __keyboard_connect(self):
         self.keyboard = pynput.keyboard.Controller()

--- a/src/selkies_gstreamer/webrtc_input.py
+++ b/src/selkies_gstreamer/webrtc_input.py
@@ -138,7 +138,7 @@ class WebRTCInput:
             'unhandled on_ping_response')
         self.on_cursor_change = lambda msg: logger.warn(
             'unhandled on_cursor_change')
-        self.on_client_webrtc_stats = lambda type, stats: logger.warn(
+        self.on_client_webrtc_stats = lambda webrtc_stat_type, webrtc_stats: logger.warn(
             'unhandled on_client_webrtc_stats')
 
     def __keyboard_connect(self):

--- a/src/selkies_gstreamer/webrtc_input.py
+++ b/src/selkies_gstreamer/webrtc_input.py
@@ -138,7 +138,7 @@ class WebRTCInput:
             'unhandled on_ping_response')
         self.on_cursor_change = lambda msg: logger.warn(
             'unhandled on_cursor_change')
-        self.on_webrtc_stats = lambda msg: logger.warn(
+        self.on_client_webrtc_stats = lambda type, stats: logger.warn(
             'unhandled on_webrtc_stats')
 
     def __keyboard_connect(self):
@@ -724,7 +724,7 @@ class WebRTCInput:
         elif toks[0] == "_stats_video" or toks[0] == "_stats_audio":
             # WebRTC Statistics API data from client 
             try:
-                self.on_webrtc_stats(toks[0], ",".join(toks[1:]))
+                self.on_client_webrtc_stats(toks[0], ",".join(toks[1:]))
             except:
                 logger.error("failed to parse WebRTC Statistics JSON object")
         else:

--- a/src/selkies_gstreamer/webrtc_input.py
+++ b/src/selkies_gstreamer/webrtc_input.py
@@ -37,10 +37,6 @@ import time
 from PIL import Image
 from gamepad import SelkiesGamepad
 
-from datetime import datetime 
-import csv
-import json
-
 import logging
 logger = logging.getLogger("webrtc_input")
 logger.setLevel(logging.INFO)
@@ -117,10 +113,6 @@ class WebRTCInput:
         self.button_mask = 0
 
         self.ping_start = None
-        self.stats_video_file_path = None
-        self.stats_audio_file_path = None
-        self.prev_stats_video_header_len = None 
-        self.prev_stats_audio_header_len = None
 
         self.on_video_encoder_bit_rate = lambda bitrate: logger.warn(
             'unhandled on_video_encoder_bit_rate')
@@ -146,6 +138,8 @@ class WebRTCInput:
             'unhandled on_ping_response')
         self.on_cursor_change = lambda msg: logger.warn(
             'unhandled on_cursor_change')
+        self.on_webrtc_stats = lambda msg: logger.warn(
+            'unhandled on_webrtc_stats')
 
     def __keyboard_connect(self):
         self.keyboard = pynput.keyboard.Controller()
@@ -728,134 +722,10 @@ class WebRTCInput:
                 logger.error(
                     "failed to parse latency report from client" + str(toks))
         elif toks[0] == "_stats_video" or toks[0] == "_stats_audio":
-            # Webrtc Statistics API data from client 
+            # WebRTC Statistics API data from client 
             try:
-                stats_obj = json.loads(",".join(toks[1:]))
-                if toks[0] == "_stats_video":
-                    self.write_webrtc_stats(stats_obj, self.stats_video_file_path)
-                else:
-                    self.write_webrtc_stats(stats_obj, self.stats_audio_file_path)
+                self.on_webrtc_stats(toks[0], ",".join(toks[1:]))
             except:
-                logger.error("failed to deserialize JSON object to python object")
+                logger.error("failed to parse WebRTC Statistics JSON object")
         else:
             logger.info('unknown data channel message: %s' % msg)
-    
-    def write_webrtc_stats(self, obj_list, file_path):
-        """Writes the webrtc statistics to a CSV file.
-
-        Arguments:
-            obj_list {[list of object]} -- list of python objects/dict.
-        """
-        
-        dt = datetime.now()
-        timestamp = dt.strftime("%d/%B/%Y:%H:%M:%S")
-        try:
-            with open(file_path, 'a+') as stats_file:
-                csv_writer = csv.writer(stats_file, quotechar='"')
-
-                # Prepare the data
-                headers = ["timestamp"]
-                for obj in obj_list:
-                    headers.extend(list(obj.keys()))
-                values = [timestamp]
-                for obj in obj_list:
-                    values.extend(['"{}"'.format(val) if isinstance(val, str) and ';' in val else val for val in obj.values()])
-
-                # Video stats
-                if 'video' in file_path:
-                    if self.prev_stats_video_header_len == None:
-                        csv_writer.writerow(headers)
-                        csv_writer.writerow(values)
-                        self.prev_stats_video_header_len = len(headers)
-                    elif self.prev_stats_video_header_len == len(headers):
-                        csv_writer.writerow(values)
-                    else:
-                        # We got new fields so update the data
-                        self.update_the_stats(file_path, headers, values)
-                        self.prev_stats_video_header_len = len(headers)
-                else:
-                    # Audio stats
-                    if self.prev_stats_audio_header_len == None:
-                        csv_writer.writerow(headers)
-                        csv_writer.writerow(values)
-                        self.prev_stats_audio_header_len = len(headers)
-                    elif self.prev_stats_audio_header_len == len(headers):
-                        csv_writer.writerow(values)
-                    else:
-                        # We got new fields so update the data
-                        self.update_the_stats(file_path, headers, values)
-                        self.prev_stats_audio_header_len = len(headers)
-                
-               
-        except Exception as e:
-            logger.error("writing webrtc stats to csv file: " + str(e))
-
-    def update_the_stats(self, file_path, headers, values):
-        """Copies data from one csv file to another to facilite dynamic updates to the data structure
-           by handling empty values and appending new data.
-        """
-        prev_headers = None
-        prev_values = []
-
-        try: 
-            with open(file_path, 'r') as stats_file:
-                csv_reader = csv.reader(stats_file,  delimiter=',')
-
-                # Get all existing data
-                header_indicator = 0
-                for row in csv_reader:
-                    if header_indicator == 0:
-                        prev_headers = row
-                        header_indicator += 1
-                    else:
-                        prev_values.append(row)
-
-                i, j = 0, 0
-                while i < len(headers):
-                    if headers[i] != prev_headers[j]:
-                        # If there's a mismatch then we encountered a new filed, so update all previous rows with
-                        # a placeholder to represent an empty value, using `-1` here
-                        for row in prev_values:
-                            row.insert(i, -1)
-                        i += 1
-                    else:
-                        i += 1
-                        j += 1
-                
-                # if the new fileds are the end then take care of those as well
-                while j<i-1:
-                    for row in prev_values:
-                        row.insert(j, -1)
-                    j += 1
-
-                # Just some validation check to see if modified rows are of same lenght as new
-                if len(prev_values[0]) != len(values):
-                    logger.warn("There's a mismatch; the columns could be misaligned with headers")
-           
-            # Purge the existing file
-            if os.path.exists(file_path):
-                os.remove(file_path)
-            else:
-                logger.warn("File {} doesn't exist to purge".format(file_path))
-
-            # create a new file with updated data
-            with open(file_path, 'a') as stats_file:
-                csv_writer = csv.writer(stats_file)
-
-                csv_writer.writerow(headers)
-                csv_writer.writerows(prev_values)
-                csv_writer.writerow(values)
-
-                logger.info("File {} created with updated data".format(stats_file))
-        except Exception as e:
-            raise e
-
-    def initialize_webrtc_stats_files(self):
-        """Initializes the Webrtc Statistics file upon every new webrtc connection
-        """
-        dt = datetime.now()
-        timestamp = dt.strftime("%Y-%m-%d:%H:%M:%S")
-        self.stats_video_file_path = '/tmp/stats-video-{}.csv'.format(timestamp)
-        self.stats_audio_file_path = '/tmp/stats-audio-{}.csv'.format(timestamp)
-        self.prev_stats_video_header_len = None
-        self.prev_stats_audio_header_len = None


### PR DESCRIPTION
This is a DRAFT: Do not merge it yet.

The reports are being sent over datachannel and being dumped to a CSV file at `/tmp/stats.csv` location.
Due to duel webrtc connection the audio stats aren't included yet as the file size keeps increasing rapidly even with just video webrtc api stats.

#139 