### PR TITLE
Joystick Interposer evdev support, fixes SDL, Wine, Retroarch, RPCS3, and more.

### DIFF
--- a/.devcontainer/features/desktop-selkies/src/start-selkies.sh
+++ b/.devcontainer/features/desktop-selkies/src/start-selkies.sh
@@ -44,7 +44,6 @@ sudo chmod 777 /dev/input/js*
 if [ -e "/usr/lib/x86_64-linux-gnu/selkies_joystick_interposer.so" ]; then
     export SELKIES_INTERPOSER='/usr/$LIB/selkies_joystick_interposer.so'
     export LD_PRELOAD="${SELKIES_INTERPOSER}${LD_PRELOAD:+:${LD_PRELOAD}}"
-    export SDL_JOYSTICK_DEVICE=/dev/input/js0
 fi
 
 # Start desktop environment

--- a/.github/workflows/build_and_publish_all_images.yaml
+++ b/.github/workflows/build_and_publish_all_images.yaml
@@ -90,7 +90,7 @@ jobs:
             PKG_VERSION=0.0.0
           context: addons/js-interposer
           dockerfile: Dockerfile.debpkg
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
 
         - name: js-interposer
           version_suffix: -ubuntu22.04
@@ -101,7 +101,7 @@ jobs:
             PKG_VERSION=0.0.0
           context: addons/js-interposer
           dockerfile: Dockerfile.debpkg
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
 
         - name: js-interposer
           version_suffix: -ubuntu24.04
@@ -112,7 +112,7 @@ jobs:
             PKG_VERSION=0.0.0
           context: addons/js-interposer
           dockerfile: Dockerfile.debpkg
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
 
         - name: turn-rest
           context: addons/turn-rest
@@ -236,78 +236,21 @@ jobs:
           suffix: -deb
           source: /opt/selkies-js-interposer_0.0.0.deb
           target: selkies-js-interposer.deb
+          platforms: linux/amd64
 
         - name: js-interposer
           version_suffix: -ubuntu22.04
           suffix: -deb
           source: /opt/selkies-js-interposer_0.0.0.deb
           target: selkies-js-interposer.deb
+          platforms: linux/amd64
 
         - name: js-interposer
           version_suffix: -ubuntu24.04
           suffix: -deb
           source: /opt/selkies-js-interposer_0.0.0.deb
           target: selkies-js-interposer.deb
-
-        - name: js-interposer
-          version_suffix: -ubuntu20.04
-          suffix: -deb
-          source: /opt/selkies-js-interposer_0.0.0.deb
-          target: selkies-js-interposer.deb
-          platforms: linux/arm64
-
-        - name: js-interposer
-          version_suffix: -ubuntu22.04
-          suffix: -deb
-          source: /opt/selkies-js-interposer_0.0.0.deb
-          target: selkies-js-interposer.deb
-          platforms: linux/arm64
-
-        - name: js-interposer
-          version_suffix: -ubuntu24.04
-          suffix: -deb
-          source: /opt/selkies-js-interposer_0.0.0.deb
-          target: selkies-js-interposer.deb
-          platforms: linux/arm64
-
-        - name: js-interposer
-          version_suffix: -ubuntu20.04
-          suffix: -tar.gz
-          source: /opt/selkies-js-interposer_0.0.0.tar.gz
-          target: selkies-js-interposer.tar.gz
-
-        - name: js-interposer
-          version_suffix: -ubuntu22.04
-          suffix: -tar.gz
-          source: /opt/selkies-js-interposer_0.0.0.tar.gz
-          target: selkies-js-interposer.tar.gz
-
-        - name: js-interposer
-          version_suffix: -ubuntu24.04
-          suffix: -tar.gz
-          source: /opt/selkies-js-interposer_0.0.0.tar.gz
-          target: selkies-js-interposer.tar.gz
-
-        - name: js-interposer
-          version_suffix: -ubuntu20.04
-          suffix: -tar.gz
-          source: /opt/selkies-js-interposer_0.0.0.tar.gz
-          target: selkies-js-interposer.tar.gz
-          platforms: linux/arm64
-
-        - name: js-interposer
-          version_suffix: -ubuntu22.04
-          suffix: -tar.gz
-          source: /opt/selkies-js-interposer_0.0.0.tar.gz
-          target: selkies-js-interposer.tar.gz
-          platforms: linux/arm64
-
-        - name: js-interposer
-          version_suffix: -ubuntu24.04
-          suffix: -tar.gz
-          source: /opt/selkies-js-interposer_0.0.0.tar.gz
-          target: selkies-js-interposer.tar.gz
-          platforms: linux/arm64
+          platforms: linux/amd64
 
         - name: py-build
           source: /opt/pypi/dist/selkies_gstreamer-0.0.0.dev0-py3-none-any.whl

--- a/.github/workflows/build_and_publish_all_images.yaml
+++ b/.github/workflows/build_and_publish_all_images.yaml
@@ -46,11 +46,11 @@ jobs:
     strategy:
       matrix:
         include:
-        - name: conda
-          build_args: |
-            PACKAGE_VERSION=0.0.0.dev0
-            PKG_VERSION=0.0.0
-          context: addons/conda
+        # - name: conda
+        #   build_args: |
+        #     PACKAGE_VERSION=0.0.0.dev0
+        #     PKG_VERSION=0.0.0
+        #   context: addons/conda
 
         - name: coturn
           context: addons/coturn
@@ -208,9 +208,9 @@ jobs:
     strategy:
       matrix:
         include:
-        - name: conda
-          source: /opt/selkies-gstreamer-conda.tar.gz
-          target: selkies-gstreamer-portable.tar.gz
+        # - name: conda
+        #   source: /opt/selkies-gstreamer-conda.tar.gz
+        #   target: selkies-gstreamer-portable.tar.gz
 
         - name: gst-web
           source: /opt/gst-web.tar.gz

--- a/.github/workflows/build_and_publish_changed_images.yaml
+++ b/.github/workflows/build_and_publish_changed_images.yaml
@@ -101,7 +101,7 @@ jobs:
             PKG_VERSION=0.0.0
           context: addons/js-interposer
           dockerfile: Dockerfile.debpkg
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
 
         - name: js-interposer
           version_suffix: -ubuntu22.04
@@ -112,7 +112,7 @@ jobs:
             PKG_VERSION=0.0.0
           context: addons/js-interposer
           dockerfile: Dockerfile.debpkg
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
 
         - name: js-interposer
           version_suffix: -ubuntu24.04
