### PR TITLE
add initial remapping logic and ingest remapping from SDL_GameControllerDB

### DIFF
--- a/addons/gst-web-core/gendb.js
+++ b/addons/gst-web-core/gendb.js
@@ -1,0 +1,105 @@
+const fs = require('fs');
+const path = require('path');
+
+const DB_URL = 'https://raw.githubusercontent.com/mdqinc/SDL_GameControllerDB/master/gamecontrollerdb.txt';
+const OUTPUT_DIR = 'dist/jsdb';
+
+const VALID_MAPPINGS = new Set([
+  'a', 'b', 'x', 'y', 'back', 'guide', 'start', 'leftstick', 'rightstick',
+  'leftshoulder', 'rightshoulder', 'lefttrigger', 'righttrigger',
+  'dpup', 'dpdown', 'dpleft', 'dpright',
+  'leftx', 'lefty', 'rightx', 'righty'
+]);
+
+function parseSdlLine(line) {
+  if (line.startsWith('#') || line.trim() === '') {
+    return null;
+  }
+
+  const parts = line.split(',');
+  const guid = parts[0];
+
+  if (guid.length < 20) return null;
+
+  const vendor = (guid.substring(10, 12) + guid.substring(8, 10)).toLowerCase();
+  const product = (guid.substring(18, 20) + guid.substring(16, 18)).toLowerCase();
+  const filename = `${vendor}-${product}.json`;
+
+  const mapping = {};
+
+  for (let i = 2; i < parts.length; i++) {
+    const mappingPart = parts[i];
+    if (!mappingPart.includes(':')) continue;
+
+    const [sdlName, rawValue] = mappingPart.split(':');
+
+    if (!VALID_MAPPINGS.has(sdlName)) {
+      continue;
+    }
+
+    const typeChar = rawValue.charAt(0);
+
+    if (typeChar === 'a' || typeChar === 'b') {
+      const index = parseInt(rawValue.substring(1), 10);
+      mapping[sdlName] = { type: typeChar === 'a' ? 'axis' : 'button', index: index };
+    } else if (typeChar === 'h') {
+      const hatParts = rawValue.substring(1).split('.');
+      const index = parseInt(hatParts[0], 10);
+      const mask = parseInt(hatParts[1], 10);
+      mapping[sdlName] = { type: 'hat', index: index, mask: mask };
+    }
+  }
+
+  if (Object.keys(mapping).length > 0) {
+    return { filename, mapping };
+  }
+
+  return null;
+}
+
+async function main() {
+  console.log(`Fetching controller DB from ${DB_URL}...`);
+
+  let fileContent;
+  try {
+    const response = await fetch(DB_URL);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch: ${response.status} ${response.statusText}`);
+    }
+    fileContent = await response.text();
+    console.log('Successfully fetched controller DB.');
+  } catch (error) {
+    console.error('Error fetching game controller DB:', error);
+    return;
+  }
+  
+  console.log('Starting conversion...');
+
+  if (!fs.existsSync(OUTPUT_DIR)) {
+    fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+    console.log(`Created output directory: ${OUTPUT_DIR}`);
+  }
+
+  const lines = fileContent.split('\n');
+
+  let convertedCount = 0;
+  let skippedCount = 0;
+
+  for (const line of lines) {
+    const result = parseSdlLine(line);
+    if (result) {
+      const outputPath = path.join(OUTPUT_DIR, result.filename);
+      const jsonContent = JSON.stringify(result.mapping, null, 2);
+      fs.writeFileSync(outputPath, jsonContent);
+      convertedCount++;
+    } else {
+      skippedCount++;
+    }
+  }
+
+  console.log(`\nConversion complete!`);
+  console.log(`  Successfully converted and wrote ${convertedCount} mapping files.`);
+  console.log(`  Skipped ${skippedCount} lines (comments, empty, or invalid).`);
+}
+
+main();

--- a/addons/gst-web-core/lib/gamepad.js
+++ b/addons/gst-web-core/lib/gamepad.js
@@ -1,26 +1,22 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
- *
- * This file incorporates work covered by the following copyright and
- * permission notice:
- *
- *   Copyright 2019 Google LLC
- *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
  */
 
-// Based on https://github.com/parsec-cloud/web-client/blob/master/src/gamepad.js
+const STANDARD_LAYOUT = {
+    buttons: {
+        'a': 0, 'b': 1, 'x': 2, 'y': 3,
+        'leftshoulder': 4, 'rightshoulder': 5,
+        'lefttrigger': 6, 'righttrigger': 7,
+        'back': 8, 'start': 9,
+        'leftstick': 10, 'rightstick': 11,
+        'dpup': 12, 'dpdown': 13, 'dpleft': 14, 'dpright': 15,
+        'guide': 16
+    },
+    axes: {
+        'leftx': 0, 'lefty': 1, 'rightx': 2, 'righty': 3
+    }
+};
 
 /*eslint no-unused-vars: ["error", { "vars": "local" }]*/
 export const GP_TIMEOUT = 16;
@@ -28,9 +24,7 @@ const MAX_GAMEPADS = 4;
 
 export class GamepadManager {
     constructor(gamepad, onButton, onAxis) {
-        this.gamepad = gamepad; 
-        this.numButtons = 0;
-        this.numAxes = 0;
+        this.gamepad = gamepad;
         this.onButton = onButton;
         this.onAxis = onAxis;
         this.state = {};
@@ -42,21 +36,70 @@ export class GamepadManager {
 
     enable() {
         if (!this._active) {
-             this._active = true;
-             console.log("GamepadManager polling activated.");
+            this._active = true;
+            console.log("GamepadManager polling activated.");
         }
     }
 
     disable() {
-         if (this._active) {
+        if (this._active) {
             this._active = false;
             console.log("GamepadManager polling deactivated.");
-         }
+        }
+    }
+
+    /**
+     * Asynchronously loads a remap profile for a given gamepad ID.
+     * @param {string} gamepadId The "vendor-product" ID of the gamepad.
+     * @param {object} state The internal state object for the specific gamepad.
+     */
+    async _loadRemapProfile(gamepadId, state) {
+        state.loadingProfile = true;
+        const url = `jsdb/${gamepadId}.json`;
+
+        try {
+            console.log(`Attempting to load mapping for ${gamepadId} from ${url}`);
+            const response = await fetch(url);
+
+            if (!response.ok) {
+                if (response.status === 404) {
+                    console.log(`No custom mapping file found for ${gamepadId}. Using browser default.`);
+                } else {
+                    console.warn(`Failed to load mapping for ${gamepadId} (HTTP Status: ${response.status})`);
+                }
+                state.remapProfile = {};
+                return;
+            }
+
+            const dbEntryMapping = await response.json();
+            console.log(`Successfully loaded and applying custom mapping for: ${gamepadId}`);
+
+            const reverseMap = { buttons: {}, axes: {} };
+            for (const sdlName in dbEntryMapping) {
+                const raw = dbEntryMapping[sdlName];
+                if (raw.type === 'button') {
+                    const standardIndex = STANDARD_LAYOUT.buttons[sdlName];
+                    if (standardIndex !== undefined) {
+                        reverseMap.buttons[raw.index] = standardIndex;
+                    }
+                } else if (raw.type === 'axis') {
+                    const standardIndex = STANDARD_LAYOUT.axes[sdlName];
+                    if (standardIndex !== undefined) {
+                        reverseMap.axes[raw.index] = standardIndex;
+                    }
+                }
+            }
+            state.remapProfile = reverseMap;
+
+        } catch (error) {
+            console.error(`Error fetching or parsing mapping file for ${gamepadId}:`, error);
+            state.remapProfile = {};
+        }
     }
 
     _poll() {
         if (!this._active) {
-            return; // Do nothing if disabled
+            return;
         }
         const gamepads = navigator.getGamepads();
         for (let i = 0; i < MAX_GAMEPADS; i++) {
@@ -65,44 +108,105 @@ export class GamepadManager {
                 let gpState = this.state[i];
 
                 if (!gpState) {
-                    gpState = this.state[i] = { axes: new Array(currentGp.axes.length).fill(0), buttons: new Array(currentGp.buttons.length).fill(0) };
+                    gpState = this.state[i] = {
+                        axes: new Array(currentGp.axes.length).fill(0),
+                        buttons: new Array(currentGp.buttons.length).fill(0),
+                        dpadAxisState: { 12: false, 13: false, 14: false, 15: false },
+                        remapProfile: null,
+                        loadingProfile: false,
+                    };
+
+                    if (currentGp.mapping !== 'standard') {
+                        const match = currentGp.id.match(/Vendor: ([0-9a-f]{4}) Product: ([0-9a-f]{4})/i);
+                        if (match && !gpState.loadingProfile) {
+                            const vendor = match[1].toLowerCase();
+                            const product = match[2].toLowerCase();
+                            const gamepadId = `${vendor}-${product}`;
+                            this._loadRemapProfile(gamepadId, gpState);
+                        }
+                    }
                 }
 
                 if (gpState.buttons.length !== currentGp.buttons.length) {
                     gpState.buttons = new Array(currentGp.buttons.length).fill(0);
                 }
                 if (gpState.axes.length !== currentGp.axes.length) {
-                     gpState.axes = new Array(currentGp.axes.length).fill(0);
+                    gpState.axes = new Array(currentGp.axes.length).fill(0);
                 }
 
-
+                // --- Button Polling ---
                 for (let x = 0; x < currentGp.buttons.length; x++) {
                     if (currentGp.buttons[x] === undefined) continue;
                     const value = currentGp.buttons[x].value;
                     const pressed = currentGp.buttons[x].pressed;
 
-                    // Check against previous state
                     if (gpState.buttons[x] !== value) {
-                        this.onButton(i, x, value, pressed);
-                        gpState.buttons[x] = value; 
+                        let buttonIndex = x;
+                        if (gpState.remapProfile) {
+                            const standardIndex = gpState.remapProfile.buttons[x];
+                            if (standardIndex !== undefined) {
+                                buttonIndex = standardIndex;
+                            } else {
+                                continue;
+                            }
+                        }
+                        this.onButton(i, buttonIndex, value, pressed);
+                        gpState.buttons[x] = value;
                     }
                 }
 
+                // --- Axis Polling ---
                 for (let x = 0; x < currentGp.axes.length; x++) {
                     if (currentGp.axes[x] === undefined) continue;
 
                     let val = currentGp.axes[x];
-                    // Apply deadzone
                     if (Math.abs(val) < 0.05) val = 0;
 
-                    // Check against previous state
                     if (gpState.axes[x] !== val) {
-                        this.onAxis(i, x, val);
+                        const isUniversalDpadAxis = (currentGp.mapping !== 'standard' && (x === 4 || x === 5));
+
+                        if (!isUniversalDpadAxis) {
+                            let axisIndex = x;
+                            if (gpState.remapProfile && gpState.remapProfile.axes[x] !== undefined) {
+                                axisIndex = gpState.remapProfile.axes[x];
+                            }
+                            this.onAxis(i, axisIndex, val);
+                        }
+                        
                         gpState.axes[x] = val;
                     }
                 }
 
+                // --- D-Pad Axis Remapping for Non-Standard Controllers ---
+                if (currentGp.mapping !== 'standard' && currentGp.axes.length >= 6) {
+                    const axisThreshold = 0.5;
+                    const dpad = {
+                        up: currentGp.axes[5] < -axisThreshold,    // Standard Button 12
+                        down: currentGp.axes[5] > axisThreshold,  // Standard Button 13
+                        left: currentGp.axes[4] < -axisThreshold,   // Standard Button 14
+                        right: currentGp.axes[4] > axisThreshold, // Standard Button 15
+                    };
+
+                    if (dpad.up !== gpState.dpadAxisState[12]) {
+                        this.onButton(i, 12, dpad.up ? 1 : 0, dpad.up);
+                        gpState.dpadAxisState[12] = dpad.up;
+                    }
+                    if (dpad.down !== gpState.dpadAxisState[13]) {
+                        this.onButton(i, 13, dpad.down ? 1 : 0, dpad.down);
+                        gpState.dpadAxisState[13] = dpad.down;
+                    }
+                    if (dpad.left !== gpState.dpadAxisState[14]) {
+                        this.onButton(i, 14, dpad.left ? 1 : 0, dpad.left);
+                        gpState.dpadAxisState[14] = dpad.left;
+                    }
+                    if (dpad.right !== gpState.dpadAxisState[15]) {
+                        this.onButton(i, 15, dpad.right ? 1 : 0, dpad.right);
+                        gpState.dpadAxisState[15] = dpad.right;
+                    }
+                }
+
             } else if (this.state[i]) {
+                // Gamepad disconnected
                 delete this.state[i];
             }
         }

--- a/addons/gst-web-core/package.json
+++ b/addons/gst-web-core/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "serve": "vite",
     "build": "vite build",
+    "postbuild": "node gendb.js",
     "preview": "vite preview"
   },
   "author": "Selkies",


### PR DESCRIPTION
This translates another project to automatically remap any controller to a "standard" controller clientside in chromium. We ingest a little json remapping file based on their ids if it is not a standard controller as reported by chromium. 

The axis will be a crapshoot but I bought a couple junky controllers that are switch based and they all work. At the very least this expands support past just PS and Xbox controllers and adds the third big player. 

For controllers that might not map 100% the only limitation will be the dpad might not work, the other buttons should map properly. 

To the user this is all seamless we do not need any interaction from the dashboard, their switch controller will just work like an xbox one. 