### PR TITLE
Updated some image urls to selkies-gstreamer and fixed pip package error

### DIFF
--- a/addons/example/Dockerfile
+++ b/addons/example/Dockerfile
@@ -5,11 +5,11 @@
 # Supported base images: Ubuntu 24.04, 22.04, 20.04
 ARG DISTRIB_IMAGE=ubuntu
 ARG DISTRIB_RELEASE=24.04
-ARG GSTREAMER_BASE_IMAGE=ghcr.io/selkies-project/selkies/gstreamer
+ARG GSTREAMER_BASE_IMAGE=ghcr.io/selkies-project/selkies-gstreamer/gstreamer
 ARG GSTREAMER_BASE_IMAGE_RELEASE=main
 ARG PY_BUILD_IMAGE=ghcr.io/selkies-project/selkies/py-build:main
-ARG WEB_IMAGE=ghcr.io/selkies-project/selkies/gst-web:main
-ARG JS_BASE_IMAGE=ghcr.io/selkies-project/selkies/js-interposer
+ARG WEB_IMAGE=ghcr.io/selkies-project/selkies-gstreamer/gst-web:main
+ARG JS_BASE_IMAGE=ghcr.io/selkies-project/selkies-gstreamer/js-interposer
 ARG JS_BASE_IMAGE_RELEASE=main
 FROM ${GSTREAMER_BASE_IMAGE}:${GSTREAMER_BASE_IMAGE_RELEASE}-${DISTRIB_IMAGE}${DISTRIB_RELEASE} AS selkies
 FROM ${PY_BUILD_IMAGE} AS selkies-build
@@ -258,13 +258,13 @@ ARG PYPI_PACKAGE=selkies
 ARG PACKAGE_VERSION=0.0.0.dev0
 ARG PIP_BREAK_SYSTEM_PACKAGES=1
 COPY --chown=1000:1000 --from=selkies-build /opt/pypi/dist/${PYPI_PACKAGE}-${PACKAGE_VERSION}-py3-none-any.whl .
-RUN pip3 install --no-cache-dir --force-reinstall /opt/${PYPI_PACKAGE}-${PACKAGE_VERSION}-py3-none-any.whl
+RUN pip3 install --no-cache-dir --force-reinstall --ignore-installed /opt/${PYPI_PACKAGE}-${PACKAGE_VERSION}-py3-none-any.whl
 
 # Copy scripts and configurations used to start the container
 COPY --chown=1000:1000 entrypoint.sh /etc/entrypoint.sh
 RUN chmod -f 755 /etc/entrypoint.sh
-COPY --chown=1000:1000 selkies-entrypoint.sh /etc/selkies-entrypoint.sh
-RUN chmod -f 755 /etc/selkies-entrypoint.sh
+COPY --chown=1000:1000 selkies-gstreamer-entrypoint.sh /etc/selkies-gstreamer-entrypoint.sh
+RUN chmod -f 755 /etc/selkies-gstreamer-entrypoint.sh
 COPY --chown=1000:1000 supervisord.conf /etc/supervisord.conf
 RUN chmod -f 755 /etc/supervisord.conf
 


### PR DESCRIPTION
Fixed build failing because of changed docker image location, and changed pip command to fix cryptography module uninstallation error.



**Explain relevant issues and how this pull request solves them**
This pull updates the example Dockerfile given in `addons/example`, at the moment it's not building.

**Describe the changes in code and its dependencies and justify that they work as intended after testing**
Image URLs set in the Dockerfile point to `ghcr.io/selkies-project/selkies` when `ghcr.io/selkies-project/selkies-gstreamer` is needed in some cases.

 - [ x] I confirm that this pull request is relevant to the scope of this project. If you know that upstream projects are the cause of this problem, please file the pull request there.
 - [ x] I confirm that this pull request has been tested thoroughly and to the best of my knowledge that additional unintended problems do not arise.
 - [ x] I confirm that the style of the changed code conforms to the overall style of the project.
 - [x ] I confirm that I have read other open and closed pull requests and that duplicates do not exist.
 - [x ] I confirm that I have justified the need for this pull request and that the changes reflect the fix for the specified problem.
 - [ x] I confirm that no portion of this pull request contains credentials or other private information, and it is my own responsibility to protect my privacy.
 - [ x] I confirm that the authors of this pull request does not willfully breach or infringe legal regulations, in any and all global law, regarding trademarks, trade names, logos, patents, or any and all other forms of external intellectual property, as well as adhering to software license terms of open-source and proprietary software projects.