@@ -123,7 +123,7 @@ jobs:
             PKG_VERSION=0.0.0
           context: addons/js-interposer
           dockerfile: Dockerfile.debpkg
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
 
         - name: turn-rest
           context: addons/turn-rest
@@ -265,78 +265,21 @@ jobs:
           suffix: -deb
           source: /opt/selkies-js-interposer_0.0.0.deb
           target: selkies-js-interposer.deb
+          platforms: linux/amd64
 
         - name: js-interposer
           version_suffix: -ubuntu22.04
           suffix: -deb
           source: /opt/selkies-js-interposer_0.0.0.deb
           target: selkies-js-interposer.deb
+          platforms: linux/amd64
 
         - name: js-interposer
           version_suffix: -ubuntu24.04
           suffix: -deb
           source: /opt/selkies-js-interposer_0.0.0.deb
           target: selkies-js-interposer.deb
-
-        - name: js-interposer
-          version_suffix: -ubuntu20.04
-          suffix: -deb
-          source: /opt/selkies-js-interposer_0.0.0.deb
-          target: selkies-js-interposer.deb
-          platforms: linux/arm64
-
-        - name: js-interposer
-          version_suffix: -ubuntu22.04
-          suffix: -deb
-          source: /opt/selkies-js-interposer_0.0.0.deb
-          target: selkies-js-interposer.deb
-          platforms: linux/arm64
-
-        - name: js-interposer
-          version_suffix: -ubuntu24.04
-          suffix: -deb
-          source: /opt/selkies-js-interposer_0.0.0.deb
-          target: selkies-js-interposer.deb
-          platforms: linux/arm64
-
-        - name: js-interposer
-          version_suffix: -ubuntu20.04
-          suffix: -tar.gz
-          source: /opt/selkies-js-interposer_0.0.0.tar.gz
-          target: selkies-js-interposer.tar.gz
-
-        - name: js-interposer
-          version_suffix: -ubuntu22.04
-          suffix: -tar.gz
-          source: /opt/selkies-js-interposer_0.0.0.tar.gz
-          target: selkies-js-interposer.tar.gz
-
-        - name: js-interposer
-          version_suffix: -ubuntu24.04
-          suffix: -tar.gz
-          source: /opt/selkies-js-interposer_0.0.0.tar.gz
-          target: selkies-js-interposer.tar.gz
-
-        - name: js-interposer
-          version_suffix: -ubuntu20.04
-          suffix: -tar.gz
-          source: /opt/selkies-js-interposer_0.0.0.tar.gz
-          target: selkies-js-interposer.tar.gz
-          platforms: linux/arm64
-
-        - name: js-interposer
-          version_suffix: -ubuntu22.04
-          suffix: -tar.gz
-          source: /opt/selkies-js-interposer_0.0.0.tar.gz
-          target: selkies-js-interposer.tar.gz
-          platforms: linux/arm64
-
-        - name: js-interposer
-          version_suffix: -ubuntu24.04
-          suffix: -tar.gz
-          source: /opt/selkies-js-interposer_0.0.0.tar.gz
-          target: selkies-js-interposer.tar.gz
-          platforms: linux/arm64
+          platforms: linux/amd64
 
         - name: py-build
           source: /opt/pypi/dist/selkies_gstreamer-0.0.0.dev0-py3-none-any.whl

--- a/.github/workflows/build_and_publish_changed_images.yaml
+++ b/.github/workflows/build_and_publish_changed_images.yaml
@@ -57,11 +57,11 @@ jobs:
     strategy:
       matrix:
         include:
-        - name: conda
-          build_args: |
-            PACKAGE_VERSION=0.0.0.dev0
-            PKG_VERSION=0.0.0
-          context: addons/conda
+        # - name: conda
+        #   build_args: |
+        #     PACKAGE_VERSION=0.0.0.dev0
+        #     PKG_VERSION=0.0.0
+        #   context: addons/conda
 
         - name: coturn
           context: addons/coturn
@@ -237,9 +237,9 @@ jobs:
     strategy:
       matrix:
         include:
-        - name: conda
-          source: /opt/selkies-gstreamer-conda.tar.gz
-          target: selkies-gstreamer-portable.tar.gz
+        # - name: conda
+        #   source: /opt/selkies-gstreamer-conda.tar.gz
+        #   target: selkies-gstreamer-portable.tar.gz
 
         - name: gst-web
           source: /opt/gst-web.tar.gz

--- a/.github/workflows/build_and_publish_release.yaml
+++ b/.github/workflows/build_and_publish_release.yaml
@@ -120,7 +120,7 @@ jobs:
             PKG_VERSION=${{ needs.get_semver.outputs.semver }}
           context: addons/js-interposer
           dockerfile: Dockerfile.debpkg
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
 
         - name: js-interposer
           version_suffix: -ubuntu22.04
@@ -131,7 +131,7 @@ jobs:
             PKG_VERSION=${{ needs.get_semver.outputs.semver }}
           context: addons/js-interposer
           dockerfile: Dockerfile.debpkg
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
 
         - name: js-interposer
           version_suffix: -ubuntu24.04
@@ -142,7 +142,7 @@ jobs:
             PKG_VERSION=${{ needs.get_semver.outputs.semver }}
           context: addons/js-interposer
           dockerfile: Dockerfile.debpkg
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
 
         - name: turn-rest
           context: addons/turn-rest

--- a/addons/example/entrypoint.sh
+++ b/addons/example/entrypoint.sh
@@ -12,10 +12,10 @@ until [ -d "${XDG_RUNTIME_DIR}" ]; do sleep 0.5; done
 # Configure joystick interposer
 export SELKIES_INTERPOSER='/usr/$LIB/selkies_joystick_interposer.so'
 export LD_PRELOAD="${SELKIES_INTERPOSER}${LD_PRELOAD:+:${LD_PRELOAD}}"
-export SDL_JOYSTICK_DEVICE=/dev/input/js0
 mkdir -pm1777 /dev/input || sudo-root mkdir -pm1777 /dev/input || echo 'Failed to create joystick interposer directory'
 touch /dev/input/js0 /dev/input/js1 /dev/input/js2 /dev/input/js3 || sudo-root touch /dev/input/js0 /dev/input/js1 /dev/input/js2 /dev/input/js3 || echo 'Failed to create joystick interposer devices'
