### PR TITLE
fix: replace bare except with except Exception in legacy modules

### DIFF
--- a/src/selkies/legacy/gamepad.py
+++ b/src/selkies/legacy/gamepad.py
@@ -328,7 +328,7 @@ class SelkiesGamepad:
             self.server.close()
             try:
                 os.unlink(self.socket_path)
-            except:
+            except Exception:
                 pass
         
         logger.info("Stopped gamepad socket server for %s" % self.socket_path)
@@ -338,7 +338,7 @@ class SelkiesGamepad:
         self.server.close()
         try:
             os.unlink(self.socket_path)
-        except:
+        except Exception:
             pass
 
 class GamepadMapper:

--- a/src/selkies/legacy/webrtc_input.py
+++ b/src/selkies/legacy/webrtc_input.py
@@ -600,7 +600,7 @@ class WebRTCInput:
                 relative = True
             try:
                 x, y, button_mask, scroll_magnitude = [int(i) for i in toks[1:]]
-            except:
+            except Exception:
                 x, y, button_mask, scroll_magnitude = 0, 0, self.button_mask, 0
                 relative = False
             try:
@@ -716,21 +716,21 @@ class WebRTCInput:
             try:
                 fps = int(toks[1])
                 self.on_client_fps(fps)
-            except:
+            except Exception:
                 logger.error("failed to parse fps from client: " + str(toks))
         elif toks[0] == "_l":
             # Reported latency from client.
             try:
                 latency_ms = int(toks[1])
                 self.on_client_latency(latency_ms)
-            except:
+            except Exception:
                 logger.error(
                     "failed to parse latency report from client" + str(toks))
         elif toks[0] == "_stats_video" or toks[0] == "_stats_audio":
             # WebRTC Statistics API data from client
             try:
                 await self.on_client_webrtc_stats(toks[0], ",".join(toks[1:]))
-            except:
+            except Exception:
                 logger.error("failed to parse WebRTC Statistics JSON object")
         else:
             logger.info('unknown data channel message: %s' % msg)


### PR DESCRIPTION
## Summary

Replace bare `except:` clauses with `except Exception:` in legacy gamepad and WebRTC input modules.

Bare `except:` catches all exceptions including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`, which is almost never intended. Using `except Exception:` follows PEP 8 best practices.

**Changes:**
```python
# Before (gamepad.py — 2 occurrences)
except:
    pass

# After
except Exception:
    pass

# Before (webrtc_input.py — 4 occurrences)
except:
    logger.error(...)

# After
except Exception:
    logger.error(...)
```

## Files Changed
- `src/selkies/legacy/gamepad.py` — 2 bare except → except Exception
- `src/selkies/legacy/webrtc_input.py` — 4 bare except → except Exception

## Testing
No behavior change for normal exceptions — style/correctness fix only.