### PR TITLE
Fix Flash of Unstyled Content (FOUC) issue

### DIFF
--- a/addons/gst-web/src/index.html
+++ b/addons/gst-web/src/index.html
@@ -16,6 +16,10 @@
       font-family: Roboto, Arial, sans;
     }
 
+    body {
+      background-color: #000000;
+    }
+
     .scrolly textarea {
       min-height: 300px;
       white-space: pre;
@@ -123,7 +127,10 @@
       word-wrap: normal;
       direction: ltr;
     }
-    body { background-color: #000000; }
+
+    [v-cloak] {
+        display: none;
+    }
   </style>
   <title>Selkies - webrtc</title>
 </head>
@@ -386,9 +393,6 @@
       </div>
     </v-app>
   </div>
-  <style>
-    [v-cloak] { display: none; }
-  </style>
 </body>
 
 <script type="text/javascript">

--- a/addons/gst-web/src/index.html
+++ b/addons/gst-web/src/index.html
@@ -123,12 +123,13 @@
       word-wrap: normal;
       direction: ltr;
     }
+    body { background-color: #000000; }
   </style>
   <title>Selkies - webrtc</title>
 </head>
 
 <body>
-  <div id="app">
+  <div id="app" v-cloak>
     <v-app>
       <v-navigation-drawer v-model="showDrawer" app fixed right temporary width="600">
         <v-container fluid grid-list-lg>
@@ -385,6 +386,9 @@
       </div>
     </v-app>
   </div>
+  <style>
+    [v-cloak] { display: none; }
+  </style>
 </body>
 
 <script type="text/javascript">


### PR DESCRIPTION
- The addition of the v-cloak directive and the accompanying CSS rule will help to prevent the application from displaying partially loaded or unstyled content while it's loading.

- The Flash of Unstyled Content (FOUC) is likely caused by the way the Vue.js application is initialized and rendered. The root cause is that the HTML content is rendered before the Vue.js application is mounted and the styles are applied.