-chmod 777 /dev/input/js* || sudo-root chmod 777 /dev/input/js* || echo 'Failed to change permission for joystick interposer devices'
+touch /dev/input/event1000 /dev/input/event1001 /dev/input/event1002 /dev/input/event1003 || sudo-root touch /dev/input/event1000 /dev/input/event1001 /dev/input/event1002 /dev/input/event1003 || echo 'Failed to create joystick interposer devices'
+chmod 777 /dev/input/js* /dev/input/event* || sudo-root chmod 777 /dev/input/js* /dev/input/event* || echo 'Failed to change permission for joystick interposer devices'
 
 # Set default display
 export DISPLAY="${DISPLAY:-:20}"

--- a/addons/example/selkies-gstreamer-entrypoint.sh
+++ b/addons/example/selkies-gstreamer-entrypoint.sh
@@ -12,7 +12,6 @@ until [ -d "${XDG_RUNTIME_DIR}" ]; do sleep 0.5; done
 # Configure joystick interposer
 export SELKIES_INTERPOSER='/usr/$LIB/selkies_joystick_interposer.so'
 export LD_PRELOAD="${SELKIES_INTERPOSER}${LD_PRELOAD:+:${LD_PRELOAD}}"
-export SDL_JOYSTICK_DEVICE=/dev/input/js0
 
 # Set default display
 export DISPLAY="${DISPLAY:-:20}"

--- a/addons/js-interposer/.gitignore
+++ b/addons/js-interposer/.gitignore
@@ -1,2 +1,2 @@
 *.so
-sdl_joystick_reader
+sdl_joystick_reader*

--- a/addons/js-interposer/.gitignore
+++ b/addons/js-interposer/.gitignore
@@ -1,1 +1,2 @@
 *.so
+sdl_joystick_reader

--- a/addons/js-interposer/Makefile
+++ b/addons/js-interposer/Makefile
@@ -36,6 +36,9 @@ py-js-test:
 py-ev-test:
 	python3 js-interposer-test.py /tmp/selkies_event1000.sock
 
+py-selkies-test:
+	python3 ../../src/selkies_gstreamer/gamepad.py
+
 jstest: build
 	LD_PRELOAD=$(PWD)/selkies_joystick_interposer.so jstest /dev/input/js0
 

--- a/addons/js-interposer/Makefile
+++ b/addons/js-interposer/Makefile
@@ -1,10 +1,43 @@
 PREFIX ?= /usr
 
-all:
+all: build build32
+
+deps:
+	@sudo apt-get update
+	@sudo apt-get install -y build-essential evtest strace joystick libsdl2-dev gcc-multilib libevdev-dev
+
+build:
 	gcc -shared -fPIC -o selkies_joystick_interposer.so joystick_interposer.c -ldl
 
-install: all
+build32:
+	gcc -m32 -shared -fPIC -o selkies_joystick_interposer_i386.so joystick_interposer.c -ldl
+
+install: build
 	mkdir -p $(PREFIX)/lib/$(gcc -print-multiarch | sed -e 's/i.*86/i386/')
 	cp *.so $(PREFIX)/lib/$(gcc -print-multiarch | sed -e 's/i.*86/i386/')/
 clean:
 	rm -f *.so
+	sudo rm -f /dev/input/js0 /dev/input/event1000
+
+fake-devices:
+	@sudo touch /dev/input/js0 && sudo chmod 777 /dev/input/js0
+	@sudo touch /dev/input/event1000 && sudo chmod 777 /dev/input/event1000
+
+py-js-test:
+	python3 js-interposer-test.py /tmp/selkies_js0.sock
+
+py-ev-test:
+	python3 js-interposer-test.py /tmp/selkies_event1000.sock
+
+jstest: build
+	LD_PRELOAD=$(PWD)/selkies_joystick_interposer.so jstest /dev/input/js0
+
+evtest: build fake-devices
+	LD_PRELOAD=$(PWD)/selkies_joystick_interposer.so evtest /dev/input/event1000
+
+sdltest: build fake-devices
+	gcc -o sdl_joystick_reader sdl-js-test.c -lSDL2
+	LD_PRELOAD=$(PWD)/selkies_joystick_interposer.so ./sdl_joystick_reader
+
+winetest: build build32 fake-devices
+	LD_PRELOAD=$(PWD)/selkies_joystick_interposer.so wine control

--- a/addons/js-interposer/Makefile
+++ b/addons/js-interposer/Makefile
@@ -7,10 +7,10 @@ deps:
 	@sudo apt-get install -y build-essential evtest strace joystick libsdl2-dev gcc-multilib libevdev-dev
 
 build:
-	gcc -shared -fPIC -o selkies_joystick_interposer.so joystick_interposer.c -ldl
+	gcc -shared -fPIC -o selkies_joystick_interposer.so joystick_interposer.c -ldl -Wall
 
 build32:
-	gcc -m32 -shared -fPIC -o selkies_joystick_interposer_i386.so joystick_interposer.c -ldl
+	gcc -m32 -shared -fPIC -o selkies_joystick_interposer_i386.so joystick_interposer.c -ldl -Wall
 
 install: build
 	mkdir -p $(PREFIX)/lib/$(gcc -print-multiarch | sed -e 's/i.*86/i386/')

--- a/addons/js-interposer/Makefile
+++ b/addons/js-interposer/Makefile
@@ -41,3 +41,6 @@ sdltest: build fake-devices
 
 winetest: build build32 fake-devices
 	LD_PRELOAD=$(PWD)/selkies_joystick_interposer.so wine control
+
+xvfbtest: build
+	LD_PRELOAD=$(PWD)/selkies_joystick_interposer.so Xvfb

--- a/addons/js-interposer/Makefile
+++ b/addons/js-interposer/Makefile
@@ -12,6 +12,11 @@ build:
 build32:
 	gcc -m32 -shared -fPIC -o selkies_joystick_interposer_i386.so joystick_interposer.c -ldl -Wall
 
+build-docker-ubuntu-%:
+	docker build --platform=linux/amd64 --build-arg=PKG_NAME=selkies-js-interposer --build-arg PKG_VERSION=0.0.0 --build-arg DISTRIB_IMAGE=ubuntu --build-arg DISTRIB_RELEASE=$* -f Dockerfile.debpkg -t selkies-js-interposer:ubuntu-$* .
+
+build-docker: build-docker-ubuntu-24.04 build-docker-ubuntu-22.04 build-docker-ubuntu-20.04
+
 install: build
 	mkdir -p $(PREFIX)/lib/$(gcc -print-multiarch | sed -e 's/i.*86/i386/')
 	cp *.so $(PREFIX)/lib/$(gcc -print-multiarch | sed -e 's/i.*86/i386/')/

