### PR TITLE
Make dual-mode supervisor port configurable

### DIFF
--- a/src/selkies/__main__.py
+++ b/src/selkies/__main__.py
@@ -133,8 +133,9 @@ async def run():
     manager = StreamSupervisor(managed_stream_modes)
     api_task = None
     if settings.enable_dual_mode[0]:
-        api_task = asyncio.create_task(create_api_server(manager, host='localhost', port=8082))
-        logger.info("Dual mode enabled: Supervisor API server started on port 8082")
+        supervisor_port = settings.supervisor_port
+        api_task = asyncio.create_task(create_api_server(manager, host='localhost', port=supervisor_port))
+        logger.info(f"Dual mode enabled: Supervisor API server started on port {supervisor_port}")
     await manager.switch_to_mode(mode)
     logger.info(f"Starting Selkies in '{mode}' mode.")
     try:

--- a/src/selkies/settings.py
+++ b/src/selkies/settings.py
@@ -114,6 +114,7 @@ SETTING_DEFINITIONS_WEBSOCKETS = [
     # Server Startup & Operational Settings
     {'name': 'port', 'type': 'int', 'default': 8081, 'env_var': 'CUSTOM_WS_PORT', 'help': 'Port for the data websocket server.'},
     {'name': 'control_port', 'type': 'int', 'default': 8083, 'help': 'Port for the internal control plane API.'},
+    {'name': 'supervisor_port', 'type': 'int', 'default': 8083, 'env_var': 'SELKIES_SUPERVISOR_PORT', 'help': 'Port for the dual-mode supervisor API (handles /switch and /status endpoints when enable_dual_mode is true).'},
     {'name': 'master_token', 'type': 'str', 'default': '', 'help': 'Master token to enable secure mode and protect the control plane API.'},
     {'name': 'dri_node', 'type': 'str', 'default': '', 'env_var': 'DRI_NODE', 'help': 'Path to the DRI render node for VA-API.'},
     {'name': 'watermark_path', 'type': 'str', 'default': '', 'env_var': 'WATERMARK_PNG', 'help': 'Absolute path to the watermark PNG file.'},

--- a/src/selkies/settings.py
+++ b/src/selkies/settings.py
@@ -95,6 +95,7 @@ COMMON_SETTING_DEFINITIONS = [
     {'name': 'debug', 'type': 'bool', 'default': False, 'help': 'Enable debug logging.'},
     {'name': 'mode', 'type': 'str', 'default': 'websockets', 'help': "Specify the mode: 'webrtc' or 'websockets'; defaults to websockets"},
     {'name': 'enable_dual_mode', 'type': 'bool', 'default': False, 'help': 'Enable switching Streaming modes from UI'},
+    {'name': 'supervisor_port', 'type': 'int', 'default': 8084, 'help': 'Port for the dual-mode supervisor API (/switch and /status endpoints) when enable_dual_mode is true.'},
     {'name': 'audio_device_name', 'type': 'str', 'default': 'output.monitor', 'help': 'Audio device name for pcmflux capture.'},
 ]
 
@@ -114,7 +115,6 @@ SETTING_DEFINITIONS_WEBSOCKETS = [
     # Server Startup & Operational Settings
     {'name': 'port', 'type': 'int', 'default': 8081, 'env_var': 'CUSTOM_WS_PORT', 'help': 'Port for the data websocket server.'},
     {'name': 'control_port', 'type': 'int', 'default': 8083, 'help': 'Port for the internal control plane API.'},
-    {'name': 'supervisor_port', 'type': 'int', 'default': 8083, 'env_var': 'SELKIES_SUPERVISOR_PORT', 'help': 'Port for the dual-mode supervisor API (handles /switch and /status endpoints when enable_dual_mode is true).'},
     {'name': 'master_token', 'type': 'str', 'default': '', 'help': 'Master token to enable secure mode and protect the control plane API.'},
     {'name': 'dri_node', 'type': 'str', 'default': '', 'env_var': 'DRI_NODE', 'help': 'Path to the DRI render node for VA-API.'},
     {'name': 'watermark_path', 'type': 'str', 'default': '', 'env_var': 'WATERMARK_PNG', 'help': 'Absolute path to the watermark PNG file.'},


### PR DESCRIPTION
**Reference the issue numbers and reviewers**

(no existing issue I'd be aware of)

**Explain relevant issues and how this pull request solves them**

When `SELKIES_ENABLE_DUAL_MODE=true`, `run()` in `src/selkies/__main__.py` starts the supervisor API server (the `/switch` and `/status` endpoints that drive the dashboard's runtime mode switch) on a hard-coded port:

```python
api_task = asyncio.create_task(create_api_server(manager, host='localhost', port=8082))
logger.info("Dual mode enabled: Supervisor API server started on port 8082")
```

That hardcoded `8082` collides with the default of the `port` setting (`SELKIES_PORT`, the data websocket server), which is also `8082`.

Result: turning dual mode on out of the box races two listeners against the same port. In the typical container deployment (e.g. `linuxserver/baseimage-selkies`, where `CUSTOM_WS_PORT` defaults to `8082`) users have to know to override `CUSTOM_WS_PORT=8081` (or similar) or one of the two services fails silently. There is no env var today to move the supervisor instead.

This PR makes the supervisor port a first-class setting so it can be moved without changing the data port:

- new `supervisor_port` setting (`SELKIES_SUPERVISOR_PORT`), default `8083`
- `run()` reads `settings.supervisor_port` instead of the hardcoded `8082`
- log line includes the actual port

`8083` matches the existing `control_port` default and removes the collision out of the box, while leaving every other default unchanged.

**Describe the changes in code and its dependencies and justify that they work as intended after testing**

Two files touched, both in `src/selkies/`:

`settings.py` — one new entry in the settings list:

```python
{'name': 'supervisor_port', 'type': 'int', 'default': 8083,
 'env_var': 'SELKIES_SUPERVISOR_PORT',
 'help': 'Port for the dual-mode supervisor API (handles /switch and /status endpoints when enable_dual_mode is true).'},
```

`__main__.py` — replace the hardcoded port in the dual-mode branch:

```python
if settings.enable_dual_mode[0]:
    supervisor_port = settings.supervisor_port
    api_task = asyncio.create_task(create_api_server(manager, host='localhost', port=supervisor_port))
    logger.info(f"Dual mode enabled: Supervisor API server started on port {supervisor_port}")
```

No new dependencies. No change to the supervisor server itself, only where it binds.

Tested manually inside a `linuxserver/baseimage-selkies`-derived container (debian-trixie + xfce):

Default (no env var):

```
$ docker run -d -e SELKIES_ENABLE_DUAL_MODE=true ... webtop:patched
$ docker exec <id> ss -ltn | grep -E '808[0-9]'
LISTEN 0 128 127.0.0.1:8082 0.0.0.0:*    # data ws (selkies --port default)
LISTEN 0 128 127.0.0.1:8083 0.0.0.0:*    # supervisor API (new default)
```

Override:

```
$ docker run -d -e SELKIES_ENABLE_DUAL_MODE=true -e SELKIES_SUPERVISOR_PORT=9099 ...
$ docker exec <id> ss -ltn | grep 9099
LISTEN 0 128 127.0.0.1:9099 0.0.0.0:*

$ curl -s http://127.0.0.1:9099/status
{"current_mode": "websockets", "status": "running"}
```

Single-mode (`enable_dual_mode=false`, default): the supervisor task is not started either way, so the new setting has no effect — confirmed by running the previous default config and observing only the data ws listener.

**Describe alternatives you've considered**

- Move the data port instead and keep the supervisor at `8082`. Rejected: the data port is far more widely referenced in downstream nginx configs, deployment scripts and docs (`CUSTOM_WS_PORT`, `proxy_pass http://127.0.0.1:8082`), so changing it would be the more disruptive break.
- Make the supervisor port follow `port + 1`. Rejected as kinda unintuitive
- Keep `8082` as the supervisor default and document that `CUSTOM_WS_PORT` must be moved. Rejected: this is the current state and the source of the bug report from downstream.

**Additional context**

This unblocks the corresponding nginx routing in `linuxserver/docker-baseimage-selkies` (separate PR) which adds
`location ~ ^/(switch|status)$` and a configurable `SELKIES_SUPERVISOR_PORT` env var on the nginx side; with that PR plus
this one, `linuxserver/webtop` users get working runtime mode switching without any custom port juggling.

 - [x] I confirm that this pull request is relevant to the scope of this project.
 - [x] I confirm that this pull request has been tested thoroughly.
 - [x] I confirm that the style of the changed code conforms to the overall style of the project.
 - [x] I confirm that I have read other open and closed pull requests and that duplicates do not exist.
 - [x] I confirm that I have justified the need for this pull request.
 - [x] I confirm that no portion of this pull request contains credentials or other private information.
 - [x] I confirm that this pull request does not willfully infringe trademarks, patents, or other IP, and adheres to applicable software license terms.