### PR TITLE
add a RO websocket with no input handling

### DIFF
--- a/src/selkies/selkies.py
+++ b/src/selkies/selkies.py
@@ -3339,7 +3339,7 @@ async def _send_stats_periodically_ws(websocket, shared_data, interval_seconds=5
     except Exception as e:
         data_logger.error(f"Stats sender (WS) error: {e}", exc_info=True)
 
-async def on_resize_handler(res_str, current_app_instance, data_server_instance=None, display_id='primary'):
+async def on_resize_handler(res_str, current_app_instance, data_server_instance=None, display_id='primary', ro_data_server_instance=None):
     """
     Handles client resize request. Updates the state for a specific display and triggers a full reconfiguration.
     """
@@ -3456,6 +3456,12 @@ async def main():
         type=int,
         help="The port for the data websocket server. Overrides the CUSTOM_WS_PORT environment variable.",
     )
+    parser.add_argument(
+        "--view_only_port",
+        default=os.environ.get("CUSTOM_RO_WS_PORT", "8083"),
+        type=int,
+        help="The port for the view-only data websocket server. Overrides the CUSTOM_RO_WS_PORT environment variable.",
+    )
     parser.add_argument("--debug", action="store_true", help="Enable debug logging")
     args, unknown = parser.parse_known_args()
     global TARGET_FRAMERATE, TARGET_VIDEO_BITRATE_KBPS
@@ -3504,6 +3510,19 @@ async def main():
         audio_device_name=args.audio_device_name,
         cli_args=args,
     )
+    ro_data_server = DataStreamingServer(
+        port=args.view_only_port,
+        app=app,
+        uinput_mouse_socket=UINPUT_MOUSE_SOCKET,
+        js_socket_path=JS_SOCKET_PATH,
+        enable_clipboard=ENABLE_CLIPBOARD,
+        enable_cursors=ENABLE_CURSORS,
+        cursor_size=CURSOR_SIZE,
+        cursor_scale=1.0,
+        cursor_debug=DEBUG_CURSORS,
+        audio_device_name=args.audio_device_name,
+        cli_args=args,
+    )
     app.data_streaming_server = data_server
 
     input_handler = InputHandler(
@@ -3538,7 +3557,9 @@ async def main():
 
     tasks_to_run = []
     data_server_task = asyncio.create_task(data_server.run_server(), name="DataServer")
+    ro_data_server_task = asyncio.create_task(ro_data_server.run_server(), name="RODataServer")
     tasks_to_run.append(data_server_task)
+    tasks_to_run.append(ro_data_server_task)
 
     if hasattr(input_handler, "connect"):  # This refers to the global input_handler
         tasks_to_run.append(

--- a/src/selkies/selkies.py
+++ b/src/selkies/selkies.py
@@ -3515,7 +3515,7 @@ async def main():
         app=app,
         uinput_mouse_socket=UINPUT_MOUSE_SOCKET,
         js_socket_path=JS_SOCKET_PATH,
-        enable_clipboard=ENABLE_CLIPBOARD,
+        enable_clipboard=False,
         enable_cursors=ENABLE_CURSORS,
         cursor_size=CURSOR_SIZE,
         cursor_scale=1.0,


### PR DESCRIPTION

**Reference the issue numbers and reviewers**
<!--
Use `#` and `@` to tag issues and reviewers.
-->
Closes #203 
**Explain relevant issues and how this pull request solves them**
<!--
A clear and concise description of the pull request. Ex. This pull request addresses issue # by [...]
-->
The goal here is to provide a mechanism to ensure a view-only connection, per issue #203 .

Currently, this is handled on the frontend, meaning as long as the websocket is open, it is possible to send keystrokes through.

Adding another endpoint allows for clean separation and smooth integration with reverse proxies/middlewares/auth setups out there.

This helps a use case where a user has got an established setup around that or wants to integrate with their platform - so custom auth middlewares can smoothly handle routing users between RW/RO endpoints.


**Describe the changes in code and its dependencies and justify that they work as intended after testing**
<!--
A clear and concise description of what you have changed. Please confirm that the pull request does not break this project by testing it in depth.
-->

This adds a RO DataStreamingServer on a separate port. It sets None as its input handler, meaning all inputs are skipped. 


**Describe alternatives you've considered**
<!--
A clear and concise description of any alternative solutions or features you've considered other than this pull request, if applicable.
-->

That was the only way I could figure out that prevents sending keystrokes and is not susceptible to misuse/malicious actors. 

**Additional context**
<!--
Add any other context or screenshots about the pull request here.
-->

 - [ x ] I confirm that this pull request is relevant to the scope of this project. If you know that upstream projects are the cause of this problem, please file the pull request there.
 - [ x ] I confirm that this pull request has been tested thoroughly and to the best of my knowledge that additional unintended problems do not arise.
 - [ x ] I confirm that the style of the changed code conforms to the overall style of the project.
 - [ x ] I confirm that I have read other open and closed pull requests and that duplicates do not exist.
 - [ x ] I confirm that I have justified the need for this pull request and that the changes reflect the fix for the specified problem.
 - [ x ] I confirm that no portion of this pull request contains credentials or other private information, and it is my own responsibility to protect my privacy.
 - [ x ] I confirm that the authors of this pull request does not willfully breach or infringe legal regulations, in any and all global law, regarding trademarks, trade names, logos, patents, or any and all other forms of external intellectual property, as well as adhering to software license terms of open-source and proprietary software projects.
