### PR TITLE
Fix bug: undefined variable used in logging call

### DIFF
--- a/src/selkies_gstreamer/resize.py
+++ b/src/selkies_gstreamer/resize.py
@@ -166,7 +166,7 @@ def set_cursor_size(size):
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = p.communicate()
         if p.returncode != 0:
-            logger.error("failed to set XFCE cursor size to: '%d': %s%s" % (dpi, str(stdout), str(stderr)))
+            logger.error("failed to set XFCE cursor size to: '%d': %s%s" % (size, str(stdout), str(stderr)))
             return False
     else:
         logger.warning("failed to find supported window manager to set DPI.")


### PR DESCRIPTION
**Reference the issue numbers and reviewers**
Bug introduced in PR #88  (@danisla) 

**Explain relevant issues and how this pull request solves them**
It looks like the logging statement used when `xfconf-query` fails had been copied from `set_dpi(dpi)` for `set_cursor_size(size)` but the `dpi` variable was not changed. So when `xfconf-query` didn't work properly in my setup, it triggered an exception and crashed the program.

**Describe the changes in code and its dependencies and justify that they work as intended after testing**
After fixing the variable name, I confirmed there is no crash and a proper logging statement is generated letting me know `xfconf-query` failed.

 - [x] I confirm that this pull request is relevant to the scope of this project. If you know that upstream projects are the cause of this problem, please file the pull request there.
 - [x] I confirm that this pull request has been tested thoroughly and to the best of my knowledge that additional unintended problems do not arise.
 - [x] I confirm that the style of the changed code conforms to the overall style of the project.
 - [x] I confirm that I have read other open and closed pull requests and that duplicates do not exist.
 - [x] I confirm that I have justified the need for this pull request and that the changes reflect the fix for the specified problem.
 - [x] I confirm that no portion of this pull request contains credentials or other private information, and it is my own responsibility to protect my privacy.
