### PR TITLE
Detect server stream mode at startup

### DIFF
--- a/addons/selkies-dashboard/src/components/Sidebar.jsx
+++ b/addons/selkies-dashboard/src/components/Sidebar.jsx
@@ -995,7 +995,7 @@ function Sidebar() {
 
   const [streamMode, setStreamMode] = useState(
     localStorage.getItem(getPrefixedKey("stream_mode")) ||
-      (typeof window !== "undefined" && window.__SELKIES_INITIAL_MODE__) ||
+      (typeof window !== "undefined" && window.__SELKIES_STREAMING_MODE__) ||
       DEFAULT_STREAM_MODE
   );
   const [encoderRTC, setEncoderRTC] = useState(

--- a/addons/selkies-dashboard/src/components/Sidebar.jsx
+++ b/addons/selkies-dashboard/src/components/Sidebar.jsx
@@ -994,7 +994,9 @@ function Sidebar() {
   };
 
   const [streamMode, setStreamMode] = useState(
-    localStorage.getItem(getPrefixedKey("stream_mode")) || DEFAULT_STREAM_MODE
+    localStorage.getItem(getPrefixedKey("stream_mode")) ||
+      (typeof window !== "undefined" && window.__SELKIES_INITIAL_MODE__) ||
+      DEFAULT_STREAM_MODE
   );
   const [encoderRTC, setEncoderRTC] = useState(
     localStorage.getItem(getPrefixedKey("encoder_rtc")) || DEFAULT_WEBRTC_ENCODER

--- a/addons/selkies-dashboard/src/main.jsx
+++ b/addons/selkies-dashboard/src/main.jsx
@@ -4,21 +4,25 @@ import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import PlayerGamepadButton from './components/PlayerGamepadButton.jsx';
 import './index.css';
-import './selkies-core.js';
 
 // Probe the dual-mode supervisor for the currently active streaming mode
-// before mounting React, so the dashboard's initial streamMode matches the
-// server. Falls back silently when no supervisor is running (single-mode setups).
+// before importing selkies-core. selkies-core reads
+// window.__SELKIES_STREAMING_MODE__ at module-evaluation time and starts the
+// transport immediately, so the probe must finish first. Falls back silently
+// (single-mode setups have no /status endpoint).
 async function detectInitialMode() {
   try {
-    const r = await fetch('./status', { credentials: 'same-origin' });
+    const r = await fetch('./status', {
+      credentials: 'same-origin',
+      signal: AbortSignal.timeout(3000),
+    });
     if (!r.ok) return;
     const data = await r.json();
     if (data && data.current_mode) {
-      window.__SELKIES_INITIAL_MODE__ = data.current_mode;
+      window.__SELKIES_STREAMING_MODE__ = data.current_mode;
     }
   } catch {
-    // /status not available (no dual-mode), keep default
+    // /status missing, slow, or returned bad JSON - keep default
   }
 }
 
@@ -28,6 +32,7 @@ const playerClientModes = ['#player2', '#player3', '#player4'];
 
 (async () => {
   await detectInitialMode();
+  await import('./selkies-core.js');
   if (!noDashboardModes.includes(currentHash)) {
     const dashboardRootElement = document.createElement('div');
     dashboardRootElement.id = 'dashboard-root';

--- a/addons/selkies-dashboard/src/main.jsx
+++ b/addons/selkies-dashboard/src/main.jsx
@@ -6,35 +6,54 @@ import PlayerGamepadButton from './components/PlayerGamepadButton.jsx';
 import './index.css';
 import './selkies-core.js';
 
+// Probe the dual-mode supervisor for the currently active streaming mode
+// before mounting React, so the dashboard's initial streamMode matches the
+// server. Falls back silently when no supervisor is running (single-mode setups).
+async function detectInitialMode() {
+  try {
+    const r = await fetch('./status', { credentials: 'same-origin' });
+    if (!r.ok) return;
+    const data = await r.json();
+    if (data && data.current_mode) {
+      window.__SELKIES_INITIAL_MODE__ = data.current_mode;
+    }
+  } catch {
+    // /status not available (no dual-mode), keep default
+  }
+}
+
 const currentHash = window.location.hash;
 const noDashboardModes = ['#shared', '#player2', '#player3', '#player4'];
 const playerClientModes = ['#player2', '#player3', '#player4'];
 
-if (!noDashboardModes.includes(currentHash)) {
-  const dashboardRootElement = document.createElement('div');
-  dashboardRootElement.id = 'dashboard-root';
-  document.body.appendChild(dashboardRootElement);
-  const appMountPoint = document.getElementById('root');
-  if (appMountPoint) {
-    ReactDOM.createRoot(appMountPoint).render(
-      <React.StrictMode>
-        <App dashboardRoot={dashboardRootElement} />
-      </React.StrictMode>,
-    );
+(async () => {
+  await detectInitialMode();
+  if (!noDashboardModes.includes(currentHash)) {
+    const dashboardRootElement = document.createElement('div');
+    dashboardRootElement.id = 'dashboard-root';
+    document.body.appendChild(dashboardRootElement);
+    const appMountPoint = document.getElementById('root');
+    if (appMountPoint) {
+      ReactDOM.createRoot(appMountPoint).render(
+        <React.StrictMode>
+          <App dashboardRoot={dashboardRootElement} />
+        </React.StrictMode>,
+      );
+    } else {
+      console.error("CRITICAL: Dashboard mount point #root not found. Primary dashboard will not render.");
+    }
   } else {
-    console.error("CRITICAL: Dashboard mount point #root not found. Primary dashboard will not render.");
+    console.log(`Dashboard UI rendering skipped for mode: ${currentHash}`);
+    if (playerClientModes.includes(currentHash)) {
+      console.log(`Player client mode detected. Initializing gamepad button UI for ${currentHash}.`);
+      const playerUIRootElement = document.createElement('div');
+      playerUIRootElement.id = 'player-ui-root';
+      document.body.appendChild(playerUIRootElement);
+      ReactDOM.createRoot(playerUIRootElement).render(
+        <React.StrictMode>
+          <PlayerGamepadButton />
+        </React.StrictMode>,
+      );
+    }
   }
-} else {
-  console.log(`Dashboard UI rendering skipped for mode: ${currentHash}`);
-  if (playerClientModes.includes(currentHash)) {
-    console.log(`Player client mode detected. Initializing gamepad button UI for ${currentHash}.`);
-    const playerUIRootElement = document.createElement('div');
-    playerUIRootElement.id = 'player-ui-root';
-    document.body.appendChild(playerUIRootElement);
-    ReactDOM.createRoot(playerUIRootElement).render(
-      <React.StrictMode>
-        <PlayerGamepadButton />
-      </React.StrictMode>,
-    );
-  }
-}
+})();


### PR DESCRIPTION
**Reference the issue numbers and reviewers**

(no existing issue)

**Explain relevant issues and how this pull request solves them**

In dual mode the selkies server may be started in either `websockets` or `webrtc` mode (`SELKIES_MODE`, controlled by `addons/selkies-dashboard` once running, or by env var on first launch). The dashboard, however, hardcodes its initial assumption to `websockets`:

```js
// addons/selkies-dashboard/src/components/Sidebar.jsx
const [streamMode, setStreamMode] = useState(
  localStorage.getItem(getPrefixedKey("stream_mode")) || DEFAULT_STREAM_MODE
);
```

with `DEFAULT_STREAM_MODE = "websockets"`. So a brand-new visitor landing on a server that was started in `--mode=webrtc` opens a websocket connection at `/websockets`, which the WebRTC pipeline does not handle, and the dashboard silently stalls. The streaming-mode selector in the sidebar is the recovery path, but in some downstream forks it is itself gated on a successful initial connect, so users hit a chicken-and-egg situation.

This PR teaches the dashboard to ask the server which mode is currently active before the first React render, using the existing `/status` endpoint exposed by the dual-mode supervisor.

**Describe the changes in code and its dependencies and justify that they work as intended after testing**

Two files touched, both under `addons/selkies-dashboard/src/`:

`main.jsx` - small async probe before mount:

```js
async function detectInitialMode() {
  try {
    const r = await fetch('./status', { credentials: 'same-origin' });
    if (!r.ok) return;
    const data = await r.json();
    if (data && data.current_mode) {
      window.__SELKIES_INITIAL_MODE__ = data.current_mode;
    }
  } catch {
    // /status not available (no dual-mode), keep default
  }
}

(async () => {
  await detectInitialMode();
  // ... existing mount logic ...
})();
```

`Sidebar.jsx` - fall through to the probe result if no localStorage preference exists:

```js
const [streamMode, setStreamMode] = useState(
  localStorage.getItem(getPrefixedKey("stream_mode")) ||
    (typeof window !== "undefined" && window.__SELKIES_INITIAL_MODE__) ||
    DEFAULT_STREAM_MODE
);
```

Order of precedence (unchanged for users with an explicit preference):

```
1. localStorage["..._stream_mode"]      explicit user choice (sticky)
2. window.__SELKIES_INITIAL_MODE__      server-reported active mode
3. DEFAULT_STREAM_MODE                  compile-time default
```

If `./status` does not exist (single-mode setup, or supervisor disabled), `fetch` throws or returns non-OK, the catch swallows it, and behaviour is identical to before this patch. No new runtime dependency on the supervisor - single-mode deployments are unaffected.

Tested in a `linuxserver/baseimage-selkies`-derived container (debian-trixie + xfce, dashboard rebuilt from source) in Firefox 149 and Chromium 142:

| Scenario                            | Before                       | After                  |
| ----------------------------------- | ---------------------------- | ---------------------- |
| Dual mode, server `--mode=webrtc`, no LS | dashboard tries WS, stalls | dashboard opens WebRTC |
| Dual mode, server `--mode=websockets`    | works                      | works (unchanged)      |
| Dual mode, LS `stream_mode=webrtc`, server in `websockets` | uses LS: webrtc | uses LS: webrtc (unchanged) |
| Single mode (no `/status`)          | works                        | works (probe fails silently) |
| `/status` returns 500               | works                        | works (probe fails silently) |

DevTools network shows exactly one `GET /status` per cold load when present, no requests when absent.

**Describe alternatives you've considered**

- Have the server inject the active mode into `index.html` at build/run time. Rejected: requires server-side templating in nginx/selkies and couples the dashboard build to a specific deployment.
- Read it from a websocket handshake response. Rejected: too late - the dashboard already had to commit to a transport by then.
- Loop until the user picks a mode in the UI. Rejected: the recovery selector is itself sometimes behind a successful connect.
- Drop `DEFAULT_STREAM_MODE` and require explicit selection. Rejected: worse first-time-visitor UX, and breaks all existing single-mode deployments that never expose a selector.

**Additional context**

This pairs with the `supervisor_port` PR (#?) and with the linuxserver nginx-routing PRs that expose `/status` to the browser. All three are necessary to fix the end-to-end flow; this one is the last piece on the dashboard side.

 - [x] I confirm that this pull request is relevant to the scope of this project.
 - [x] I confirm that this pull request has been tested thoroughly.
 - [x] I confirm that the style of the changed code conforms to the overall style of the project.
 - [x] I confirm that I have read other open and closed pull requests and that duplicates do not exist.
 - [x] I confirm that I have justified the need for this pull request.
 - [x] I confirm that no portion of this pull request contains credentials or other private information.
 - [x] I confirm that this pull request does not willfully infringe trademarks, patents, or other IP, and adheres to applicable software license terms.