### PR TITLE
Expose CBR and CRF rate control modes

### DIFF
--- a/addons/selkies-dashboard/src/components/Sidebar.jsx
+++ b/addons/selkies-dashboard/src/components/Sidebar.jsx
@@ -12,8 +12,8 @@ const PER_DISPLAY_SETTINGS = [
     'framerate', 'h264_crf', 'h264_fullcolor',
     'h264_streaming_mode', 'jpeg_quality', 'paint_over_jpeg_quality', 'use_cpu',
     'h264_paintover_crf', 'h264_paintover_burst_frames', 'use_paint_over_quality',
-    'is_manual_resolution_mode', 'manual_width', 'manual_height',
-    'encoder', 'scaleLocallyManual', 'use_browser_cursors'
+    'is_manual_resolution_mode', 'manual_width', 'manual_height', 'encoder',
+    'scaleLocallyManual', 'use_browser_cursors', 'rate_control_mode', 'video_bitrate'
 ];
 
 const encoderOptions = [
@@ -27,6 +27,8 @@ const encoderOptionsWR = [
   "nvh264enc",
   "vp8enc",
 ]
+
+const rateControlOptions = ["cbr", "crf"];
 
 const commonResolutionValues = [
   "",
@@ -87,6 +89,8 @@ const DEFAULT_STREAM_MODE = STREAM_MODE_WEBSOCKETS;
 const DEFAULT_WEBRTC_ENCODER = "x264enc";
 const DEFAULT_AUDIO_BITRATE = 128000;  // in bps
 const DEFAULT_VIDEO_BITRATE = 8;   // in mbps
+const RATE_CONTROL_CBR = "cbr";
+const RATE_CONTROL_CRF = "crf";
 
 // --- Helper Functions ---
 function formatBytes(bytes, decimals = 2, rawDict) {
@@ -623,7 +627,7 @@ function Sidebar() {
     newRenderable.use_browser_cursors = isRenderable('use_browser_cursors');
     newRenderable.video_bitrate = isRenderable('video_bitrate');
     newRenderable.audio_bitrate = isRenderable('audio_bitrate');
-    
+
     const hypotheticalHidpi = s.hidpi_enabled || { value: true, locked: false };
     newRenderable.hidpi = hypotheticalHidpi.locked !== true;
 
@@ -639,6 +643,7 @@ function Sidebar() {
     newRenderable.microphoneToggle = isRenderable('microphone_enabled');
     newRenderable.gamepadToggle = isRenderable('gamepad_enabled');
 
+    newRenderable.enableRateControl = s.enable_rate_control?.value ?? false;
     const ftSetting = s.file_transfers;
     newRenderable.fileUpload = ftSetting ? ftSetting.value.includes('upload') : true;
     newRenderable.fileDownload = ftSetting ? ftSetting.value.includes('download') : true;
@@ -919,6 +924,13 @@ function Sidebar() {
       const final = s_use_browser_cursors.locked ? s_use_browser_cursors.value : getStoredBool("use_browser_cursors");
       setUseBrowserCursors(final);
     }
+    const s_rate_control_mode = serverSettings.rate_control_mode;
+    if (s_rate_control_mode) {
+      const stored = localStorage.getItem(getPrefixedKey("rate_control_mode"));
+      const final = s_rate_control_mode.allowed.includes(stored) ? stored : s_rate_control_mode.value;
+      setRateControlMode(final);
+      localStorage.setItem(getPrefixedKey("rate_control_mode"), final);
+    }
     const s_ui_title = serverSettings.ui_title;
     if (s_ui_title) {
         setUiTitle(s_ui_title.value);
@@ -1059,6 +1071,10 @@ function Sidebar() {
   const [enableBinaryClipboard, setEnableBinaryClipboard] = useState(() => {
     const saved = localStorage.getItem(getPrefixedKey("enable_binary_clipboard"));
     return saved !== null ? saved === 'true' : DEFAULT_ENABLE_BINARY_CLIPBOARD;
+  });
+  const [rateControlMode, setRateControlMode] = useState(() => {
+    const saved = localStorage.getItem(getPrefixedKey("rate_control_mode"));
+    return saved !== null ? saved : "";
   });
   const [videoBitrateMbps, setVideoBitrateMbps] = useState(0);
   const [presetValue, setPresetValue] = useState("");
@@ -1438,6 +1454,11 @@ function Sidebar() {
     const newStreamingModeState = !h264StreamingMode;
     setH264StreamingMode(newStreamingModeState);
     debouncedPostSetting({ h264_streaming_mode: newStreamingModeState });
+  };
+  const handleRateControlChange = (event) => {
+    const selectedRateControl = event.target.value;
+    setRateControlMode(selectedRateControl);
+    debouncedPostSetting({ rate_control_mode: selectedRateControl });
   };
   const handleAudioInputChange = (event) => {
     const deviceId = event.target.value;
@@ -2424,6 +2445,25 @@ function Sidebar() {
                     </select>
                   </div>
                 )}
+                {(renderableSettings.enableRateControl ?? true) && (
+                  <div className="dev-setting-item">
+                    <label htmlFor="rateControlSelect">
+                      {t("sections.video.rateControlLabel")}
+                    </label>
+                    <select
+                      id="rateControlSelect"
+                      value={rateControlMode}
+                      onChange={handleRateControlChange}
+                      disabled={!serverSettings || serverSettings.rate_control_mode?.allowed?.length <= 1}
+                    >
+                      {(serverSettings?.rate_control_mode?.allowed || rateControlOptions).map((rc) => (
+                        <option key={rc} value={rc}>
+                          {rc.toUpperCase()}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                )}
                 {(isWebrtc || showFPS) && (renderableSettings.framerate ?? true) && (
                   <div className="dev-setting-item">
                     <label htmlFor="framerateSlider">
@@ -2443,7 +2483,8 @@ function Sidebar() {
                     />
                   </div>
                 )}
-                {isWebrtc && (renderableSettings.video_bitrate ?? true) && (
+                {((renderableSettings.enableRateControl && rateControlMode === RATE_CONTROL_CBR) ||
+                  (!renderableSettings.enableRateControl && isWebrtc)) && (renderableSettings.video_bitrate ?? true) && (
                   <div className="dev-setting-item">
                     <label htmlFor="videoBitrateSlider">
                       {t("sections.video.bitrateLabel", {
@@ -2504,7 +2545,8 @@ function Sidebar() {
                     )}
                   </>
                 )}
-                {!isWebrtc && showCRF && (renderableSettings.h264_crf ?? true) && (
+                {((renderableSettings.enableRateControl && rateControlMode === RATE_CONTROL_CRF) ||
+                  (!renderableSettings.enableRateControl && !isWebrtc)) && showCRF && (renderableSettings.h264_crf ?? true) && (
                   <div className="dev-setting-item">
                     <label htmlFor="videoCRFSlider">
                       {t("sections.video.crfLabel", { crf: h264_crf })}

--- a/addons/selkies-dashboard/src/styles/Overlay.css
+++ b/addons/selkies-dashboard/src/styles/Overlay.css
@@ -390,6 +390,7 @@
 .dev-setting-item #streamModeSelect,
 .dev-setting-item #encoderSelect,
 .dev-setting-item #encoderRTCSelect,
+.dev-setting-item #rateControlSelect,
 .dev-setting-item #resolutionPresetSelect,
 .dev-setting-item #uiScalingSelect,
 .dev-setting-item .audio-device-select {
@@ -412,8 +413,10 @@
 }
 
 /* Custom arrow SVG for light theme select elements. */
+.theme-light .dev-setting-item #streamModeSelect,
 .theme-light .dev-setting-item #encoderSelect,
 .theme-light .dev-setting-item #encoderRTCSelect,
+.theme-light .dev-setting-item #rateControlSelect,
 .theme-light .dev-setting-item #resolutionPresetSelect,
 .theme-light .dev-setting-item #uiScalingSelect,
 .theme-light .dev-setting-item .audio-device-select {
@@ -423,8 +426,10 @@
 }
 
 /* Hover state for select elements. */
+.dev-setting-item #streamModeSelect:hover,
 .dev-setting-item #encoderSelect:hover,
 .dev-setting-item #encoderRTCSelect:hover,
+.dev-setting-item #rateControlSelect:hover,
 .dev-setting-item #resolutionPresetSelect:hover,
 .theme-light .dev-setting-item #uiScalingSelect,
 .dev-setting-item .audio-device-select:hover {
@@ -432,8 +437,10 @@
 }
 
 /* Focus state for select elements. */
+.dev-setting-item #streamModeSelect:focus,
 .dev-setting-item #encoderSelect:focus,
 .dev-setting-item #encoderRTCSelect:focus,
+.dev-setting-item #rateControlSelect:focus,
 .dev-setting-item #resolutionPresetSelect:focus,
 .dev-setting-item #uiScalingSelect:focus,
 .dev-setting-item .audio-device-select:focus {
@@ -1564,8 +1571,10 @@ a:active {
 
 /* Style for select elements like #encoderSelect.
    Custom arrow SVG for dark theme. */
+.dev-setting-item #streamModeSelect,
 .dev-setting-item #encoderSelect,
 .dev-setting-item #encoderRTCSelect,
+.dev-setting-item #rateControlSelect,
 .dev-setting-item #resolutionPresetSelect,
 .dev-setting-item .audio-device-select {
     width: 100%;
@@ -1587,8 +1596,10 @@ a:active {
 }
 
 /* Custom arrow SVG for light theme select elements. */
+.theme-light .dev-setting-item #streamModeSelect,
 .theme-light .dev-setting-item #encoderSelect,
 .theme-light .dev-setting-item #encoderRTCSelect,
+.theme-light .dev-setting-item #rateControlSelect,
 .theme-light .dev-setting-item #resolutionPresetSelect,
 .theme-light .dev-setting-item .audio-device-select {
      background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%22292.4%22%3E%3Cpath%20fill%3D%22%23333%22%20d%3D%22M287%2C114.7L159.1%2C282.6c-3.2%2C3.2-8.3%2C3.2-11.6%2C0L5.5%2C114.7c-3.2-3.2-3.2-8.3%2C0-11.6l10.3-10.3c3.2-3.2%2C8.3-3.2%2C11.6%2C0l124.9%2C124.9l124.9-124.9c3.2-3.2%2C8.3-3.2%2C11.6%2C0l10.3%2C10.3C290.3%2C106.5%2C290.3%2C111.5%2C287%2C114.7z%22%2F%3E%3C%2Fsvg%3E');
@@ -1599,6 +1610,7 @@ a:active {
 /* Hover state for select elements. */
 .dev-setting-item #encoderSelect:hover,
 .dev-setting-item #encoderRTCSelect:hover,
+.dev-setting-item #rateControlSelect:hover,
 .dev-setting-item #resolutionPresetSelect:hover,
 .dev-setting-item #uiScalingSelect:hover,
 .dev-setting-item .audio-device-select:hover {

--- a/addons/selkies-dashboard/src/translations.js
+++ b/addons/selkies-dashboard/src/translations.js
@@ -55,6 +55,7 @@ const en = {
             paintOverJpegQualityLabel: "Paintover Quality: {paintOverJpegQuality}",
             paintoverCrfLabel: "Paint-Overs CRF ({crf}):",
             usePaintOverQualityLabel: "Use Paint-Overs",
+            rateControlLabel: "Encoder Rate Control Mode",
         },
         audio: {
             title: "Audio Settings",

--- a/addons/selkies-web-core/selkies-wr-core.js
+++ b/addons/selkies-web-core/selkies-wr-core.js
@@ -222,6 +222,7 @@ class ClipboardWorkerBridge {
 
 export default function webrtc() {
 	let appName;
+	let crf = 23;
 	let videoBitRate = 8;      // in mbps
 	let videoFramerate = 60;
 	let audioBitRate = 128000; // in kbps
@@ -234,7 +235,8 @@ export default function webrtc() {
 	let clipboardStatus = 'disabled';
 	let windowResolution = [];
 	let encoderLabel = "";
-	let encoder = ""
+	let encoder = "";
+	let rateControlMode = "cbr";
 	let gamepad = {
 			gamepadState: 'disconnected',
 			gamepadName: 'none',
@@ -516,13 +518,14 @@ export default function webrtc() {
 
 		const knownSettings = [
 			'framerate', 'encoder_rtc', 'is_manual_resolution_mode',
-			'audio_bitrate', 'video_bitrate', 'scaling_dpi', 'enable_binary_clipboard'
+			'audio_bitrate', 'video_bitrate', 'scaling_dpi', 'enable_binary_clipboard',
+			'rate_control_mode', 'h264_crf'
 		];
 		const booleanSettingKeys = [
 			'is_manual_resolution_mode', 'enable_binary_clipboard'
 		];
 		const integerSettingKeys = [
-			'framerate', 'audio_bitrate', 'scaling_dpi', 'video_bitrate'
+			'framerate', 'audio_bitrate', 'scaling_dpi', 'video_bitrate', 'h264_crf'
 		];
 
 		for (const key in localStorage) {
@@ -864,7 +867,28 @@ export default function webrtc() {
 			setBoolParam('enable_binary_clipboard', enable_binary_clipboard);
 			console.log(`Binary clipboard support ${enable_binary_clipboard ? 'enabled' : 'disabled'}`);
 		}
+		if (settings.rate_control_mode !== undefined) {
+			rateControlMode = settings.rate_control_mode;
+			webrtc.sendDataChannelMessage(`_rc,${rateControlMode}`);
+			sendRespectiveRCvalue(rateControlMode);
+			setStringParam('rate_control_mode', rateControlMode);
+			console.log(`Rate control mode set to ${rateControlMode}`);
+		}
+		if (settings.h264_crf !== undefined) {
+			crf = parseInt(settings.h264_crf, 10);
+			webrtc.sendDataChannelMessage(`_crf,${crf}`);
+			setIntParam('h264_crf', crf);
+			console.log(`H264 CRF set to ${crf}`);
+		}
 	}
+
+	function sendRespectiveRCvalue(newMode) {
+		if (newMode === "cbr") {
+			webrtc.sendDataChannelMessage(`vb,${videoBitRate}`);
+		} else if (newMode === "crf") {
+			webrtc.sendDataChannelMessage(`_crf,${crf}`);
+		}
+	};
 
 	function handleRequestFileUpload() {
 		const hiddenInput = document.getElementById('globalFileInput');
@@ -887,7 +911,7 @@ export default function webrtc() {
 		// doesn't support simultaneous reception of multiple files, yet.
 		if (!webrtc.createAuxDataChannel()) {
 			console.warn("Simultaneous uploading of files with distinct upload operations is not supported yet");
-			const errorMsg = "Please let the ongoing upload complete";
+			const errorMsg = "Please let the ongoing upload complete.";
 			window.postMessage({
 				type: 'fileUpload',
 				payload: {
@@ -1524,9 +1548,12 @@ export default function webrtc() {
 			setIntParam('manual_height', manualHeight);
 			encoder = getStringParam('encoder_rtc', 'x264enc');
 			setStringParam('encoder_rtc', encoder)
+			rateControlMode = getStringParam('rate_control_mode', 'cbr');
+			setStringParam('rate_control_mode', rateControlMode);
 			useCssScaling = getBoolParam('useCssScaling', true);  // TODO: need to handle hiDPI
 			setBoolParam('useCssScaling', useCssScaling);
 			enable_binary_clipboard = getBoolParam('enable_binary_clipboard', enable_binary_clipboard);
+			crf = getIntParam('h264_crf', crf);
 
 			if (!isSharedMode) {
 				// listen for dashboard messages (Dashboard -> core client)

--- a/addons/selkies-web-core/selkies-ws-core.js
+++ b/addons/selkies-web-core/selkies-ws-core.js
@@ -49,7 +49,8 @@ const PER_DISPLAY_SETTINGS = [
     'h264_streaming_mode', 'jpeg_quality', 'paint_over_jpeg_quality', 'use_cpu',
     'h264_paintover_crf', 'h264_paintover_burst_frames', 'use_paint_over_quality',
     'is_manual_resolution_mode', 'manual_width', 'manual_height',
-    'encoder', 'scaleLocallyManual', 'use_browser_cursors'
+    'encoder', 'scaleLocallyManual', 'use_browser_cursors', 'rate_control_mode',
+    'video_bitrate'
 ];
 // Microphone related resources
 let micStream = null;
@@ -188,6 +189,7 @@ let h264_paintover_crf = 18;
 let h264_paintover_burst_frames = 5;
 let use_paint_over_quality = true;
 let audio_bitrate = 320000;
+let videoBitrate = 8;
 let showStart = true;
 let status = 'connecting';
 let loadingText = '';
@@ -221,6 +223,7 @@ let lastFpsUpdateTime = performance.now();
 let statusDisplayElement;
 let playButtonElement;
 let overlayInput;
+let rateControlMode = 'crf';
 
 const getIntParam = (key, default_value) => {
   const prefixedKey = `${storageAppName}_${key}`;
@@ -379,6 +382,8 @@ is_manual_resolution_mode = getBoolParam('is_manual_resolution_mode', false);
 isGamepadEnabled = getBoolParam('isGamepadEnabled', true);
 useCssScaling = getBoolParam('useCssScaling', false);
 trackpadMode = getBoolParam('trackpadMode', false);
+rateControlMode = getStringParam('rate_control_mode', rateControlMode);
+videoBitrate = getIntParam('video_bitrate', videoBitrate);
 if (getStringParam('scaling_dpi', null) === null) {
   const dpr = window.devicePixelRatio || 1;
   const target = Math.round(dpr * 4) * 24;
@@ -404,6 +409,7 @@ setIntParam('h264_paintover_burst_frames', h264_paintover_burst_frames);
 setIntParam('audio_bitrate', audio_bitrate);
 setStringParam('encoder', currentEncoderMode);
 setIntParam('scaling_dpi', scalingDPI);
+setIntParam('video_bitrate', videoBitrate);
 
 if (isSharedMode) {
     manual_width = 1280;
@@ -613,6 +619,8 @@ function getCurrentSettingsPayload() {
     settingsToSend['use_paint_over_quality'] = getBoolParam('use_paint_over_quality', true);
     settingsToSend['scaling_dpi'] = getIntParam('scaling_dpi', 96);
     settingsToSend['enable_binary_clipboard'] = getBoolParam('enable_binary_clipboard', false);
+    settingsToSend['rate_control_mode'] = getStringParam('rate_control_mode', 'crf');
+    settingsToSend['video_bitrate'] = getIntParam('video_bitrate', 8);
     if (window.is_manual_resolution_mode && manual_width != null && manual_height != null) {
         settingsToSend['is_manual_resolution_mode'] = true;
         settingsToSend['manual_width'] = roundDownToEven(manual_width);
@@ -2088,10 +2096,29 @@ function handleSettingsMessage(settings) {
     setTimeout(() => { window.location.reload(); }, 700);
     return;
   }
+  if (settings.rate_control_mode !== undefined) {
+    rateControlMode = settings.rate_control_mode;
+    setStringParam('rate_control_mode', rateControlMode);
+    fetchLatestRCvalue(rateControlMode);
+    settingsChanged = true;
+  }
+  if (settings.video_bitrate !== undefined) {
+    videoBitrate = parseInt(settings.video_bitrate, 10);
+    setIntParam('video_bitrate', videoBitrate);
+    settingsChanged = true;
+  }
   if (settingsChanged) {
     sendFullSettingsUpdateToServer('handleSettingsMessage');
   }
 }
+
+function fetchLatestRCvalue(newMode) {
+  if (newMode === "cbr") {
+    videoBitrate = getIntParam('video_bitrate', videoBitrate);
+  } else if (newMode === "crf") {
+    h264_crf = getIntParam('h264_crf', h264_crf);
+  }
+};
 
 function sendStatsMessage() {
   const stats = {
@@ -2816,7 +2843,7 @@ function handleDecodedFrame(frame) {
         'audio_bitrate', 'h264_fullcolor', 'h264_streaming_mode',
         'jpeg_quality', 'paint_over_jpeg_quality', 'use_cpu', 'h264_paintover_crf',
         'h264_paintover_burst_frames', 'use_paint_over_quality', 'scaling_dpi',
-        'enable_binary_clipboard'
+        'enable_binary_clipboard', 'rate_control_mode', 'video_bitrate'
       ];
       const booleanSettingKeys = [
         'is_manual_resolution_mode', 'h264_fullcolor', 'h264_streaming_mode',
@@ -2825,7 +2852,7 @@ function handleDecodedFrame(frame) {
       const integerSettingKeys = [
         'framerate', 'h264_crf', 'audio_bitrate', 'jpeg_quality',
         'paint_over_jpeg_quality', 'h264_paintover_crf',
-        'h264_paintover_burst_frames', 'scaling_dpi'
+        'h264_paintover_burst_frames', 'scaling_dpi', 'video_bitrate'
       ];
 
       for (const key in localStorage) {

--- a/src/selkies/input_handler.py
+++ b/src/selkies/input_handler.py
@@ -32,7 +32,7 @@ import json
 from PIL import Image 
 import urllib.parse
 import urllib.request
-
+from .media_pipeline import RateControlMode
 try:
     from xkbcommon import xkb
 except ImportError:
@@ -883,6 +883,8 @@ class WebRTCInput:
         self.clipboard_injection_lock = asyncio.Lock()
         self.keyboard_queue = asyncio.Queue()
         self.keyboard_worker_task = None
+        self.on_update_rate_control_mode = lambda mode: logger_webrtc_input.warning("unhandled on_update_rate_control_mode")
+        self.on_update_crf = lambda value: logger_webrtc_input.warning("unhandled on_update_crf")
 
         if self.is_wayland:
             import shutil
@@ -1992,7 +1994,7 @@ class WebRTCInput:
             except Exception as e:
                 logger_webrtc_input.error(f"Error in keyboard worker: {e}", exc_info=True)
 
-    async def on_message(self, msg, display_id='primary'):
+    async def on_message(self, msg: str, display_id='primary'):
         toks = msg.split(",")
         msg_type = toks[0]
 
@@ -2260,6 +2262,22 @@ class WebRTCInput:
                 asyncio.create_task(self.update_binary_clipboard_setting(enable))
             except Exception as e:
                 logger_webrtc_input.error(f"Error updating binary clipboard setting: {e}")
+        elif msg_type == "_rc":
+            try:
+                mode = toks[1].strip().lower()
+                rc_mode = RateControlMode(mode)
+                asyncio.create_task(self.on_update_rate_control_mode(rc_mode))
+            except Exception as e:
+                logger_webrtc_input.error(f"Error updating rate control mode: {e}")
+        elif msg_type == "_crf":
+            try:
+                crf_value = int(toks[1])
+                if not (0 <= crf_value <= 51):
+                    logger_webrtc_input.warning(f"CRF value out of range (0-51): {crf_value}")
+                    return
+                asyncio.create_task(self.on_update_crf(crf_value))
+            except Exception as e:
+                logger_webrtc_input.error(f"Error updating CRF value: {e}")
         elif toks[0].startswith("FILE_UPLOAD_START:"):
             if self.upload_dir_path is None:
                 logger_webrtc_input.warning("Upload directory doesn't exits, skipping the file upload")

--- a/src/selkies/media_pipeline.py
+++ b/src/selkies/media_pipeline.py
@@ -22,6 +22,7 @@
 import asyncio
 import logging
 import ctypes
+from enum import Enum
 from abc import ABCMeta, abstractmethod
 
 from pixelflux import CaptureSettings, ScreenCapture, StripeCallback
@@ -29,6 +30,10 @@ from pcmflux import AudioCapture, AudioCaptureSettings, AudioChunkCallback
 
 logger = logging.getLogger("media_pipeline")
 logger.setLevel(logging.INFO)
+
+class RateControlMode(str, Enum):
+    CBR = "cbr"
+    CRF = "crf"
 
 class MediaPipelineError(Exception):
     pass
@@ -66,25 +71,38 @@ class MediaPipeline(metaclass=ABCMeta):
     async def dynamic_idr_frame(self):
         pass
 
+    @abstractmethod
+    async def update_rate_control_mode(self, mode: RateControlMode):
+        pass
+
+    @abstractmethod
+    async def set_crf(self, crf: int):
+        pass
+
 class MediaPipelinePixel(MediaPipeline):
     def __init__(
         self,
         async_event_loop: asyncio.AbstractEventLoop,
-        encoder: str,
+        encoder_rtc: str,
         framerate: int = 30,
-        video_bitrate: int = 2000,
+        video_bitrate: int = 8,
         audio_bitrate: int = 128000,
         width: int = 1920,
         height: int = 1080,
         audio_channels: int = 2,
         audio_enabled: bool = True,
-        audio_device_name = 'output.monitor'
+        audio_device_name = 'output.monitor',
+        crf: int = 23,
+        rc_mode: RateControlMode = RateControlMode.CBR
     ):
         self.async_event_loop = async_event_loop
         self.audio_channels = audio_channels
-        self.encoder = encoder
+        self.encoder_rtc = encoder_rtc
         self.framerate = framerate
         self.video_bitrate = video_bitrate
+        self.rc_mode = rc_mode
+        # FIXME: h264_crf variable name could be encoder agnostic
+        self.h264_crf = crf
         self.audio_bitrate = audio_bitrate
         self.last_resize_success = True
         self.width = width
@@ -117,6 +135,51 @@ class MediaPipelinePixel(MediaPipeline):
         await self.restart_screen_capture()
         logger.info(f"Set pointer visibility to: {visible}")
 
+    async def update_rate_control_mode(self, mode: RateControlMode):
+        """Set rate control mode for video encoder.
+
+        :mode: Rate control mode, either "cbr" or "crf"
+        """
+        if not self._is_screen_capturing or self.capture_module is None:
+            return
+
+        if mode == self.rc_mode:
+            return
+
+        if mode not in [RateControlMode.CBR, RateControlMode.CRF]:
+            logger.error(f"Invalid rate control mode: {mode}")
+            return
+
+        self.rc_mode = mode
+        try:
+            await self.restart_screen_capture()
+            logger.info(f"Updated rate control mode to: {self.rc_mode}")
+        except AttributeError:
+            logger.error("Video capture module does not support rate control mode updation")
+        except Exception as e:
+            logger.info(f"Error updating rate control mode {e}", exc_info=True)
+
+    async def set_crf(self, new_crf: int):
+        """Set video encoder target CRF.
+
+        :new_crf: CRF value
+        """
+        if not self._is_screen_capturing or self.capture_module is None:
+            return
+
+        if self.rc_mode != RateControlMode.CRF or self.h264_crf == new_crf:
+            return
+
+        old_crf = self.h264_crf
+        self.h264_crf = new_crf
+        try:
+            await self.restart_screen_capture()
+            logger.info(f"Updated CRF: {old_crf} -> {new_crf}")
+        except AttributeError:
+            logger.error("Video capture module does not support CRF updation")
+        except Exception as e:
+            logger.info(f"Error updating CRF {e}", exc_info=True)
+
     async def set_video_bitrate(self, new_bitrate: int):
         """Set video encoder target bitrate.
 
@@ -125,13 +188,12 @@ class MediaPipelinePixel(MediaPipeline):
         if not self._is_screen_capturing or self.capture_module is None:
             return
 
-        new_bitrate *= 1000   # convert to kpbs
-        if new_bitrate <= 0 or self.video_bitrate == new_bitrate:
+        if self.rc_mode == RateControlMode.CRF or new_bitrate <= 0 or self.video_bitrate == new_bitrate:
             return
 
         try:
-            await self.async_event_loop.run_in_executor(None, self.capture_module.update_video_bitrate, new_bitrate)
-            logger.info(f"Updated video bitrate: {self.video_bitrate} -> {new_bitrate}")
+            await self.async_event_loop.run_in_executor(None, self.capture_module.update_video_bitrate, new_bitrate * 1000)
+            logger.info(f"Updated video bitrate: {self.video_bitrate}Mbps -> {new_bitrate}Mbps")
             self.video_bitrate = new_bitrate
         except AttributeError:
             logger.error("Video capture module does not support video bitrate updation")
@@ -196,18 +258,18 @@ class MediaPipelinePixel(MediaPipeline):
         cs.target_fps = float(self.framerate)
         cs.capture_cursor = self.capture_cursor
         cs.output_mode = 1
+        cs.auto_adjust_screen_capture_size = True
 
-        if self.encoder in ["nvh264enc", "x264enc"]:
+        if self.encoder_rtc in ["nvh264enc", "x264enc"]:
             cs.h264_streaming_mode = True
             cs.h264_fullframe = True
-            cs.h264_crf = 23
-            cs.h264_cbr_mode = True
-            cs.h264_bitrate_kbps = self.video_bitrate
+            cs.h264_crf = self.h264_crf
+            # Setting h264_cbr_mode to True will make the encoder ignore the crf value
+            cs.h264_cbr_mode = self.rc_mode == RateControlMode.CBR
+            cs.h264_bitrate_kbps = self.video_bitrate * 1000  # Convert Mbps to kbps
             cs.vaapi_render_node_index = -1
-            if self.encoder == "x264enc":
-                cs.use_cpu = True
-
-        cs.auto_adjust_screen_capture_size = True
+            if self.encoder_rtc == "x264enc":
+                cs.use_cpu = True        
         return cs
 
     async def start_screen_capture(self):
@@ -215,7 +277,7 @@ class MediaPipelinePixel(MediaPipeline):
             return
 
         settings = self.generate_capture_settings()
-        def screen_capture_callback(result_ptr, user_data):
+        def screen_capture_callback(result_ptr, _):
             if not result_ptr:
                 return
             try:

--- a/src/selkies/selkies.py
+++ b/src/selkies/selkies.py
@@ -56,6 +56,7 @@ import urllib.parse
 import sys
 import time
 import io
+from enum import Enum
 from PIL import Image, ImageDraw
 import websockets
 import websockets.asyncio.server as ws_async
@@ -117,6 +118,9 @@ client_permissions = {}
 class SelkiesAppError(Exception):
     pass
 
+class RateControlMode(str, Enum):
+    CBR = "cbr"
+    CRF = "crf"
 
 class SelkiesStreamingApp:
     def __init__(
@@ -832,6 +836,7 @@ class DataStreamingServer:
         audio_device_name,
         cli_args,
         is_secure_mode,
+        rc_mode = RateControlMode.CRF,
     ):
         self.port = port
         self.mode = "websockets"
@@ -858,6 +863,7 @@ class DataStreamingServer:
         self._rtt_samples = deque(maxlen=RTT_SMOOTHING_SAMPLES)
         self._smoothed_rtt_ms = 0.0
         self._sent_frames_log = deque()
+        self.rc_mode = rc_mode
         
         def get_initial_value(setting_name):
             """Helper to get the correct initial integer/bool from a processed setting."""
@@ -891,6 +897,8 @@ class DataStreamingServer:
         self.use_cpu = self._initial_use_cpu
         self._initial_use_paint_over_quality = get_initial_value('use_paint_over_quality')
         self.use_paint_over_quality = self._initial_use_paint_over_quality
+        self._initial_video_bitrate = get_initial_value('video_bitrate')
+        self.video_bitrate = self._initial_video_bitrate
 
         self._system_monitor_task_ws = None
         self._gpu_monitor_task_ws = None
@@ -1328,6 +1336,8 @@ class DataStreamingServer:
         parsed["enable_binary_clipboard"] = get_bool("enable_binary_clipboard")
         parsed["displayId"] = get_str("displayId")
         parsed["displayPosition"] = get_str("displayPosition")
+        parsed["rate_control_mode"] = get_str("rate_control_mode")
+        parsed["video_bitrate"] = get_int("video_bitrate")
         data_logger.debug(f"Parsed client settings: {parsed}")
         return parsed
 
@@ -1450,6 +1460,11 @@ class DataStreamingServer:
                 display_state["use_cpu"] = sanitize_value("use_cpu", settings.get("use_cpu"))
             self.app.audio_bitrate = sanitize_value("audio_bitrate", settings.get("audio_bitrate"))
             display_state["audio_bitrate"] = self.app.audio_bitrate
+            display_state["video_bitrate"] = sanitize_value("video_bitrate", settings.get("video_bitrate"))
+            enable_rate_control, _ = self.cli_args.enable_rate_control
+            if enable_rate_control:
+                display_state["rate_control_mode"] = sanitize_value("rate_control_mode", settings.get("rate_control_mode"))
+            
             if self.input_handler:
                 self.enable_binary_clipboard = sanitize_value("enable_binary_clipboard", settings.get("enable_binary_clipboard"))
                 await self.input_handler.update_binary_clipboard_setting(self.enable_binary_clipboard)
@@ -1486,7 +1501,7 @@ class DataStreamingServer:
             video_params_list = [
                 'encoder', 'framerate', 'h264_crf', 'h264_fullcolor', 'h264_streaming_mode',
                 'jpeg_quality', 'paint_over_jpeg_quality', 'use_cpu', 'h264_paintover_crf',
-                'h264_paintover_burst_frames', 'use_paint_over_quality'
+                'h264_paintover_burst_frames', 'use_paint_over_quality', 'rate_control_mode', 'video_bitrate'
             ]
             if IS_WAYLAND and which("kwin_wayland"):
                 video_params_list.append('scaling_dpi')
@@ -2165,6 +2180,8 @@ class DataStreamingServer:
                                     'h264_paintover_crf': self._initial_h264_paintover_crf,
                                     'h264_paintover_burst_frames': self._initial_h264_paintover_burst_frames,
                                     'use_paint_over_quality': self._initial_use_paint_over_quality,
+                                    'rate_control_mode': self.rc_mode.value,
+                                    'video_bitrate': self._initial_video_bitrate,
                                     'scale': 1.0,
                                 }
                             else:
@@ -3201,6 +3218,10 @@ class DataStreamingServer:
             cs.h264_fullcolor = display_state.get('h264_fullcolor', self._initial_h264_fullcolor)
             cs.h264_streaming_mode = display_state.get('h264_streaming_mode', self._initial_h264_streaming_mode)
             cs.h264_fullframe = (encoder == "x264enc")
+            rc_mode = display_state.get('rate_control_mode', 'crf')
+            cs.h264_cbr_mode = (rc_mode == 'cbr')
+            video_bitrate = display_state.get('video_bitrate', self._initial_video_bitrate)
+            cs.h264_bitrate_kbps = video_bitrate * 1000  # Convert Mbps to kbps
 
         cs.use_paint_over_quality = display_state.get('use_paint_over_quality', self._initial_use_paint_over_quality)
         cs.paint_over_trigger_frames = 15
@@ -3539,6 +3560,8 @@ async def ws_entrypoint():
         cli_args=settings,
         is_secure_mode=is_secure_mode,
     )
+    if settings.enable_rate_control[0]:
+        data_server.rc_mode = RateControlMode(settings.rate_control_mode)
     app.data_streaming_server = data_server
 
     clipboard_mode = "false"

--- a/src/selkies/settings.py
+++ b/src/selkies/settings.py
@@ -45,6 +45,10 @@ COMMON_SETTING_DEFINITIONS = [
     {'name': 'command_enabled', 'type': 'bool', 'default': True, 'help': 'Enable parsing of command websocket messages.'},
     {'name': 'file_transfers', 'type': 'list', 'default': 'upload,download', 'meta': {'allowed': ['upload', 'download']}, 'help': 'Allowed file transfer directions (comma-separated: "upload,download"). Set to "" or "none" to disable.'},
     {'name': 'framerate', 'type': 'range', 'default': '8-120', 'meta': {'default_value': 60}, 'help': 'Allowed framerate range (e.g., "8-165") or a fixed value (e.g., "60").'},
+    {'name': 'h264_crf', 'type': 'range', 'default': '5-50', 'meta': {'default_value': 25}, 'help': 'Allowed H.264 CRF range (e.g., "5-50") or a fixed value.'},
+    {'name': 'video_bitrate', 'type': 'range', 'default': '1-100', 'meta': {"default_value": 8}, 'help': 'Default video-bitrate aka CBR, in Megabits per second (Mbps), allowed range (e.g., "1-100") or a fixed value (e.g., "8" for 8 Mbps)'},
+    {'name': 'rate_control_mode', 'type': 'enum', 'default': 'crf', 'meta': {'allowed': ['crf', 'cbr']}, 'help': 'Rate control mode for video encoding (cbr or crf). Only effective when enable_rate_control is true.'},
+    {'name': 'enable_rate_control', 'type': 'bool', 'default': False, 'help': 'Enable rate control for video encoding. Used in association with rate_control_mode.'},
 
     # Audio Settings
     {'name': 'audio_bitrate', 'type': 'enum', 'default': '320000', 'meta': {'allowed': ['64000', '128000', '192000', '256000', '320000']}, 'help': 'The default audio bitrate.'},
@@ -97,7 +101,6 @@ COMMON_SETTING_DEFINITIONS = [
 SETTING_DEFINITIONS_WEBSOCKETS = [
     # Video & Encoder Settings
     {'name': 'encoder', 'type': 'enum', 'default': 'x264enc', 'meta': {'allowed': ['x264enc', 'x264enc-striped', 'jpeg']}, 'help': 'The default video encoder.'},
-    {'name': 'h264_crf', 'type': 'range', 'default': '5-50', 'meta': {'default_value': 25}, 'help': 'Allowed H.264 CRF range (e.g., "5-50") or a fixed value.'},
     {'name': 'jpeg_quality', 'type': 'range', 'default': '1-100', 'meta': {'default_value': 40}, 'help': 'Allowed JPEG quality range (e.g., "1-100") or a fixed value.'},
     {'name': 'h264_fullcolor', 'type': 'bool', 'default': False, 'help': 'Enable H.264 full color range for pixelflux encoders.'},
     {'name': 'h264_streaming_mode', 'type': 'bool', 'default': False, 'help': 'Enable H.264 streaming mode for pixelflux encoders.'},
@@ -152,7 +155,6 @@ SETTING_DEFINITIONS_WEBRTC = [
     {'name': 'cloudflare_turn_api_token', 'type': 'str', 'default': '', 'help': 'The Cloudflare TURN API token.'},
 
     {'name': 'encoder_rtc', 'type': 'enum', 'default': 'x264enc', 'meta': {'allowed': ['av1enc', 'x264enc', 'nvh264enc', 'vp8enc']}, 'help': 'Video encoder to encode video media'},
-    {'name': 'video_bitrate', 'type': 'range', 'default': '1-100', 'meta': {"default_value": 8}, 'help': 'Default video bitrate in Megabits per second (Mbps), allowed range (e.g., "1-100") or a fixed value (e.g., "8" for 8 Mbps)'},
     {'name': 'app_wait_ready', 'type': 'bool', 'default': False, 'help': 'Waits for --app_ready_file to exist before starting stream if set to "true"'},
     {'name': 'app_ready_file', 'type': 'str', 'default': '/tmp/selkies-appready', 'help': 'File set by sidecar used to indicate that app is initialized and ready'},
     {'name': 'uinput_mouse_socket', 'type': 'str', 'default': '', 'help': 'Path to the uinput mouse socket, if not provided uinput is used directly'},

--- a/src/selkies/webrtc_mode.py
+++ b/src/selkies/webrtc_mode.py
@@ -35,7 +35,7 @@ logger = logging.getLogger("main")
 logger.setLevel(logging.INFO)
 
 from .rtc import RTCApp
-from .media_pipeline import MediaPipeline, MediaPipelinePixel
+from .media_pipeline import MediaPipeline, MediaPipelinePixel, RateControlMode
 from .webrtc_signaling import WebRTCSignaling
 from .signaling_server import WebRTCSimpleServer
 from .input_handler import WebRTCInput
@@ -136,14 +136,17 @@ class WebRTCApp:
 
         self.media_pipeline = MediaPipelinePixel(
             async_event_loop=asyncio.get_running_loop(),
-            encoder=self.args.encoder_rtc,
+            encoder_rtc=self.args.encoder_rtc,
             framerate=int(self.args.framerate),
-            video_bitrate=int(self.args.video_bitrate) * 1000,  # Convert to kbps
+            video_bitrate=int(self.args.video_bitrate),
             audio_bitrate=int(self.args.audio_bitrate),
             audio_channels=int(self.args.audio_channels),
             audio_enabled=self.args.audio_enabled,
-            audio_device_name=self.args.audio_device_name
+            audio_device_name=self.args.audio_device_name,
+            crf=int(self.args.h264_crf),
         )
+        if self.args.enable_rate_control:
+            self.media_pipeline.rc_mode = RateControlMode(self.args.rate_control_mode)
 
         # Fetch rtc configuration
         stun_servers, turn_servers, rtc_config, self.monitoring_utils_used = await get_rtc_configuration(self.args)
@@ -300,6 +303,8 @@ class WebRTCApp:
         self.input_handler.on_ping_response = lambda latency: self.rtc_app.send_latency_time(latency)
         self.input_handler.on_client_webrtc_stats = self.handle_client_werbtc_stats
         self.input_handler.on_update_settings = self.handle_update_settings
+        self.input_handler.on_update_rate_control_mode = self.media_pipeline.update_rate_control_mode
+        self.input_handler.on_update_crf = self.media_pipeline.set_crf
 
         if self.args.enable_resize:
             self.input_handler.on_resize = self.on_resize_handler
@@ -456,6 +461,8 @@ class WebRTCApp:
     async def handle_update_settings(self, settings_json: dict) -> None:
         # TODO: Gradually expand the list of settings that can be updated via this method
         settings_allowed_to_update = [
+            'rate_control_mode',
+            'h264_crf',
             'video_bitrate',
             'audio_bitrate',
             'framerate',
@@ -503,15 +510,22 @@ class WebRTCApp:
                 return def_val_meta if def_val_meta is not None else setting_def.get('default')
             return client_value
 
-        for key, value in settings_json.items():
-            if key not in settings_allowed_to_update:
-                logger.warning(f"Client attempted to update disallowed setting '{key}'. Ignoring.")
+        for key in settings_allowed_to_update:
+            client_value = settings_json.get(key)
+            if client_value is None:
+                continue
+            if key == 'rate_control_mode' and self.args.enable_rate_control is False:
+                logger.debug(f"Server has rate control disabled. Ignoring update for '{key}'.")
                 continue
             current_value = getattr(self.args, key, None)
             if current_value is not None:
-                sanitized_value = sanitize_value(key, value)
+                sanitized_value = sanitize_value(key, client_value)
                 if sanitized_value is not None and sanitized_value != current_value:
-                    if key == 'video_bitrate' and self.media_pipeline:
+                    if key == 'rate_control_mode':
+                        await self.media_pipeline.update_rate_control_mode(RateControlMode(sanitized_value))
+                    elif key == 'h264_crf':
+                        await self.media_pipeline.set_crf(sanitized_value)
+                    elif key == 'video_bitrate' and self.media_pipeline:
                         await self.media_pipeline.set_video_bitrate(sanitized_value)
                     elif key == 'audio_bitrate' and self.media_pipeline:
                         await self.media_pipeline.set_audio_bitrate(int(sanitized_value))


### PR DESCRIPTION
**Reference the issue numbers and reviewers**
#227 @ehfd 

**Explain relevant issues and how this pull request solves them**
Addresses 4th issue mentioned in Tier 1 of #227

**Describe the changes in code and its dependencies and justify that they work as intended after testing**
- Added rate control modes to be configurable from UI
- Added CBR and CRF modes to websockets and webrtc streaming modes respectively
- Rate control Mode are configurable from server config, keeping the default modes for each streaming mode as fallback if rate control is disabled.

**Describe alternatives you've considered**
NA

**Additional context**
NA

 - [x] I confirm that this pull request is relevant to the scope of this project. If you know that upstream projects are the cause of this problem, please file the pull request there.
 - [x] I confirm that this pull request has been tested thoroughly and to the best of my knowledge that additional unintended problems do not arise.
 - [x] I confirm that the style of the changed code conforms to the overall style of the project.
 - [x] I confirm that I have read other open and closed pull requests and that duplicates do not exist.
 - [x] I confirm that I have justified the need for this pull request and that the changes reflect the fix for the specified problem.
 - [x] I confirm that no portion of this pull request contains credentials or other private information, and it is my own responsibility to protect my privacy.
 - [x] I confirm that the authors of this pull request does not willfully breach or infringe legal regulations, in any and all global law, regarding trademarks, trade names, logos, patents, or any and all other forms of external intellectual property, as well as adhering to software license terms of open-source and proprietary software projects.
