### PR TITLE
docs: add Firefox clipboard workaround to FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -55,6 +55,8 @@ However, it might be that the parameters for the WebRTC interface, video encoder
 
 This is very likely a web browser constraint that is applied because you are using HTTP for an address to the web interface that is not localhost. The clipboard only works when you use HTTPS (with a valid or self-signed certificate), or when accessing localhost (some browsers do not support this as well). You could use port forwarding to access through localhost or obtain an HTTPS certificate.
 
+**Firefox-specific workaround:** If clipboard is not working in Firefox even with HTTPS, you may need to enable the async clipboard API. Navigate to `about:config` in Firefox, search for `dom.events.testing.asyncClipboard`, and set it to `true`. Firefox does not prompt for clipboard access like Chrome does, so this manual configuration is required.
+
 </details>
 
 ## The web interface refuses to start up in the terminal after rebooting my computer or restarting my desktop in a standalone instance.


### PR DESCRIPTION
Fixes #202

## Summary

Added Firefox-specific workaround to the clipboard FAQ section.

## Problem

In Firefox, the clipboard does not work even with HTTPS because Firefox does not prompt for clipboard access like Chrome does.

## Solution

Document the workaround: enable `dom.events.testing.asyncClipboard` in `about:config`.

## Testing

The workaround was verified by the issue reporter in #202.