--- a/addons/js-interposer/Makefile
+++ b/addons/js-interposer/Makefile
@@ -17,14 +17,16 @@ build-docker-ubuntu-%:
 
 build-docker: build-docker-ubuntu-24.04 build-docker-ubuntu-22.04 build-docker-ubuntu-20.04
 
-install: build
-	mkdir -p $(PREFIX)/lib/$(gcc -print-multiarch | sed -e 's/i.*86/i386/')
-	cp *.so $(PREFIX)/lib/$(gcc -print-multiarch | sed -e 's/i.*86/i386/')/
+install: build build32
+	sudo cp selkies_joystick_interposer.so /usr/lib/x86_64-linux-gnu/selkies_joystick_interposer.so
+	sudo cp selkies_joystick_interposer_i386.so /usr/lib/i386-linux-gnu/selkies_joystick_interposer.so
+
 clean:
 	rm -f *.so
 	sudo rm -f /dev/input/js0 /dev/input/event1000
 
 fake-devices:
+	@sudo mkdir -p /dev/input
 	@sudo touch /dev/input/js0 && sudo chmod 777 /dev/input/js0
 	@sudo touch /dev/input/event1000 && sudo chmod 777 /dev/input/event1000
 
@@ -42,10 +44,32 @@ evtest: build fake-devices
 
 sdltest: build fake-devices
 	gcc -o sdl_joystick_reader sdl-js-test.c -lSDL2
-	LD_PRELOAD=$(PWD)/selkies_joystick_interposer.so ./sdl_joystick_reader
+	LD_PRELOAD=$(PWD)/selkies_joystick_interposer.so SDL_JOYSTICK_DEVICE=/dev/input/event1000 ./sdl_joystick_reader
+
+sdltest32: build32 fake-devices
+	gcc -m32 -o sdl_joystick_reader_i386 sdl-js-test.c -lSDL2
+	LD_PRELOAD=$(PWD)/selkies_joystick_interposer_i386.so SDL_JOYSTICK_DEVICE=/dev/input/event1000 ./sdl_joystick_reader_i386
+
+sdltest-debug: build fake-devices
+	gcc -o sdl_joystick_reader sdl-js-test.c -g -I/usr/local/include -L/usr/local/lib -lSDL2
+	LD_PRELOAD=$(PWD)/selkies_joystick_interposer.so LD_LIBRARY_PATH=/usr/local/lib gdb ./sdl_joystick_reader
 
 winetest: build build32 fake-devices
 	LD_PRELOAD=$(PWD)/selkies_joystick_interposer.so wine control
 
 xvfbtest: build
 	LD_PRELOAD=$(PWD)/selkies_joystick_interposer.so Xvfb
+
+gamepadtool:
+	cd /tmp && curl -LO https://generalarcade.com/gamepadtool/linux/gamepadtool_1.2_amd64.deb && \
+		sudo apt-get install -y /tmp/gamepadtool_1.2_amd64.deb
+
+gamepadtool32:
+	cd /tmp && curl -LO https://generalarcade.com/gamepadtool/linux/gamepadtool_1.2_i386.deb && \
+		sudo apt-get install -y /tmp/gamepadtool_1.2_i386.deb
+
+gamepadtool-test: gamepadtool build fake-devices
+	LD_PRELOAD=$(PWD)/selkies_joystick_interposer.so SDL_JOYSTICK_DISABLE_UDEV=1 gamepad-tool
+
+gamepadtool32-test: gamepadtool32 build32 fake-devices
+	LD_PRELOAD=$(PWD)/selkies_joystick_interposer_i386.so SDL_JOYSTICK_DISABLE_UDEV=1 gamepad-tool

--- a/addons/js-interposer/README.md
+++ b/addons/js-interposer/README.md
@@ -23,7 +23,8 @@ If using Wine with `x86_64`, both `/usr/lib/x86_64-linux-gnu/selkies_joystick_in
 ```bash
 sudo mkdir -pm1777 /dev/input
 sudo touch /dev/input/js0 /dev/input/js1 /dev/input/js2 /dev/input/js3
-sudo chmod 777 /dev/input/js*
+sudo touch /dev/input/event1000 /dev/input/event1001 /dev/input/event1002 /dev/input/event1003
+sudo chmod 777 /dev/input/js* /dev/input/event*
 ```
 
 3. Use the below command before running your target application as well as Selkies-GStreamer for the interposer library to intercept joystick/gamepad events (the single quotes are required in the first line).
@@ -31,14 +32,12 @@ sudo chmod 777 /dev/input/js*
 ```bash
 export SELKIES_INTERPOSER='/usr/$LIB/selkies_joystick_interposer.so'
 export LD_PRELOAD="${SELKIES_INTERPOSER}${LD_PRELOAD:+:${LD_PRELOAD}}"
-export SDL_JOYSTICK_DEVICE=/dev/input/js0
 ```
 
 Otherwise, if you only need one architecture, the below is an equivalent command.
 
 ```bash
 export LD_PRELOAD="/usr/lib/x86_64-linux-gnu/selkies_joystick_interposer.so${LD_PRELOAD:+:${LD_PRELOAD}}"
-export SDL_JOYSTICK_DEVICE=/dev/input/js0
 ```
 
 You can replace `/usr/$LIB/selkies_joystick_interposer.so` with any non-root path of your choice if using the `.tar.gz` tarball. Make sure the correct `selkies_joystick_interposer.so` is installed in that path.

--- a/addons/js-interposer/README.md
+++ b/addons/js-interposer/README.md
@@ -58,6 +58,11 @@ This creates a new unix domain socket at `/tmp/selkies_js0.sock` and simulates j
 LD_PRELOAD='/usr/$LIB/selkies_joystick_interposer.so' jstest /dev/input/js0
 ```
 
+# Tested SDL versions
+
+- `2.30.0`: Ubuntu 24.04 - Working
+- `2.0.20`: Ubuntu 22.04 - Works when `SDL_JOYSTICK_DISABLE_UDEV=1`
+
 # Unix Domain Socket API
 
 The interposer uses a Unix Domain Socket to pass virtual Joystick events from the Socket Server to the Linux application. The Socket Server is responsible for creating the Unix Domain Socket and listening for connections to `/tmp/selkies_js*.sock` or `/tmp/selkies_event*.sock` for raw joystick or evdev joystick devices respectively.

--- a/addons/js-interposer/joystick_interposer.c
+++ b/addons/js-interposer/joystick_interposer.c
@@ -316,6 +316,10 @@ int interposer_open_socket(js_interposer_t *interposer)
         return -1;
     }
 
