### PR TITLE
fix(input): Resolve unicode dropping, stabilize clipboard, and fix undo behavior.

### DIFF
--- a/src/selkies/input_handler.py
+++ b/src/selkies/input_handler.py
@@ -1419,7 +1419,7 @@ class WebRTCInput:
                 await self.send_x11_keypress(KEY_INSERT, down=True)
                 await self.send_x11_keypress(KEY_INSERT, down=False)
                 await self.send_x11_keypress(KEY_SHIFT_L, down=False)
-                await asyncio.sleep(0.02)
+                await asyncio.sleep(0.05)
 
                 if old_data is not None:
                     await self.write_clipboard(old_data, mime_type=old_mime or "text/plain")
@@ -1953,42 +1953,73 @@ class WebRTCInput:
         await self.__gamepad_disconnect()
 
     async def _keyboard_worker(self):
+        unicode_buffer = []
+
+        async def flush_buffer():
+            if unicode_buffer:
+                combined_text = "".join(unicode_buffer)
+                unicode_buffer.clear()
+                await self._inject_unicode_via_clipboard(combined_text)
+
         while True:
             try:
-                msg_type, data = await self.keyboard_queue.get()
-                
-                if msg_type == "kd":
-                    keysym = data
-                    is_printable = (0x20 <= keysym <= 0xFF) or ((keysym & 0xFF000000) == 0x01000000)
-                    if keysym in self.MODIFIER_KEYSYMS:
-                        self.active_modifiers.add(keysym)
-                    if is_printable and not self.active_modifiers:
-                        unicode_codepoint = keysym & 0x00FFFFFF if (keysym & 0xFF000000) == 0x01000000 else keysym
-                        try:            
-                            char_to_type = chr(unicode_codepoint)
-                            await self.send_x11_keypress(keysym, down=True)
-                        except (ValueError, TypeError):
-                            await self.send_x11_keypress(keysym, down=True)
-                    else:   
+                if unicode_buffer:
+                    try:
+                        msg_type, data = await asyncio.wait_for(self.keyboard_queue.get(), timeout=0.15)
+                    except asyncio.TimeoutError:
+                        await flush_buffer()
+                        continue
+                else:
+                    msg_type, data = await self.keyboard_queue.get()
+
+                try:
+                    keysym = data if msg_type in ("kd", "ku") else None
+                    is_unicode_fallback = False
+                    if keysym is not None:
+                        is_unicode_fallback = (0xA0 <= keysym <= 0xFF) or keysym == 0x20AC or ((keysym & 0xFF000000) == 0x01000000)
+
+                    if msg_type == "kd":
+                        if is_unicode_fallback and not self.active_modifiers:
+                            unicode_codepoint = keysym & 0x00FFFFFF if (keysym & 0xFF000000) == 0x01000000 else keysym
+                            try:
+                                char_to_type = chr(unicode_codepoint)
+                                unicode_buffer.append(char_to_type)
+                                continue
+                            except ValueError:
+                                pass
+                        
+                        if keysym == 65288 and unicode_buffer:
+                            unicode_buffer.pop() 
+                            continue
+                            
+                        await flush_buffer()
+                        
+                        if keysym in self.MODIFIER_KEYSYMS:
+                            self.active_modifiers.add(keysym)
+                        
                         await self.send_x11_keypress(keysym, down=True)
 
-                elif msg_type == "ku":
-                    keysym = data
-                    if keysym in self.MODIFIER_KEYSYMS:
-                        self.active_modifiers.discard(keysym)
-                    if keysym in self.atomically_typed_keys:
-                        self.atomically_typed_keys.discard(keysym)
-                    else:
-                        await self.send_x11_keypress(keysym, down=False)
+                    elif msg_type == "ku":
+                        if is_unicode_fallback:
+                            continue
 
-                elif msg_type == "kr":
-                    await self.reset_keyboard()
+                        if keysym in self.MODIFIER_KEYSYMS:
+                            self.active_modifiers.discard(keysym)
+                        if keysym in self.atomically_typed_keys:
+                            self.atomically_typed_keys.discard(keysym)
+                        else:
+                            await self.send_x11_keypress(keysym, down=False)
 
-                elif msg_type == "co_end":
-                    text_to_type = data
-                    await self._inject_unicode_via_clipboard(text_to_type)
+                    elif msg_type == "kr":
+                        await flush_buffer()
+                        await self.reset_keyboard()
 
-                self.keyboard_queue.task_done()
+                    elif msg_type == "co_end":
+                        unicode_buffer.append(data)
+
+                finally:
+                    self.keyboard_queue.task_done()
+
             except asyncio.CancelledError:
                 break
             except Exception as e:


