### PR TITLE
fix(settings): accept "none" / "" as explicit empty list for list-type settings

### DIFF
--- a/src/selkies/settings.py
+++ b/src/selkies/settings.py
@@ -231,12 +231,19 @@ class AppSettings:
                 elif stype in ['enum', 'list']:
                     if is_override:
                         master_list = setting.get('meta', {}).get('allowed', [])
-                        user_items = [item.strip() for item in str(raw_value).split(',') if item.strip()]
-                        valid_items = [item for item in user_items if item in master_list]
-                        if not valid_items:
-                            logging.warning(f"Invalid value(s) '{raw_value}' for {name}. Using system default.")
-                            default_str = str(setting['default'])
-                            valid_items = [item.strip() for item in default_str.split(',') if item in master_list]
+                        raw_value_str = str(raw_value)
+                        if stype == 'list' and raw_value_str.strip().lower() in ('', 'none'):
+                            # Explicit "disable" tokens for list-type settings.
+                            # Documented in each list setting's help text (e.g.
+                            # file_transfers: 'Set to "" or "none" to disable.').
+                            valid_items = []
+                        else:
+                            user_items = [item.strip() for item in raw_value_str.split(',') if item.strip()]
+                            valid_items = [item for item in user_items if item in master_list]
+                            if not valid_items:
+                                logging.warning(f"Invalid value(s) '{raw_value_str}' for {name}. Using system default.")
+                                default_str = str(setting['default'])
+                                valid_items = [item.strip() for item in default_str.split(',') if item in master_list]
                         setting['meta']['allowed'] = valid_items
                         if stype == 'enum':
                             processed_value = valid_items[0] if valid_items else setting['default']


### PR DESCRIPTION
**Reference the issue numbers and reviewers**

Closes #239.

**Explain relevant issues and how this pull request solves them**

This PR addresses #239: `SELKIES_FILE_TRANSFERS="none"` (and `""`) — both documented in the help text as the way to disable transfers — are rejected by the list-type validator and silently overridden with the default `upload,download`.

The list-type validator filters comma-separated user values against `meta.allowed`. For `'none'` and `''` the filter yields an empty `valid_items`, hits the `if not valid_items:` branch, logs `WARNING:root:Invalid value(s) ... Using system default.`, and refills `valid_items` from the default. The user's intent to disable is lost.

This PR adds a small short-circuit at the top of the list branch: if the raw value is `''` or `'none'` (case-insensitive) AND the type is `list`, resolve to `[]` without emitting the warning. Genuinely-invalid values (`'uploadx'`) keep the existing warn-and-fallback behaviour, and the entire `enum` path is unchanged.

**Describe the changes in code and its dependencies and justify that they work as intended after testing**

One change in `src/selkies/settings.py`, inside `AppSettings._process_and_set_attributes`, in the `elif stype in ['enum', 'list']:` branch. No new imports, no API surface change.

Verified locally with a Python harness importing `selkies.settings` after setting `SELKIES_FILE_TRANSFERS` (and `SELKIES_RATE_CONTROL_MODE` for the enum path). On `main` at `1a9cd02` (pre-fix) and on this branch (post-fix):

| Env override | Pre-fix `file_transfers` | Pre-fix log | Post-fix `file_transfers` | Post-fix log |
|---|---|---|---|---|
| `SELKIES_FILE_TRANSFERS=none` | `['upload','download']` | warn `Invalid value(s) 'none'` | `[]` | (none) |
| `SELKIES_FILE_TRANSFERS=""` | `['upload','download']` | warn `Invalid value(s) ''` | `[]` | (none) |
| `SELKIES_FILE_TRANSFERS=upload` | `['upload']` | (none) | `['upload']` | (none) |
| `SELKIES_FILE_TRANSFERS=upload,download` | `['upload','download']` | (none) | `['upload','download']` | (none) |
| `SELKIES_FILE_TRANSFERS=uploadx` | `['upload','download']` (typo path) | warn `Invalid value(s) 'uploadx'` | `['upload','download']` (typo path) | warn `Invalid value(s) 'uploadx'` |
| unset | `['upload','download']` (default) | (none) | `['upload','download']` (default) | (none) |

Enum path (`SELKIES_RATE_CONTROL_MODE`) post-fix:

| Env override | Resolved | Log |
|---|---|---|
| `none` | `'crf'` (default) | warn `Invalid value(s) 'none'` |
| `cbr` | `'cbr'` | (none) |

All expected. Typo path and enum semantics are unchanged.

I did not add a unit test in this PR — the project does not currently ship a `tests/` directory and I did not want to make that structural choice unsolicited. Happy to add a self-contained `test_settings.py` covering this and the enum case if you'd prefer; let me know what shape would fit the project.

**Describe alternatives you've considered**

* **Field-specific special case for `file_transfers`.** Smaller blast radius but doesn't generalise. Other list-type settings would need the same special case if they want a "disable" token. Rejected because the help text format ("Set to '' or 'none' to disable") reads as a generic mechanism rather than a per-field convention.
* **Help-text-only fix (delete the misleading sentence).** Leaves users with no documented way to disable transfers from config, and our downstream operator (and presumably others) already depends on the documented behaviour.
* **Treat any unrecognised value as "explicit empty"** (drop the warn-and-fallback entirely). Rejected — `uploadx` typos would silently fail closed; loud failure on typos is the right default.

**Additional context**

Filed against `main` at `1a9cd02b61e31e65939ac2453e3f119a8793d3f0`. License header on `settings.py` is unchanged (MPL-2.0).

 - [x] I confirm that this pull request is relevant to the scope of this project. If you know that upstream projects are the cause of this problem, please file the pull request there.
 - [x] I confirm that this pull request has been tested thoroughly and to the best of my knowledge that additional unintended problems do not arise.
 - [x] I confirm that the style of the changed code conforms to the overall style of the project.
 - [x] I confirm that I have read other open and closed pull requests and that duplicates do not exist.
 - [x] I confirm that I have justified the need for this pull request and that the changes reflect the fix for the specified problem.
 - [x] I confirm that no portion of this pull request contains credentials or other private information, and it is my own responsibility to protect my privacy.
 - [x] I confirm that the authors of this pull request does not willfully breach or infringe legal regulations, in any and all global law, regarding trademarks, trade names, logos, patents, or any and all other forms of external intellectual property, as well as adhering to software license terms of open-source and proprietary software projects.