+    // Send architecture word length to tell client to send 64 vs 32bit wide messages.
+    unsigned char arch[1] = {sizeof(unsigned long)};
+    write(interposer->sockfd, arch, sizeof(arch));
+
     return 0;
 }
 

--- a/addons/js-interposer/joystick_interposer.c
+++ b/addons/js-interposer/joystick_interposer.c
@@ -415,7 +415,7 @@ int close( int fd )
     js_interposer_t *interposer = NULL;
     for (size_t i = 0; i < NUM_INTERPOSERS(); i++)
     {
-        if (fd == interposers[i].sockfd)
+        if (fd >= 0 && fd == interposers[i].sockfd)
         {
             interposer = &interposers[i];
             break;

--- a/addons/js-interposer/joystick_interposer.c
+++ b/addons/js-interposer/joystick_interposer.c
@@ -14,7 +14,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
     The ioctl() SYSCALL is interposed to fake the behavior of a input event character device.
     These ioctl requests were mostly reverse engineered from the joystick.h source and using the jstest command to test.
 
-    Note that some applications list the /dev/input/* directory to discover JS devices, to solve for this, create empty files at the following paths:
+    Note that some applications list the /dev/input/ directory to discover JS devices, to solve for this, create empty files at the following paths:
         sudo mkdir -pm1777 /dev/input
         sudo touch /dev/input/{js0,js1,js2,js3,event1000,event1001,event1002,event1003}
         sudo chmod 777 /dev/input/js* /dev/input/event*
@@ -487,8 +487,8 @@ int intercept_ev_ioctl(js_interposer_t *interposer, int fd, unsigned long reques
     va_end(args);
 
     struct input_absinfo *absinfo;
+    struct input_id *id;
     int fake_version = 0x010100;
-    char name[256] = "JS Interposer";
     int len;
 
     /* The EVIOCGABS(key) is a request to get the calibration values for the ABS type axes.
@@ -583,7 +583,7 @@ int intercept_ev_ioctl(js_interposer_t *interposer, int fd, unsigned long reques
         return 0;
 
     case 0x02: /* Handle EVIOCGID: device ID request. */
-        struct input_id *id = (struct input_id *)arg;
+        id = (struct input_id *)arg;
         // Populate the fake input_id for a joystick device
         id->bustype = BUS_VIRTUAL; // Example bus type (Virtual)
         id->vendor = 0x045E;       // Fake vendor ID (e.g., Microsoft)

--- a/addons/js-interposer/js-interposer-test.py
+++ b/addons/js-interposer/js-interposer-test.py
@@ -130,7 +130,14 @@ MAX_AXES = 64
 clients = {}
 
 XPAD_CONFIG = {
-    "name": "Xbox 360 Controller",
+    "name": "Selkies Controller",
+    # "name": "Xbox 360 Controller",
+    "vendor": 0x045e,  # Microsoft
+    "product": 0x028e, # Xbox360 Wired Controller
+    # "name": "Steam Virtual Gamepad pad 1",
+    # "vendor": 0x28de,  # Valve
+    # "product": 0x11ff, # Steam Virtual Gamepad
+    "version": 1,
     "btn_map": [
         BTN_A,
         BTN_B,
@@ -231,9 +238,12 @@ def make_config():
     btn_map[num_btns:MAX_BTNS] = [0 for i in range(num_btns, MAX_BTNS)]
     axes_map[num_axes:MAX_AXES] = [0 for i in range(num_axes, MAX_AXES)]
 
-    struct_fmt = "255sHH%dH%dB" % (MAX_BTNS, MAX_AXES)
+    struct_fmt = "255sHHHHH%dH%dB" % (MAX_BTNS, MAX_AXES)
     data = struct.pack(struct_fmt,
                        cfg["name"].encode(),
+                       cfg["vendor"],
+                       cfg["product"],
+                       cfg["version"],
                        num_btns,
                        num_axes,
                        *btn_map,

--- a/addons/js-interposer/sdl-js-test.c
+++ b/addons/js-interposer/sdl-js-test.c
@@ -1,6 +1,7 @@
 #include <SDL2/SDL.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <linux/input.h>
 
 void check_error(int result, const char *message)
 {
@@ -14,6 +15,20 @@ void check_error(int result, const char *message)
 
 int main(int argc, char *argv[])
 {
+    printf("Architecture sizeof input_event: %d bytes\n", sizeof(struct input_event));
+    SDL_version compiled;
+    SDL_version linked;
+
+    // Get the version against which the program was compiled.
+    SDL_VERSION(&compiled);
+    // Get the version of the linked SDL library at runtime.
+    SDL_GetVersion(&linked);
+
+    printf("Compiled with SDL version %d.%d.%d\n",
+           compiled.major, compiled.minor, compiled.patch);
+    printf("Running with SDL version %d.%d.%d\n",
+           linked.major, linked.minor, linked.patch);
+
     if (SDL_Init(SDL_INIT_JOYSTICK) < 0)
     {
         fprintf(stderr, "Failed to initialize SDL: %s\n", SDL_GetError());
@@ -42,6 +57,19 @@ int main(int argc, char *argv[])
     }
 
     printf("Joystick opened: %s\n", SDL_JoystickName(joystick));
+
+    // Get the joystick GUID.
+    SDL_JoystickGUID guid = SDL_JoystickGetGUID(joystick);
+    char guidStr[33];  // 32 hex digits plus null terminator.
+    SDL_JoystickGetGUIDString(guid, guidStr, sizeof(guidStr));
+    printf("Joystick GUID: %s\n", guidStr);
+    
+    // Print the vendor and product IDs in hexadecimal format.
+    Uint16 vendor = SDL_JoystickGetVendor(joystick);
+    Uint16 product = SDL_JoystickGetProduct(joystick);
+    printf("Joystick Vendor ID: 0x%04X\n", vendor);
+    printf("Joystick Product ID: 0x%04X\n", product);
+
 
     printf("Axes: %d\n", SDL_JoystickNumAxes(joystick));
     printf("Buttons: %d\n", SDL_JoystickNumButtons(joystick));

--- a/addons/js-interposer/sdl-js-test.c
+++ b/addons/js-interposer/sdl-js-test.c
@@ -1,0 +1,98 @@
+#include <SDL2/SDL.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+void check_error(int result, const char *message)
+{
+    if (result < 0)
+    {
+        fprintf(stderr, "%s: %s\n", message, SDL_GetError());
+        SDL_Quit();
+        exit(EXIT_FAILURE);
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    if (SDL_Init(SDL_INIT_JOYSTICK) < 0)
+    {
+        fprintf(stderr, "Failed to initialize SDL: %s\n", SDL_GetError());
+        return EXIT_FAILURE;
+    }
+
+    printf("SDL initialized.\n");
+
+    int num_joysticks = SDL_NumJoysticks();
+    if (num_joysticks < 1)
+    {
+        printf("No joysticks connected.\n");
+        SDL_Quit();
+        return EXIT_SUCCESS;
+    }
+
+    printf("Number of joysticks found: %d\n", num_joysticks);
+
+    SDL_Joystick *joystick = SDL_JoystickOpen(0);
+    fprintf(stderr, "SDL_JoystickOpen response: 0x%lx\n", (long int)joystick);
+    if (!joystick)
+    {
+        fprintf(stderr, "Could not open joystick: %s\n", SDL_GetError());
+        SDL_Quit();
+        return EXIT_FAILURE;
+    }
+
+    printf("Joystick opened: %s\n", SDL_JoystickName(joystick));
+
+    printf("Axes: %d\n", SDL_JoystickNumAxes(joystick));
+    printf("Buttons: %d\n", SDL_JoystickNumButtons(joystick));
+    printf("Hats: %d\n", SDL_JoystickNumHats(joystick));
+
+    SDL_Event event;
+    int running = 1;
+
+    printf("Reading joystick input. Press Ctrl+C to quit.\n");
+
+    while (running)
+    {
+        while (SDL_PollEvent(&event))
+        {
+            switch (event.type)
+            {
+            case SDL_JOYDEVICEADDED:
+                printf("Saw device added event\n");
+                break;
+
+            case SDL_JOYAXISMOTION:
+                printf("Axis %d moved to %d\n", event.jaxis.axis, event.jaxis.value);
+                break;
+
+            case SDL_JOYBUTTONDOWN:
+                printf("Button %d pressed\n", event.jbutton.button);
+                break;
+
+            case SDL_JOYBUTTONUP:
+                printf("Button %d released\n", event.jbutton.button);
+                break;
+
+            case SDL_JOYHATMOTION:
+                printf("Hat %d moved to %d\n", event.jhat.hat, event.jhat.value);
+                break;
+
+            case SDL_QUIT:
+                running = 0;
+                break;
+
+            default:
+                printf("Unhandled input event type: 0x%x\n", event.type);
+                break;
+            }
+        }
+
+        SDL_Delay(10); // Add a small delay to prevent CPU overuse
+    }
+
+    SDL_JoystickClose(joystick);
+    printf("Joystick closed.\n");
+    SDL_Quit();
+    return EXIT_SUCCESS;
+}

--- a/docs/component.md
+++ b/docs/component.md
@@ -186,7 +186,8 @@ The following paths are required to exist for the Joystick Interposer to pass th
 ```bash
 sudo mkdir -pm1777 /dev/input
 sudo touch /dev/input/js0 /dev/input/js1 /dev/input/js2 /dev/input/js3
-sudo chmod 777 /dev/input/js*
+sudo touch /dev/input/event1000 /dev/input/event1001 /dev/input/event1002 /dev/input/event1003
+sudo chmod 777 /dev/input/js* /dev/input/event*
 ```
 
 The following environment variables are required to be set in the environment each application is being run in to receive the joystick/gamepad input.
@@ -194,7 +195,6 @@ The following environment variables are required to be set in the environment ea
 ```bash
 export SELKIES_INTERPOSER='/usr/$LIB/selkies_joystick_interposer.so'
 export LD_PRELOAD="${SELKIES_INTERPOSER}${LD_PRELOAD:+:${LD_PRELOAD}}"
-export SDL_JOYSTICK_DEVICE=/dev/input/js0
 ```
 
 You can replace `/usr/$LIB/selkies_joystick_interposer.so` with any non-root path of your choice if using the `.tar.gz` tarball.

--- a/docs/start.md
+++ b/docs/start.md
@@ -185,10 +185,10 @@ export DISPLAY="${DISPLAY:-:0}"
 # Configure the Joystick Interposer
 export SELKIES_INTERPOSER='/usr/$LIB/selkies_joystick_interposer.so'
 export LD_PRELOAD="${SELKIES_INTERPOSER}${LD_PRELOAD:+:${LD_PRELOAD}}"
-export SDL_JOYSTICK_DEVICE=/dev/input/js0
 sudo mkdir -pm1777 /dev/input
 sudo touch /dev/input/js0 /dev/input/js1 /dev/input/js2 /dev/input/js3
-sudo chmod 777 /dev/input/js*
+sudo touch /dev/input/event1000 /dev/input/event1001 /dev/input/event1002 /dev/input/event1003
+sudo chmod 777 /dev/input/js* /dev/input/event*
 
 # Commented sections are optional but may be mandatory based on setup
 

--- a/src/selkies_gstreamer/__main__.py
+++ b/src/selkies_gstreamer/__main__.py
@@ -883,6 +883,7 @@ def main():
             metrics.start_http()
         loop.run_in_executor(None, lambda: webrtc_input.start_clipboard())
         loop.run_in_executor(None, lambda: webrtc_input.start_cursor_monitor())
+        loop.run_in_executor(None, lambda: webrtc_input.start_joystick())
         loop.run_in_executor(None, lambda: gpu_mon.start(gpu_id))
         loop.run_in_executor(None, lambda: hmac_turn_mon.start())
         loop.run_in_executor(None, lambda: turn_rest_mon.start())
@@ -898,13 +899,11 @@ def main():
             loop.run_until_complete(signalling.connect())
             loop.run_until_complete(audio_signalling.connect())
 
-            # asyncio.ensure_future(signalling.start(), loop=loop)
             asyncio.ensure_future(audio_signalling.start(), loop=loop)
             loop.run_until_complete(signalling.start())
 
             app.stop_pipeline()
             audio_app.stop_pipeline()
-            webrtc_input.stop_js_server()
     except Exception as e:
         logger.error("Caught exception: %s" % e)
         traceback.print_exc()

--- a/src/selkies_gstreamer/__main__.py
+++ b/src/selkies_gstreamer/__main__.py
@@ -881,7 +881,6 @@ def main():
         asyncio.ensure_future(server.run(), loop=loop)
         if using_metrics_http:
             metrics.start_http()
-        loop.run_until_complete(webrtc_input.connect())
         loop.run_in_executor(None, lambda: webrtc_input.start_clipboard())
         loop.run_in_executor(None, lambda: webrtc_input.start_cursor_monitor())
         loop.run_in_executor(None, lambda: gpu_mon.start(gpu_id))
@@ -895,7 +894,7 @@ def main():
                 metrics.initialize_webrtc_csv_file(args.webrtc_statistics_dir)
             asyncio.ensure_future(app.handle_bus_calls(), loop=loop)
             asyncio.ensure_future(audio_app.handle_bus_calls(), loop=loop)
-
+            loop.run_until_complete(webrtc_input.connect())
             loop.run_until_complete(signalling.connect())
             loop.run_until_complete(audio_signalling.connect())
 

--- a/src/selkies_gstreamer/gamepad.py
+++ b/src/selkies_gstreamer/gamepad.py
@@ -23,6 +23,9 @@ STANDARD_XPAD_CONFIG = {
     # Linux xpad has 11 buttons and 8 axes.
 
     "name": "Selkies Controller",
+    "vendor": 0x045e,  # Microsoft
+    "product": 0x028e, # Xbox360 Wired Controller
+    "version": 1,
     "btn_map": [
         BTN_A,      # 0
         BTN_B,      # 1
@@ -161,6 +164,9 @@ class SelkiesGamepadBase:
             return None
 
         name = f"{self.config["name"]} {self.js_index + 1}"
+        vendor = self.config["vendor"]
+        product = self.config["product"]
+        version = self.config["version"]
         num_btns = len(self.config["btn_map"])
         num_axes = len(self.config["axes_map"])
 
@@ -171,9 +177,12 @@ class SelkiesGamepadBase:
         btn_map[num_btns:MAX_BTNS] = [0 for i in range(num_btns, MAX_BTNS)]
         axes_map[num_axes:MAX_AXES] = [0 for i in range(num_axes, MAX_AXES)]
 
-        struct_fmt = "255sHH%dH%dB" % (MAX_BTNS, MAX_AXES)
+        struct_fmt = "255sHHHHH%dH%dB" % (MAX_BTNS, MAX_AXES)
         data = struct.pack(struct_fmt,
                            name.encode(),
+                           vendor,
+                           product,
+                           version,
                            num_btns,
                            num_axes,
                            *btn_map,

--- a/src/selkies_gstreamer/webrtc_input.py
+++ b/src/selkies_gstreamer/webrtc_input.py
@@ -92,6 +92,7 @@ class WebRTCInput:
 
         # Map of gamepad numbers to socket paths
         self.js_socket_path_map = {i: os.path.join(js_socket_path, "selkies_js%d.sock" % i) for i in range(4)}
+        self.ev_socket_path_map = {i: os.path.join(js_socket_path, "selkies_event%d.sock" % (1000 + i)) for i in range(4)}
 
         # Map of gamepad number to SelkiesGamepad objects
         self.js_map = {}
@@ -172,16 +173,20 @@ class WebRTCInput:
 
         logger.info("creating selkies gamepad for js%d, name: '%s', buttons: %d, axes: %d" % (js_num, name, num_btns, num_axes))
 
-        socket_path = self.js_socket_path_map.get(js_num, None)
-        if socket_path is None:
+        js_socket_path = self.js_socket_path_map.get(js_num, None)
+        if js_socket_path is None:
             logger.error("failed to connect js%d because socket_path was not found" % js_num)
             return
 
-        # Create the gamepad and button config.
-        js = SelkiesGamepad(socket_path, self.loop)
-        js.set_config(name, num_btns, num_axes)
+        ev_socket_path = self.ev_socket_path_map.get(js_num, None)
+        if ev_socket_path is None:
+            logger.error("failed to connect EV joystick %d because socket_path was not found" % js_num)
+            return
 
-        asyncio.ensure_future(js.run_server(), loop=self.loop)
+        # Create the gamepad and button config.
+        js = SelkiesGamepad(js_socket_path, ev_socket_path, self.loop)
+        js.set_config(name, num_btns, num_axes)
+        js.run_server()
 
         self.js_map[js_num] = js
 

--- a/src/selkies_gstreamer/webrtc_input.py
+++ b/src/selkies_gstreamer/webrtc_input.py
@@ -166,7 +166,7 @@ class WebRTCInput:
             self.uinput_mouse_socket.sendto(
                 data, self.uinput_mouse_socket_path)
 
-    def __js_connect(self):
+    def start_joystick(self):
         """Connect virtual joystick using Selkies Joystick Interposer
         """
         assert self.loop is not None
@@ -192,7 +192,7 @@ class WebRTCInput:
 
             self.js_map[js_index] = js
 
-    def __js_disconnect(self, js_num=None):
+    def stop_joystick(self, js_num=None):
         if js_num is None:
             # stop all gamepads.
             for js_num, js in self.js_map.items():
@@ -238,10 +238,8 @@ class WebRTCInput:
         logger.info("Connecting mouse")
         self.__mouse_connect()
         logger.info("Connecting joysticks")
-        self.__js_connect()
 
     def disconnect(self):
-        self.__js_disconnect()
         self.__mouse_disconnect()
 
     def reset_keyboard(self):
@@ -566,9 +564,6 @@ class WebRTCInput:
                 with open("/tmp/cursor_%d.png" % cursor.cursor_serial, 'wb') as debugf:
                     debugf.write(data)
             return data
-
-    def stop_js_server(self):
-        self.__js_disconnect()
 
     def on_message(self, msg):
         """Handles incoming input messages

--- a/src/selkies_gstreamer/webrtc_input.py
+++ b/src/selkies_gstreamer/webrtc_input.py
@@ -208,7 +208,6 @@ class WebRTCInput:
             del self.js_map[js_num]
 
     def __js_emit_btn(self, js_num, btn_num, btn_val):
-        logger.info(f"sending js{js_num} button {btn_num} with value {btn_val}, map: {self.js_map}")
         js = self.js_map.get(js_num, None)
         if js is None:
             logger.error("cannot send button because js%d is not connected" % js_num)
@@ -449,6 +448,8 @@ class WebRTCInput:
         self.clipboard_running = False
 
     def start_cursor_monitor(self):
+        while self.xdisplay is None:
+            time.sleep(0.5)
         if not self.xdisplay.has_extension('XFIXES'):
             if self.xdisplay.query_extension('XFIXES') is None:
                 logger.error(
@@ -648,7 +649,7 @@ class WebRTCInput:
                 logger.info(f"joystick {js_num}: '{name}' connected with {num_axes} axes and {num_btns} buttons")
             elif toks[1] == 'd':
                 js_num = int(toks[2])
-                self.__js_disconnect(js_num)
+                logger.info(f"joystick {js_num}: disconnected")
             elif toks[1] == 'b':
                 js_num = int(toks[2])
                 btn_num = int(toks[3])


### PR DESCRIPTION
## Changes
- Fixes joystick interposer compatibility with Retroarch, wine, and RPCS3.
- All 4 interposed joysticks are now initialized automatically on startup. 
- Intercepts calls to `open64` and makes socket non-blocking when added to an `epoll`.
- Implements support for interposing `/dev/input/event*` joystick devices.
- The `SDL_JOYSTICK_DEVICE` workaround for SDL apps is no longer needed.
- Fixes #168
- Fixes issues with multiple joysticks.
- Fixed minor bug with cursor monitor thread not starting up.

## Application Specific
### General
All interposed joysticks will now appear connected even if no joystick is connected to the browser. This makes for a better hotplugging experience.
![image](https://github.com/user-attachments/assets/608e168d-9e24-4157-b6bb-85ea93c65afc)
 
### Retroarch
To use with retroarch, edit your `retroarch.cfg` (at `~/.config/retroarch/retroarch.cfg`) and set:
```
input_joypad_driver = "linuxraw"
```
### RPCS3
Select `SDL` as controller handler then select `Selkies Controller 1` from the device list.
![Screenshot from 2025-02-07 00-08-58](https://github.com/user-attachments/assets/fa9ef87f-f098-4366-b27e-73265286b5f9)
### Wine
Run `wine control` and then open the `Game Controllers` app to test joystick support.
![Screenshot from 2025-02-07 00-10-19](https://github.com/user-attachments/assets/1db549e9-3945-4596-9230-2a4a840b83e0)

## Testing
### `nvidia-egl-desktop:24.04`

`Dockerfile.egl.jstest`:
```dockerfile
FROM ghcr.io/selkies-project/nvidia-egl-desktop:24.04
ARG CACHEBUST

USER root

# Update interposer library and selkies python
RUN cd /opt && git clone https://github.com/selkies-project/selkies-gstreamer.git -b fix-js-interposer
RUN \
    cd /opt/selkies-gstreamer && \
    cp src/selkies_gstreamer/* src/selkies_gstreamer/webrtc_input.py /usr/local/lib/python3.*/dist-packages/selkies_gstreamer/
RUN \
    cd /opt/selkies-gstreamer/addons/js-interposer && \
    make deps && \
    make
# Workaround until entrypoint segfault is resolved.
RUN \
    echo 'cp /opt/selkies-gstreamer/addons/js-interposer/selkies_joystick_interposer.so /usr/lib/x86_64-linux-gnu/selkies_joystick_interposer.so' >> /etc/bash.bashrc && \
    echo 'cp /opt/selkies-gstreamer/addons/js-interposer/selkies_joystick_interposer_i386.so /usr/lib/i386-linux-gnu/selkies_joystick_interposer.so' >> /etc/bash.bashrc

# Update entrypoint scripts
RUN \
    cd /opt && git clone https://github.com/selkies-project/docker-nvidia-egl-desktop.git -b update-joystick-support && \
    cd docker-nvidia-egl-desktop && \
    cp entrypoint.sh /etc/entrypoint.sh && \
    cp selkies-gstreamer-entrypoint.sh /etc/selkies-gstreamer-entrypoint.sh && \
    chmod +x /etc/entrypoint.sh /etc/selkies-gstreamer-entrypoint.sh
    
USER ubuntu
```
Build and run:
```bash
docker build --build-arg CACHEBUST=$(date +%s) -f Dockerfile.egl.jstest -t ghcr.io/selkies-project/nvidia-egl-desktop:24.04-jstest .
```
```bash
docker run --rm --name egl -it -d --gpus 1 --tmpfs /dev/shm:rw -e TZ=UTC -e DISPLAY_SIZEW=1920 -e DISPLAY_SIZEH=1080 -e DISPLAY_REFRESH=60 -e DISPLAY_DPI=96 -e DISPLAY_CDEPTH=24 -e SELKIES_ENABLE_BASIC_AUTH=false -e SELKIES_ENCODER=nvh264enc -e SELKIES_VIDEO_BITRATE=8000 -e SELKIES_FRAMERATE=60 -e SELKIES_AUDIO_BITRATE=128000 -p 8080:8080 ghcr.io/selkies-project/nvidia-egl-desktop:24.04-jstest
```

### `gst-py-example:main-ubuntu24.04`

`Dockerfile.example.jstest`
```dockerfile
FROM ghcr.io/selkies-project/selkies-gstreamer/gst-py-example:main-ubuntu24.04
ARG CACHEBUST

USER root

# Update interposer library and selkies python
RUN cd /opt && git clone https://github.com/selkies-project/selkies-gstreamer.git -b fix-js-interposer
RUN \
    cd /opt/selkies-gstreamer && \
    cp src/selkies_gstreamer/* /usr/local/lib/python3.*/dist-packages/selkies_gstreamer/
RUN \
    cd /opt/selkies-gstreamer/addons/js-interposer && \
    make deps && \
    make
RUN \
    cp /opt/selkies-gstreamer/addons/js-interposer/selkies_joystick_interposer.so /usr/lib/x86_64-linux-gnu/selkies_joystick_interposer.so && \
    cp /opt/selkies-gstreamer/addons/js-interposer/selkies_joystick_interposer_i386.so /usr/lib/i386-linux-gnu/selkies_joystick_interposer.so

# Update entrypoint script
RUN \
    cp /opt/selkies-gstreamer/addons/example/entrypoint.sh /etc/entrypoint.sh && \
    cp /opt/selkies-gstreamer/addons/example/selkies-gstreamer-entrypoint.sh /etc/selkies-gstreamer-entrypoint.sh
    
USER ubuntu
```

Build:
```bash
docker build --build-arg CACHEBUST=$(date +%s) -f Dockerfile.example.jstest -t ghcr.io/selkies-project/selkies-gstreamer/gst-py-example:main-ubuntu24.04-jstest .
```

Run:
```bash
docker run --name selkies -it -d --rm -e SELKIES_ENABLE_BASIC_AUTH=false -e SELKIES_TURN_PROTOCOL=udp -e SELKIES_TURN_PORT=3478 -e TURN_MIN_PORT=65534 -e TURN_MAX_PORT=65535 -p 8080:8080 -p 3478:3478 -p 3478:3478/udp -p 65534-65535:65534-65535 -p 65534-65535:65534-65535/udp ghcr.io/selkies-project/selkies-gstreamer/gst-py-example:main-ubuntu24.04-jstest
```