### PR DESCRIPTION
**Summary**
- Implement an asynchronous `unicode_buffer` to debounce rapid keystrokes during IME composition.
- Prevent race conditions under high CPU load by batching clipboard injections instead of executing them per keystroke.
- Intercept Backspace (keysym 65288) during composition to pop characters from the buffer rather than triggering a premature flush.
- Ignore `keyup` events during Unicode input to maintain composition context.
- Increase the post-paste delay in `_inject_unicode_via_clipboard` from 0.02s to 0.05s to ensure the target application reads the clipboard before restoration.
- Improve Undo (Ctrl+Z) behavior by preventing the target application's undo history from being polluted with intermediate IME backspaces.

**Reference the issue numbers and reviewers**
https://github.com/linuxserver/docker-baseimage-selkies/issues/150
@thelamer 

**Explain relevant issues and how this pull request solves them**
### Before this PR
- **Per-Keystroke Injection:** Every single Unicode keydown triggered a heavy clipboard injection cycle (`backup -> write -> Shift+Insert -> restore`).
- **Composition Breakage:** The client simulates IME composition by sending sequences like `char -> backspace -> combined char`. The previous logic treated this `backspace` (keysym 65288) as a control key, immediately flushing the buffer and breaking the composition.
- **Polluted Undo History (Ctrl+Z):** Because every intermediate step and backspace during IME composition (e.g., `ㅇ` -> `Backspace` -> `아` -> `Backspace` -> `안`) was individually injected into the OS, the target application recorded every single step. Users had to press `Ctrl+Z` multiple times just to undo one composed character.
- **Unwanted Keyup Flushing:** `keyup` events generated during IME composition caused premature buffer flushes.
- **Premature Clipboard Restoration:** The post-paste wait time in `_inject_unicode_via_clipboard` was set to `0.02s`. Under high CPU load, this was too short, causing the clipboard to be restored to its original state *before* the target application could actually read the injected text.

### After this PR (The Solution)
- **Debouncing with `unicode_buffer`:** Introduced an asynchronous buffer to debounce rapid Unicode keystrokes. The buffer waits for a short timeout (`0.15s`) before flushing, executing the heavy clipboard injection only once for a complete string (e.g., a full word) rather than per character.
- **Backspace Interception:** If a Backspace (`0xFF08`) is received while the `unicode_buffer` has data, it pops the last character from the buffer instead of flushing it to the screen. This perfectly syncs with the client's IME composition behavior.
- **Restored Natural Undo (Ctrl+Z) Behavior:** Since the text is now injected as a complete, debounced batch after the user finishes composing a word, the target application registers it as a single, atomic action. This restores the expected, single-step Undo functionality.
- **Ignored Unicode Keyups:** `keyup` events for Unicode fallbacks are now safely ignored, ensuring the buffer only flushes on actual context-breaking keys (Enter, Space, etc.) or timeout.
- **Stabilized Injection Timing:** Increased the post-paste delay from `0.02s` to `0.05s` to guarantee the target application has enough time to process the `Shift+Insert` action before the clipboard is restored.

### Key Changes
- Refactored `_keyboard_worker` in `input_handler.py`.
- Added `flush_buffer()` logic with a `0.15s` `asyncio.wait_for` timeout.
- Added logic to safely intercept keysym `65288` (Backspace) for local buffer manipulation.
- Increased `asyncio.sleep(0.02)` to `asyncio.sleep(0.05)` after the `Shift+Insert` sequence in `_inject_unicode_via_clipboard`.

**Describe the changes in code and its dependencies and justify that they work as intended after testing**
- Works as intended.
- No changes to dependencies.
- The input isn't immediate, so it seems like it's lagging. (We may need to consider adjusting 0.15 seconds to 0.1 seconds.)

**Describe alternatives you've considered**
I think the best approach is to pass the keys directly without using the clipboard, but I'm not sure if that's possible.

**Additional context**
- Before

https://github.com/user-attachments/assets/dd1474ad-ab56-47ba-a741-e6040a3807c4

- After

https://github.com/user-attachments/assets/525b215b-86ff-4249-bbe6-af43ebc1b956


 - [x] I confirm that this pull request is relevant to the scope of this project. If you know that upstream projects are the cause of this problem, please file the pull request there.
 - [x] I confirm that this pull request has been tested thoroughly and to the best of my knowledge that additional unintended problems do not arise.
 - [x] I confirm that the style of the changed code conforms to the overall style of the project.
 - [x] I confirm that I have read other open and closed pull requests and that duplicates do not exist.
 - [x] I confirm that I have justified the need for this pull request and that the changes reflect the fix for the specified problem.
 - [x] I confirm that no portion of this pull request contains credentials or other private information, and it is my own responsibility to protect my privacy.
 - [x] I confirm that the authors of this pull request does not willfully breach or infringe legal regulations, in any and all global law, regarding trademarks, trade names, logos, patents, or any and all other forms of external intellectual property, as well as adhering to software license terms of open-source and proprietary software projects.
