### PR TITLE
Configure streaming modes to honor disabling of audio from config settings

### DIFF
--- a/addons/example/selkies-entrypoint.sh
+++ b/addons/example/selkies-entrypoint.sh
@@ -318,16 +318,13 @@ if [ ! -z "${DEV_MODE+x}" ]; then
     "python3" -m selkies \
       --addr="${addr}" \
       --port="${port}" \
-      --enable_basic_auth="false" \
+      --enable-basic-auth="false" \
       --mode="${SELKIES_MODE:-websockets}"
 else
   # Start Selkies
   exec selkies \
     --addr="${addr}" \
     --port="${port}" \
-    --enable_basic_auth="false" \
-    --enable_metrics_http="true" \
-    --mode="${SELKIES_MODE:-websockets}" \
     $@
 fi
 

--- a/addons/selkies-web-core/selkies-ws-core.js
+++ b/addons/selkies-web-core/selkies-ws-core.js
@@ -41,6 +41,8 @@ let isGamepadEnabled;
 let lastReceivedVideoFrameId = -1;
 let mainDecoderHasKeyframe = false;
 let initializationComplete = false;
+let audioEnabled = true;
+let microphoneEnabled = true;
 // Display related resources
 let displayId = 'primary';
 let displayPosition = 'right';
@@ -1803,6 +1805,10 @@ function receiveMessage(event) {
             console.log("Secondary display: Audio control blocked.");
             break;
         }
+        if (!audioEnabled) {
+          console.log("Audio is disabled. Audio pipeline control blocked.");
+          break;
+        }
         if (isAudioPipelineActive !== desiredState) {
           isAudioPipelineActive = desiredState;
           stateChangedFromControl = true;
@@ -1819,6 +1825,10 @@ function receiveMessage(event) {
       } else if (pipeline === 'microphone') {
         if (isSharedMode) {
           console.log("Shared mode: Microphone control blocked.");
+          break;
+        }
+        if (!microphoneEnabled) {
+          console.log("Microphone is disabled. Microphone pipeline control blocked.");
           break;
         }
         if (desiredState) {
@@ -1843,6 +1853,10 @@ function receiveMessage(event) {
       console.log('Received audioDeviceSelected message:', message);
       if (isSharedMode && message.context === 'input') {
           console.log("Shared mode: Audio input device selection ignored.");
+          break;
+      }
+      if (!audioEnabled) {
+          console.log("Audio control flag is disabled. Audio device selection blocked.");
           break;
       }
       const {
@@ -3876,6 +3890,32 @@ function handleDecodedFrame(frame) {
           isAudioPipelineActive = false;
           window.postMessage({ type: 'pipelineStatusUpdate', audio: false }, window.location.origin);
           if (audioDecoderWorker) audioDecoderWorker.postMessage({ type: 'updatePipelineStatus', data: { isActive: false } });
+        } else if (event.data === 'AUDIO_DISABLED' && !isSharedMode) {
+          console.log("Server reports audio is disabled. Tearing down audio workers.");
+          audioEnabled = false;
+          isAudioPipelineActive = false;
+          if (audioDecoderWorker) {
+            audioDecoderWorker.postMessage({ type: 'updatePipelineStatus', data: { isActive: false } });
+            audioDecoderWorker.postMessage({ type: 'close' });
+            setTimeout(() => {
+              if (audioDecoderWorker) {
+                audioDecoderWorker.terminate();
+                audioDecoderWorker = null;
+              }
+            }, 50);
+          }
+          if (audioContext) {
+            try { audioContext.close(); } catch (e) { console.error("Error closing AudioContext on AUDIO_DISABLED:", e); }
+            audioContext = null;
+            audioWorkletNode = null;
+            audioWorkletProcessorPort = null;
+          }
+          window.postMessage({ type: 'pipelineStatusUpdate', audio: false }, window.location.origin);
+        } else if (event.data === 'MICROPHONE_DISABLED' && !isSharedMode) {
+          console.log("Server reports microphone is disabled. Stopping microphone capture.");
+          microphoneEnabled = false;
+          stopMicrophoneCapture();
+          window.postMessage({ type: 'pipelineStatusUpdate', microphone: false }, window.location.origin);
         } else {
           if (window.webrtcInput && window.webrtcInput.on_message && !isSharedMode) {
             window.webrtcInput.on_message(event.data);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "distro",
     "importlib-resources>=6.0; python_version < '3.9'",
     # PulseAudio Microphone
-    "pulsectl",
+    "pulsectl-asyncio",
     "pasimple",
     # WebRTC
     "aioice>=0.10.1,<1.0.0",

--- a/src/selkies/media_pipeline.py
+++ b/src/selkies/media_pipeline.py
@@ -22,21 +22,26 @@
 import asyncio
 import logging
 import ctypes
+import pulsectl
 from enum import Enum
 from abc import ABCMeta, abstractmethod
+from typing import Callable
 
-from pixelflux import CaptureSettings, ScreenCapture, StripeCallback
+from pixelflux import CaptureSettings, ScreenCapture
 from pcmflux import AudioCapture, AudioCaptureSettings, AudioChunkCallback
 
 logger = logging.getLogger("media_pipeline")
 logger.setLevel(logging.INFO)
 
+
 class RateControlMode(str, Enum):
     CBR = "cbr"
     CRF = "crf"
 
+
 class MediaPipelineError(Exception):
     pass
+
 
 class MediaPipeline(metaclass=ABCMeta):
     @abstractmethod
@@ -79,6 +84,7 @@ class MediaPipeline(metaclass=ABCMeta):
     async def set_crf(self, crf: int):
         pass
 
+
 class MediaPipelinePixel(MediaPipeline):
     def __init__(
         self,
@@ -91,9 +97,9 @@ class MediaPipelinePixel(MediaPipeline):
         height: int = 1080,
         audio_channels: int = 2,
         audio_enabled: bool = True,
-        audio_device_name = 'output.monitor',
+        audio_device_name="output.monitor",
         crf: int = 23,
-        rc_mode: RateControlMode = RateControlMode.CBR
+        rc_mode: RateControlMode = RateControlMode.CBR,
     ):
         self.async_event_loop = async_event_loop
         self.audio_channels = audio_channels
@@ -110,8 +116,12 @@ class MediaPipelinePixel(MediaPipeline):
         self.audio_enabled = audio_enabled
         self.audio_device_name = audio_device_name
         self.capture_cursor = False
-        self.produce_data = lambda buf, pts, kind: logger.warning('unhandled produce_data')
-        self.send_data_channel_message = lambda msg: logger.warning('unhandled send_data_channel_message')
+        self.produce_data: Callable[[bytes, int, str], None] = lambda buf, pts, kind: logger.warning(
+            "unhandled produce_data"
+        )
+        self.send_data_channel_message: Callable[[str], None] = lambda msg: logger.warning(
+            "unhandled send_data_channel_message"
+        )
 
         self.capture_module = None
         self.pcmflux_module = None
@@ -155,7 +165,9 @@ class MediaPipelinePixel(MediaPipeline):
             await self.restart_screen_capture()
             logger.info(f"Updated rate control mode to: {self.rc_mode}")
         except AttributeError:
-            logger.error("Video capture module does not support rate control mode updation")
+            logger.error(
+                "Video capture module does not support rate control mode updation"
+            )
         except Exception as e:
             logger.info(f"Error updating rate control mode {e}", exc_info=True)
 
@@ -188,12 +200,20 @@ class MediaPipelinePixel(MediaPipeline):
         if not self._is_screen_capturing or self.capture_module is None:
             return
 
-        if self.rc_mode == RateControlMode.CRF or new_bitrate <= 0 or self.video_bitrate == new_bitrate:
+        if (
+            self.rc_mode == RateControlMode.CRF
+            or new_bitrate <= 0
+            or self.video_bitrate == new_bitrate
+        ):
             return
 
         try:
-            await self.async_event_loop.run_in_executor(None, self.capture_module.update_video_bitrate, new_bitrate * 1000)
-            logger.info(f"Updated video bitrate: {self.video_bitrate}Mbps -> {new_bitrate}Mbps")
+            await self.async_event_loop.run_in_executor(
+                None, self.capture_module.update_video_bitrate, new_bitrate * 1000
+            )
+            logger.info(
+                f"Updated video bitrate: {self.video_bitrate}Mbps -> {new_bitrate}Mbps"
+            )
             self.video_bitrate = new_bitrate
         except AttributeError:
             logger.error("Video capture module does not support video bitrate updation")
@@ -208,12 +228,16 @@ class MediaPipelinePixel(MediaPipeline):
         if not self._is_pcmflux_capturing or self.pcmflux_module is None:
             return
 
-        if  new_bitrate <= 0 or self.audio_bitrate == new_bitrate:
+        if new_bitrate <= 0 or self.audio_bitrate == new_bitrate:
             return
 
         try:
-            await self.async_event_loop.run_in_executor(None, self.pcmflux_module.update_audio_bitrate, new_bitrate)
-            logger.info(f"Updated audio bitrate: {self.audio_bitrate // 1000} -> {new_bitrate // 1000} kbps")
+            await self.async_event_loop.run_in_executor(
+                None, self.pcmflux_module.update_audio_bitrate, new_bitrate
+            )
+            logger.info(
+                f"Updated audio bitrate: {self.audio_bitrate // 1000} -> {new_bitrate // 1000} kbps"
+            )
             self.audio_bitrate = new_bitrate
         except AttributeError:
             logger.error("Audio capture module does not support audio bitrate updation")
@@ -233,7 +257,9 @@ class MediaPipelinePixel(MediaPipeline):
                 return
 
             self.framerate = framerate
-            await self.async_event_loop.run_in_executor(None, self.capture_module.update_framerate, float(self.framerate))
+            await self.async_event_loop.run_in_executor(
+                None, self.capture_module.update_framerate, float(self.framerate)
+            )
             logger.info(f"Updated framerate to: {self.framerate}")
 
     async def dynamic_idr_frame(self):
@@ -241,7 +267,9 @@ class MediaPipelinePixel(MediaPipeline):
         if not self._is_screen_capturing or self.capture_module is None:
             return
         try:
-            await self.async_event_loop.run_in_executor(None, self.capture_module.request_idr_frame)
+            await self.async_event_loop.run_in_executor(
+                None, self.capture_module.request_idr_frame
+            )
             logger.info("IDR frame requested successfully")
         except AttributeError:
             logger.error("ScreenCapture module does not support IDR frame request")
@@ -269,7 +297,7 @@ class MediaPipelinePixel(MediaPipeline):
             cs.h264_bitrate_kbps = self.video_bitrate * 1000  # Convert Mbps to kbps
             cs.vaapi_render_node_index = -1
             if self.encoder_rtc == "x264enc":
-                cs.use_cpu = True        
+                cs.use_cpu = True
         return cs
 
     async def start_screen_capture(self):
@@ -277,27 +305,38 @@ class MediaPipelinePixel(MediaPipeline):
             return
 
         settings = self.generate_capture_settings()
+
         def screen_capture_callback(result_ptr, _):
             if not result_ptr:
                 return
             try:
                 result = result_ptr.contents
                 if result.size > 0:
-                    data_bytes = bytes(result.data[10:result.size])
+                    data_bytes = bytes(result.data[10 : result.size])
                     if not hasattr(result, "frame_id"):
-                        logger.error(f"frame_id from callback is empty: {result.frame_id}")
+                        logger.error(
+                            f"frame_id from callback is empty: {result.frame_id}"
+                        )
                     else:
                         # Generate pts from frame_id
                         pts_step = 90000 // self.framerate
                         pts = result.frame_id * pts_step
-                        asyncio.run_coroutine_threadsafe(self.produce_data(data_bytes, pts, "video"), self.async_event_loop)
+                        asyncio.run_coroutine_threadsafe(
+                            self.produce_data(data_bytes, pts, "video"),
+                            self.async_event_loop,
+                        )
 
             except Exception as e:
                 logger.error(f"Error in capture callback: {e}", exc_info=False)
 
         try:
             self.capture_module = ScreenCapture()
-            await self.async_event_loop.run_in_executor(None, self.capture_module.start_capture, settings, screen_capture_callback)
+            await self.async_event_loop.run_in_executor(
+                None,
+                self.capture_module.start_capture,
+                settings,
+                screen_capture_callback,
+            )
             self._is_screen_capturing = True
             logger.info("Started screen capture module")
         except Exception as e:
@@ -305,12 +344,13 @@ class MediaPipelinePixel(MediaPipeline):
             self.capture_module = None
             self._is_screen_capturing = False
 
-
     async def stop_screen_capture(self):
         if not self._is_screen_capturing or self.capture_module is None:
             return
         try:
-            await self.async_event_loop.run_in_executor(None, self.capture_module.stop_capture)
+            await self.async_event_loop.run_in_executor(
+                None, self.capture_module.stop_capture
+            )
             self.capture_module = None
             self._is_screen_capturing = False
             logger.info("Stopped screen capture module")
@@ -338,7 +378,11 @@ class MediaPipelinePixel(MediaPipeline):
         logger.info("Starting pcmflux audio pipeline...")
         try:
             capture_settings = AudioCaptureSettings()
-            device_name_bytes = self.audio_device_name.encode('utf-8') if self.audio_device_name else None
+            device_name_bytes = (
+                self.audio_device_name.encode("utf-8")
+                if self.audio_device_name
+                else None
+            )
             capture_settings.device_name = device_name_bytes
             capture_settings.sample_rate = 48000
             capture_settings.channels = self.audio_channels
@@ -350,8 +394,10 @@ class MediaPipelinePixel(MediaPipeline):
             capture_settings.debug_logging = False
             pcmflux_settings = capture_settings
 
-            logger.info(f"pcmflux settings: device='{self.audio_device_name}', "
-                        f"bitrate={capture_settings.opus_bitrate}, channels={capture_settings.channels}")
+            logger.info(
+                f"pcmflux settings: device='{self.audio_device_name}', "
+                f"bitrate={capture_settings.opus_bitrate}, channels={capture_settings.channels}"
+            )
 
             def audio_capture_callback(result_ptr, user_data):
                 if not result_ptr:
@@ -359,23 +405,160 @@ class MediaPipelinePixel(MediaPipeline):
                 try:
                     result = result_ptr.contents
                     if result.data and result.size > 0:
-                        data_bytes = bytes(ctypes.cast(
-                            result.data, ctypes.POINTER(ctypes.c_ubyte * result.size)
-                        ).contents)
+                        data_bytes = bytes(
+                            ctypes.cast(
+                                result.data,
+                                ctypes.POINTER(ctypes.c_ubyte * result.size),
+                            ).contents
+                        )
 
-                        asyncio.run_coroutine_threadsafe(self.produce_data(data_bytes, result.pts, "audio"), self.async_event_loop)
+                        asyncio.run_coroutine_threadsafe(
+                            self.produce_data(data_bytes, result.pts, "audio"),
+                            self.async_event_loop,
+                        )
                 except Exception as e:
                     logger.info(f"Error audio capture callback: {e}")
 
             pcmflux_callback = AudioChunkCallback(audio_capture_callback)
             self.pcmflux_module = AudioCapture()
-            await self.async_event_loop.run_in_executor(None, self.pcmflux_module.start_capture, pcmflux_settings, pcmflux_callback)
+            await self.async_event_loop.run_in_executor(
+                None,
+                self.pcmflux_module.start_capture,
+                pcmflux_settings,
+                pcmflux_callback,
+            )
             self._is_pcmflux_capturing = True
+            asyncio.create_task(self._enforce_audio_routing())
             logger.info("pcmflux audio capture started successfully.")
         except Exception as e:
             logger.error(f"Failed to start pcmflux audio pipeline: {e}", exc_info=True)
             await self._stop_audio_pipeline()
             return
+
+    async def _enforce_audio_routing(self):
+        """
+        PipeWire often ignores requested audio device and connects recording apps
+        to the default source. This could happen when switching between
+        streaming modes. So route the pcmflux stream to correct source.
+        """
+        # Give pcmflux a fraction of a second to initialize its PA stream
+        await asyncio.sleep(0.5)
+        try:
+            pulse = pulsectl.Pulse("selkies-webrtc-router")
+        except Exception as e:
+            logger.error(
+                f"Failed to connect to PulseAudio for routing enforcement: {e}"
+            )
+            return
+
+        try:
+            current_source_list = pulse.source_list()
+            correct_source = None
+            for s in current_source_list:
+                if s.name == self.audio_device_name:
+                    correct_source = s
+                    break
+
+            if not correct_source:
+                logger.warning(
+                    f"Routing enforcement: Target source '{self.audio_device_name}' not found."
+                )
+                return
+
+            source_outputs = pulse.source_output_list()
+            for output in source_outputs:
+                app_name = output.proplist.get("application.name", "")
+                if app_name == "pcmflux":
+                    if output.source != correct_source.index:
+                        connected_source_name = "Unknown"
+                        for s in current_source_list:
+                            if s.index == output.source:
+                                connected_source_name = s.name
+                                break
+                        logger.warning(
+                            f"WebRTC pcmflux connected to wrong source "
+                            f"'{connected_source_name}', moving to '{correct_source.name}'"
+                        )
+                        try:
+                            pulse.source_output_move(output.index, correct_source.index)
+                            logger.info(
+                                f"Successfully moved WebRTC pcmflux to '{correct_source.name}'"
+                            )
+                        except Exception as move_e:
+                            logger.error(f"Failed to move WebRTC pcmflux: {move_e}")
+                    else:
+                        logger.info(
+                            f"WebRTC pcmflux correctly connected to '{correct_source.name}'"
+                        )
+                    break
+        except Exception as e:
+            logger.error(f"Error enforcing WebRTC audio routing: {e}")
+        finally:
+            pulse.close()
+
+    async def _ensure_audio_device(self):
+        """
+        Verify the configured audio_device_name is a valid source.
+        If not, attempt to fallback to the default sink's monitor
+        """
+        try:
+            pulse = pulsectl.Pulse("selkies-media-pipeline")
+        except Exception as e:
+            logger.error(f"Failed to connect to PulseAudio/PipeWire: {e}")
+            return
+
+        try:
+            default_sink_name = None
+            default_monitor_name = None
+            try:
+                server_info = pulse.server_info()
+                default_sink_name = server_info.default_sink_name
+                logger.info(
+                    f"***Default sink from PulseAudio/PipeWire: '{default_sink_name}'"
+                )
+                if default_sink_name:
+                    default_monitor_name = f"{default_sink_name}.monitor"
+            except Exception as e:
+                logger.warning(f"Could not determine default sink: {e}")
+
+            available_sources = set()
+            try:
+                for src in pulse.source_list():
+                    available_sources.add(src.name)
+            except Exception as e:
+                logger.error(f"Failed to enumerate audio sources: {e}")
+                pulse.close()
+                return
+
+            if self.audio_device_name and self.audio_device_name in available_sources:
+                logger.info(
+                    f"Configured audio device '{self.audio_device_name}' is valid."
+                )
+            else:
+                if self.audio_device_name:
+                    logger.warning(
+                        f"Configured audio device '{self.audio_device_name}' not found "
+                        f"in available sources."
+                    )
+                # Fallback to default sink's monitor if available
+                if default_monitor_name and default_monitor_name in available_sources:
+                    logger.info(
+                        f"Falling back to default sink monitor: '{default_monitor_name}'"
+                    )
+                    self.audio_device_name = default_monitor_name
+                elif "auto_null.monitor" in available_sources:
+                    logger.info(
+                        "Default sink monitor not available; falling back to 'auto_null.monitor'"
+                    )
+                    # Pipewiere's default sink monitor
+                    self.audio_device_name = "auto_null.monitor"
+                else:
+                    logger.error(
+                        "No valid audio source found. Audio capture will likely fail. "
+                        f"Available sources: {sorted(available_sources)}"
+                    )
+        finally:
+            pulse.close()
 
     async def _stop_audio_pipeline(self):
         if not self._is_pcmflux_capturing or not self.pcmflux_module:
@@ -385,7 +568,9 @@ class MediaPipelinePixel(MediaPipeline):
         self._is_pcmflux_capturing = False
         if self.pcmflux_module:
             try:
-                await self.async_event_loop.run_in_executor(None, self.pcmflux_module.stop_capture)
+                await self.async_event_loop.run_in_executor(
+                    None, self.pcmflux_module.stop_capture
+                )
             except Exception as e:
                 logger.error(f"Error during pcmflux stop_capture: {e}")
             finally:
@@ -404,9 +589,12 @@ class MediaPipelinePixel(MediaPipeline):
                 await self.start_screen_capture()
 
                 if self.audio_enabled:
+                    await self._ensure_audio_device()
                     await self._start_audio_pipeline()
                 else:
-                    logger.info("Audio pipeline is disabled, skipping audio capture startup.")
+                    logger.info(
+                        "Audio pipeline is disabled, skipping audio capture startup."
+                    )
                 self._running = True
             except Exception as e:
                 logger.error(f"Error starting media pipelines: {e}", exc_info=True)

--- a/src/selkies/media_pipeline.py
+++ b/src/selkies/media_pipeline.py
@@ -22,10 +22,10 @@
 import asyncio
 import logging
 import ctypes
-import pulsectl
+import pulsectl_asyncio
 from enum import Enum
 from abc import ABCMeta, abstractmethod
-from typing import Callable
+from typing import Callable, Awaitable
 
 from pixelflux import CaptureSettings, ScreenCapture
 from pcmflux import AudioCapture, AudioCaptureSettings, AudioChunkCallback
@@ -116,7 +116,7 @@ class MediaPipelinePixel(MediaPipeline):
         self.audio_enabled = audio_enabled
         self.audio_device_name = audio_device_name
         self.capture_cursor = False
-        self.produce_data: Callable[[bytes, int, str], None] = lambda buf, pts, kind: logger.warning(
+        self.produce_data: Callable[[bytes, int, str], Awaitable[None]] = lambda buf, pts, kind: logger.warning(
             "unhandled produce_data"
         )
         self.send_data_channel_message: Callable[[str], None] = lambda msg: logger.warning(
@@ -315,7 +315,7 @@ class MediaPipelinePixel(MediaPipeline):
                     data_bytes = bytes(result.data[10 : result.size])
                     if not hasattr(result, "frame_id"):
                         logger.error(
-                            f"frame_id from callback is empty: {result.frame_id}"
+                            f"Missing frame_id from screen capture result, skipping frame"
                         )
                     else:
                         # Generate pts from frame_id
@@ -443,8 +443,10 @@ class MediaPipelinePixel(MediaPipeline):
         """
         # Give pcmflux a fraction of a second to initialize its PA stream
         await asyncio.sleep(0.5)
+        pulse = None
         try:
-            pulse = pulsectl.Pulse("selkies-webrtc-router")
+            pulse = pulsectl_asyncio.PulseAsync("selkies-webrtc-router")
+            await pulse.connect()
         except Exception as e:
             logger.error(
                 f"Failed to connect to PulseAudio for routing enforcement: {e}"
@@ -452,7 +454,7 @@ class MediaPipelinePixel(MediaPipeline):
             return
 
         try:
-            current_source_list = pulse.source_list()
+            current_source_list = await pulse.source_list()
             correct_source = None
             for s in current_source_list:
                 if s.name == self.audio_device_name:
@@ -465,7 +467,7 @@ class MediaPipelinePixel(MediaPipeline):
                 )
                 return
 
-            source_outputs = pulse.source_output_list()
+            source_outputs = await pulse.source_output_list()
             for output in source_outputs:
                 app_name = output.proplist.get("application.name", "")
                 if app_name == "pcmflux":
@@ -480,7 +482,7 @@ class MediaPipelinePixel(MediaPipeline):
                             f"'{connected_source_name}', moving to '{correct_source.name}'"
                         )
                         try:
-                            pulse.source_output_move(output.index, correct_source.index)
+                            await pulse.source_output_move(output.index, correct_source.index)
                             logger.info(
                                 f"Successfully moved WebRTC pcmflux to '{correct_source.name}'"
                             )
@@ -494,15 +496,18 @@ class MediaPipelinePixel(MediaPipeline):
         except Exception as e:
             logger.error(f"Error enforcing WebRTC audio routing: {e}")
         finally:
-            pulse.close()
+            if pulse is not None:
+                pulse.close()
 
     async def _ensure_audio_device(self):
         """
         Verify the configured audio_device_name is a valid source.
         If not, attempt to fallback to the default sink's monitor
         """
+        pulse = None
         try:
-            pulse = pulsectl.Pulse("selkies-media-pipeline")
+            pulse = pulsectl_asyncio.PulseAsync("selkies-media-pipeline")
+            await pulse.connect()
         except Exception as e:
             logger.error(f"Failed to connect to PulseAudio/PipeWire: {e}")
             return
@@ -511,10 +516,10 @@ class MediaPipelinePixel(MediaPipeline):
             default_sink_name = None
             default_monitor_name = None
             try:
-                server_info = pulse.server_info()
+                server_info = await pulse.server_info()
                 default_sink_name = server_info.default_sink_name
                 logger.info(
-                    f"***Default sink from PulseAudio/PipeWire: '{default_sink_name}'"
+                    f"Default sink from PulseAudio/PipeWire: '{default_sink_name}'"
                 )
                 if default_sink_name:
                     default_monitor_name = f"{default_sink_name}.monitor"
@@ -523,11 +528,11 @@ class MediaPipelinePixel(MediaPipeline):
 
             available_sources = set()
             try:
-                for src in pulse.source_list():
+                sources = await pulse.source_list()
+                for src in sources:
                     available_sources.add(src.name)
             except Exception as e:
                 logger.error(f"Failed to enumerate audio sources: {e}")
-                pulse.close()
                 return
 
             if self.audio_device_name and self.audio_device_name in available_sources:
@@ -557,8 +562,11 @@ class MediaPipelinePixel(MediaPipeline):
                         "No valid audio source found. Audio capture will likely fail. "
                         f"Available sources: {sorted(available_sources)}"
                     )
+        except Exception as e:
+            logger.error(f"Error enforcing WebRTC audio routing: {e}")
         finally:
-            pulse.close()
+            if pulse is not None:
+                pulse.close()
 
     async def _stop_audio_pipeline(self):
         if not self._is_pcmflux_capturing or not self.pcmflux_module:

--- a/src/selkies/media_pipeline.py
+++ b/src/selkies/media_pipeline.py
@@ -405,6 +405,8 @@ class MediaPipelinePixel(MediaPipeline):
 
                 if self.audio_enabled:
                     await self._start_audio_pipeline()
+                else:
+                    logger.info("Audio pipeline is disabled, skipping audio capture startup.")
                 self._running = True
             except Exception as e:
                 logger.error(f"Error starting media pipelines: {e}", exc_info=True)

--- a/src/selkies/selkies.py
+++ b/src/selkies/selkies.py
@@ -1107,7 +1107,7 @@ class DataStreamingServer(BaseStreamingService):
 
     async def _start_pcmflux_pipeline(self):
         if not settings.audio_enabled[0]:
-            data_logger.info("Server-to-client audio is disabled by server settings. Not starting pipeline.")
+            data_logger.info("Audio is disabled by server settings. Not starting pipeline.")
             return False
         if not PCMFLUX_AVAILABLE:
             data_logger.error("Cannot start audio pipeline: pcmflux library not available.")
@@ -1805,18 +1805,22 @@ class DataStreamingServer(BaseStreamingService):
             _collect_network_stats_ws(self._shared_stats_ws, self)
         )
 
+        pulse = None
         try:
             if PULSEAUDIO_AVAILABLE:
-                try:
-                    data_logger.info("Attempting to establish PulseAudio connection...")
-                    pulse = pulsectl.Pulse("selkies-mic-handler")
-                    data_logger.info("PulseAudio connection established.")
-                except Exception as e_pa_conn:
-                    data_logger.error(
-                        f"Initial PulseAudio connection failed: {e_pa_conn}",
-                        exc_info=True,
-                    )
-                    pulse = None
+                if not settings.audio_enabled[0]:
+                    data_logger.info("Audio is disabled in settings. Skipping PulseAudio setup.")
+                else:
+                    try:
+                        data_logger.info("Attempting to establish PulseAudio connection...")
+                        pulse = pulsectl.Pulse("selkies-mic-handler")
+                        data_logger.info("PulseAudio connection established.")
+                    except Exception as e_pa_conn:
+                        data_logger.error(
+                            f"Initial PulseAudio connection failed: {e_pa_conn}",
+                            exc_info=True,
+                        )
+                        pulse = None
 
             async for msg in websocket:
                 if msg.type == WSMsgType.BINARY:
@@ -1847,7 +1851,7 @@ class DataStreamingServer(BaseStreamingService):
                                 ]
                                 active_upload_target_path_conn = None
                     elif msg_type == 0x02:  # Mic data
-                        if not settings.microphone_enabled[0]:
+                        if not settings.audio_enabled[0] or not settings.microphone_enabled[0]:
                             continue
                         if not PULSEAUDIO_AVAILABLE:
                             if len(payload) > 0:
@@ -2439,14 +2443,17 @@ class DataStreamingServer(BaseStreamingService):
                                     "Received START_AUDIO command from client for server-to-client audio."
                                 )
                                 if PCMFLUX_AVAILABLE:
+                                    started = False
                                     if not self.is_pcmflux_capturing:
                                         data_logger.info("START_AUDIO: Starting pcmflux audio pipeline.")
-                                        await self._start_pcmflux_pipeline()
+                                        started = await self._start_pcmflux_pipeline()
                                     else:
+                                        started = True
                                         data_logger.info("START_AUDIO: pcmflux audio pipeline already active.")
+                                    if started:
+                                        await _broadcast_to_clients(self.clients, "AUDIO_STARTED")
                                 else:
                                     data_logger.warning("START_AUDIO: Cannot start server-to-client audio (pcmflux not available).")
-                                await _broadcast_to_clients(self.clients, "AUDIO_STARTED")
                         asyncio.create_task(_handle_start_audio_request())
 
                     elif message == "STOP_AUDIO":

--- a/src/selkies/selkies.py
+++ b/src/selkies/selkies.py
@@ -1781,6 +1781,8 @@ class DataStreamingServer(BaseStreamingService):
         # Define virtual source details
         virtual_source_name = "SelkiesVirtualMic"
         master_monitor = "input.monitor"
+        # PipeWire prepends "output." to virtual sources
+        valid_source_names = [virtual_source_name, f"output.{virtual_source_name}"]
 
         if not self.input_handler:
             logger.error(
@@ -1868,71 +1870,100 @@ class DataStreamingServer(BaseStreamingService):
 
                         if not mic_setup_done:
                             data_logger.info(
-                                "Performing PulseAudio virtual microphone setup check..."
+                                "Performing PulseAudio/PipeWire virtual microphone setup check..."
                             )
                             try:
+                                input_sink = "input"
+                                output_sink = self.audio_device_name.strip().split(".monitor")[0] if self.audio_device_name else "output"
+                                # Create required null sinks if they don't exist
+                                required_sinks = [input_sink, output_sink]
+                                for sink_name in required_sinks:
+                                    sink_exists = False
+                                    for sink in pulse.sink_list():
+                                        if sink.name == sink_name:
+                                            sink_exists = True
+                                            break
+
+                                    if not sink_exists:
+                                        data_logger.info(f"Sink '{sink_name}' not found. Attempting to create...")
+                                        sink_module_index = pulse.module_load("module-null-sink", f"sink_name={sink_name}")
+
+                                        sink_created = await self._poll_audio_sink(pulse, [sink_name])
+                                        if sink_created:
+                                            data_logger.info(f"Successfully created and verified sink '{sink_name}'.")
+                                        else:
+                                            data_logger.error(f"Loaded module-null-sink for '{sink_name}' but it failed to appear in sink list.")
+                                    else:
+                                        data_logger.info(f"Sink '{sink_name}' already exists. Skipping creation.")
+
+                                # Force the system default sink to output sink
+                                try:
+                                    pulse.sink_default_set(output_sink)
+                                    data_logger.info(f"Set system default sink to '{output_sink}'.")
+                                except Exception as e:
+                                    data_logger.warning(f"Could not set default sink to '{output_sink}': {e}")
+
+                                target_device_names = [self.audio_device_name]
+                                if "auto_null.monitor" not in target_device_names:
+                                    # Pipewire's default virtual sink is auto_null
+                                    target_device_names.append("auto_null.monitor")
+
                                 existing_source_info = None
                                 source_list = pulse.source_list()
                                 for source_obj in source_list:
-                                    if source_obj.name == virtual_source_name:
+                                    if source_obj.name in valid_source_names:
                                         existing_source_info = source_obj
                                         break
 
                                 if existing_source_info:
                                     data_logger.info(
-                                        f"Virtual source '{virtual_source_name}' (Index: {existing_source_info.index}) already exists."
+                                        f"Virtual source '{existing_source_info.name}' (Index: {existing_source_info.index}) already exists."
                                     )
-                                    actual_master = existing_source_info.proplist.get(
-                                        "device.master_device"
-                                    )
+                                    actual_master = existing_source_info.proplist.get("device.master_device")
                                     if actual_master == master_monitor:
-                                        data_logger.info(
-                                            f"Existing source correctly linked to '{master_monitor}'."
-                                        )
+                                        data_logger.info(f"Existing source correctly linked to '{master_monitor}'.")
                                     else:
                                         data_logger.warning(
-                                            f"Existing source '{virtual_source_name}' linked to '{actual_master}' not '{master_monitor}'. Manual fix may be needed."
+                                            f"Existing source '{existing_source_info.name}' linked to '{actual_master}' not '{master_monitor}'. Manual fix may be needed."
                                         )
-                                    pa_module_index = (
-                                        existing_source_info.owner_module
-                                    )
+                                    pa_module_index = existing_source_info.owner_module
                                     mic_setup_done = True
+
+                                    # Ensure default source is maintained even if it already existed
+                                    try:
+                                        pulse.source_default_set(existing_source_info.name)
+                                    except Exception as e:
+                                        pass
                                 else:
                                     data_logger.info(
                                         f"Virtual source '{virtual_source_name}' not found. Attempting to load module..."
                                     )
                                     load_args = f"source_name={virtual_source_name} master={master_monitor}"
-                                    pa_module_index = pulse.module_load(
-                                        "module-virtual-source", load_args
-                                    )
-                                    data_logger.info(
-                                        f"Loaded module-virtual-source with index {pa_module_index} for '{virtual_source_name}'."
-                                    )
+                                    pa_module_index = pulse.module_load("module-virtual-source", load_args)
+                                    data_logger.info(f"Loaded module-virtual-source with index {pa_module_index} for '{virtual_source_name}'.")
 
-                                    new_source_info = None
-                                    source_list_after_load = pulse.source_list()
-                                    for source_obj_after in source_list_after_load:
-                                        if source_obj_after.name == virtual_source_name:
-                                            new_source_info = source_obj_after
-                                            break
+                                    new_source_info = await self._poll_audio_source(pulse, valid_source_names)
                                     if new_source_info:
                                         data_logger.info(
-                                            f"Successfully verified creation of source '{virtual_source_name}' (Index: {new_source_info.index})."
+                                            f"Successfully verified creation of source '{new_source_info.name}' (Index: {new_source_info.index})."
                                         )
-                                        mic_setup_done = True
+
+                                        # Force the system default source to SelkiesVirtualMic so apps record from it
+                                        try:
+                                            pulse.source_default_set(new_source_info.name)
+                                            data_logger.info(f"Set system default source to '{new_source_info.name}'.")
+                                            mic_setup_done = True
+                                        except Exception as e:
+                                            data_logger.warning(f"Could not set default source via pulsectl: {e}")
                                     else:
                                         data_logger.error(
                                             f"Loaded module {pa_module_index} but failed to find source '{virtual_source_name}'."
                                         )
-                                        if (
-                                            pa_module_index is not None
-                                        ):
+                                        if pa_module_index is not None:
                                             try:
                                                 pulse.module_unload(pa_module_index)
                                             except Exception as unload_err:
-                                                data_logger.error(
-                                                    f"Failed to unload module {pa_module_index}: {unload_err}"
-                                                )
+                                                data_logger.error(f"Failed to unload module {pa_module_index}: {unload_err}")
                                             pa_module_index = None
 
                                 if mic_setup_done:
@@ -1955,23 +1986,23 @@ class DataStreamingServer(BaseStreamingService):
                                                     if source.index == pcmflux_output.source:
                                                         connected_source = source
                                                         break
-                                                if connected_source and connected_source.name != self.audio_device_name:
+                                                if connected_source and connected_source.name not in target_device_names:
                                                     data_logger.warning(
-                                                        f"pcmflux connected to wrong source '{connected_source.name}', moving to '{self.audio_device_name}'"
+                                                        f"pcmflux connected to wrong source '{connected_source.name}', looking for a valid target in {target_device_names}..."
                                                     )
                                                     correct_source = None
                                                     for source in current_source_list:
-                                                        if source.name == self.audio_device_name:
+                                                        if source.name in target_device_names:
                                                             correct_source = source
                                                             break
                                                     if correct_source:
                                                         pulse.source_output_move(pcmflux_output.index, correct_source.index)
                                                         data_logger.info(
-                                                            f"Successfully moved pcmflux from '{connected_source.name}' to '{self.audio_device_name}'"
+                                                            f"Successfully moved pcmflux from '{connected_source.name}' to '{correct_source.name}'"
                                                         )
                                                     else:
                                                         data_logger.error(
-                                                            f"Could not find source '{self.audio_device_name}' to move pcmflux to"
+                                                            f"Could not find any valid source {target_device_names} to move pcmflux to"
                                                         )
                                                 elif connected_source:
                                                     data_logger.info(f"pcmflux correctly connected to '{connected_source.name}'")
@@ -2794,6 +2825,29 @@ class DataStreamingServer(BaseStreamingService):
                      await self.shutdown_pipelines()
 
             data_logger.info(f"Data WS handler for {raddr} finished all cleanup.")
+
+    async def _poll_audio_source(self, pulse, valid_source_names, poll_interval=0.1, timeout=2.0):
+        """Asynchronous polling loop for PipeWire source"""
+        max_retries = int(timeout / poll_interval)
+        for _ in range(max_retries):
+            source_list_after_load = pulse.source_list()
+            for source_obj_after in source_list_after_load:
+                if source_obj_after.name in valid_source_names:
+                    return source_obj_after
+            await asyncio.sleep(poll_interval)
+        return None
+    
+    async def _poll_audio_sink(self, pulse, valid_sink_names, poll_interval=0.1, timeout=2.0):
+        """Asynchronous polling loop for PipeWire sink"""
+        # as pipewire takes time to create and register it.
+        sink_retries = int(timeout / poll_interval)
+        sink_verified = False
+        for _ in range(sink_retries):
+            for s in pulse.sink_list():
+                if s.name in valid_sink_names:
+                    return s
+            await asyncio.sleep(poll_interval)
+        return None
 
     async def _cleanup_client(self, websocket, display_id):
         """Removes a client and triggers reconfiguration if necessary."""

--- a/src/selkies/selkies.py
+++ b/src/selkies/selkies.py
@@ -1769,7 +1769,9 @@ class DataStreamingServer(BaseStreamingService):
         active_upload_target_path_conn = None
         upload_dir_valid = upload_dir_path is not None
         
-        mic_setup_done = False 
+        mic_setup_done = False
+        mic_disabled_sent = False
+        mic_error = False
         pa_module_index = None
         pa_stream = None
         pulse = None
@@ -1810,7 +1812,7 @@ class DataStreamingServer(BaseStreamingService):
         pulse = None
         try:
             if PULSEAUDIO_AVAILABLE:
-                if not settings.audio_enabled[0]:
+                if not settings.audio_enabled[0] or not settings.microphone_enabled[0]:
                     data_logger.info("Audio is disabled in settings. Skipping PulseAudio setup.")
                 else:
                     try:
@@ -1822,7 +1824,9 @@ class DataStreamingServer(BaseStreamingService):
                             f"Initial PulseAudio connection failed: {e_pa_conn}",
                             exc_info=True,
                         )
-                        pulse = None
+                        mic_error = True
+            else:
+                mic_error = True
 
             async for msg in websocket:
                 if msg.type == WSMsgType.BINARY:
@@ -1853,7 +1857,14 @@ class DataStreamingServer(BaseStreamingService):
                                 ]
                                 active_upload_target_path_conn = None
                     elif msg_type == 0x02:  # Mic data
-                        if not settings.audio_enabled[0] or not settings.microphone_enabled[0]:
+                        if mic_error or not settings.audio_enabled[0] or not settings.microphone_enabled[0]:
+                            if not mic_disabled_sent:
+                                mic_disabled_sent = True
+                                data_logger.info("Microphone is disabled/errored. Sending MICROPHONE_DISABLED to client.")
+                                try:
+                                    await websocket.send_str("MICROPHONE_DISABLED")
+                                except (ConnectionResetError, OSError, RuntimeError):
+                                    pass
                             continue
                         if not PULSEAUDIO_AVAILABLE:
                             if len(payload) > 0:
@@ -2038,9 +2049,9 @@ class DataStreamingServer(BaseStreamingService):
                         if not mic_setup_done or not payload:
                             if not mic_setup_done and len(payload) > 0:
                                 data_logger.warning(
-                                    "Mic setup not complete, skipping mic data."
+                                    "Mic setup not complete, setting microphone error."
                                 )
-                            continue
+                            mic_error = True
 
                         try:
                             if pa_stream is None:
@@ -2473,6 +2484,10 @@ class DataStreamingServer(BaseStreamingService):
                                 data_logger.info(
                                     "Received START_AUDIO command from client for server-to-client audio."
                                 )
+                                if not settings.audio_enabled[0]:
+                                    data_logger.info("START_AUDIO: Audio is disabled by server settings. Sending AUDIO_DISABLED.")
+                                    await websocket.send_str("AUDIO_DISABLED")
+                                    return
                                 if PCMFLUX_AVAILABLE:
                                     started = False
                                     if not self.is_pcmflux_capturing:

--- a/src/selkies/selkies.py
+++ b/src/selkies/selkies.py
@@ -68,14 +68,14 @@ except ImportError:
     data_logger.warning("pcmflux library not found. Audio capture is unavailable.")
 
 try:
-    import pulsectl
+    import pulsectl_asyncio
     import pasimple
 
     PULSEAUDIO_AVAILABLE = True
 except ImportError:
     PULSEAUDIO_AVAILABLE = False
     data_logger.warning(
-        "pulsectl or pasimple not found. Microphone forwarding will be disabled."
+        "pulsectl_asyncio or pasimple not found. Microphone forwarding will be disabled."
     )
 
 try:
@@ -986,7 +986,7 @@ class DataStreamingServer(BaseStreamingService):
         initial_encoder = settings.encoder
 
         if not settings.debug[0] and PULSEAUDIO_AVAILABLE:
-            logging.getLogger("pulsectl").setLevel(logging.WARNING)
+            logging.getLogger("pulsectl_asyncio").setLevel(logging.WARNING)
 
         logger.info(f"Initializing DataStreamingServer with encoder: {initial_encoder}, Framerate: {TARGET_FRAMERATE}")
 
@@ -1817,7 +1817,8 @@ class DataStreamingServer(BaseStreamingService):
                 else:
                     try:
                         data_logger.info("Attempting to establish PulseAudio connection...")
-                        pulse = pulsectl.Pulse("selkies-mic-handler")
+                        pulse = pulsectl_asyncio.PulseAsync("selkies-mic-handler")
+                        await pulse.connect()
                         data_logger.info("PulseAudio connection established.")
                     except Exception as e_pa_conn:
                         data_logger.error(
@@ -1890,14 +1891,14 @@ class DataStreamingServer(BaseStreamingService):
                                 required_sinks = [input_sink, output_sink]
                                 for sink_name in required_sinks:
                                     sink_exists = False
-                                    for sink in pulse.sink_list():
+                                    for sink in await pulse.sink_list():
                                         if sink.name == sink_name:
                                             sink_exists = True
                                             break
 
                                     if not sink_exists:
                                         data_logger.info(f"Sink '{sink_name}' not found. Attempting to create...")
-                                        sink_module_index = pulse.module_load("module-null-sink", f"sink_name={sink_name}")
+                                        sink_module_index = await pulse.module_load("module-null-sink", f"sink_name={sink_name}")
 
                                         sink_created = await self._poll_audio_sink(pulse, [sink_name])
                                         if sink_created:
@@ -1909,7 +1910,7 @@ class DataStreamingServer(BaseStreamingService):
 
                                 # Force the system default sink to output sink
                                 try:
-                                    pulse.sink_default_set(output_sink)
+                                    await pulse.sink_default_set(output_sink)
                                     data_logger.info(f"Set system default sink to '{output_sink}'.")
                                 except Exception as e:
                                     data_logger.warning(f"Could not set default sink to '{output_sink}': {e}")
@@ -1920,7 +1921,7 @@ class DataStreamingServer(BaseStreamingService):
                                     target_device_names.append("auto_null.monitor")
 
                                 existing_source_info = None
-                                source_list = pulse.source_list()
+                                source_list = await pulse.source_list()
                                 for source_obj in source_list:
                                     if source_obj.name in valid_source_names:
                                         existing_source_info = source_obj
@@ -1942,7 +1943,7 @@ class DataStreamingServer(BaseStreamingService):
 
                                     # Ensure default source is maintained even if it already existed
                                     try:
-                                        pulse.source_default_set(existing_source_info.name)
+                                        await pulse.source_default_set(existing_source_info.name)
                                     except Exception as e:
                                         pass
                                 else:
@@ -1950,7 +1951,7 @@ class DataStreamingServer(BaseStreamingService):
                                         f"Virtual source '{virtual_source_name}' not found. Attempting to load module..."
                                     )
                                     load_args = f"source_name={virtual_source_name} master={master_monitor}"
-                                    pa_module_index = pulse.module_load("module-virtual-source", load_args)
+                                    pa_module_index = await pulse.module_load("module-virtual-source", load_args)
                                     data_logger.info(f"Loaded module-virtual-source with index {pa_module_index} for '{virtual_source_name}'.")
 
                                     new_source_info = await self._poll_audio_source(pulse, valid_source_names)
@@ -1961,29 +1962,29 @@ class DataStreamingServer(BaseStreamingService):
 
                                         # Force the system default source to SelkiesVirtualMic so apps record from it
                                         try:
-                                            pulse.source_default_set(new_source_info.name)
+                                            await pulse.source_default_set(new_source_info.name)
                                             data_logger.info(f"Set system default source to '{new_source_info.name}'.")
                                             mic_setup_done = True
                                         except Exception as e:
-                                            data_logger.warning(f"Could not set default source via pulsectl: {e}")
+                                            data_logger.warning(f"Could not set default source via pulsectl_asyncio: {e}")
                                     else:
                                         data_logger.error(
                                             f"Loaded module {pa_module_index} but failed to find source '{virtual_source_name}'."
                                         )
                                         if pa_module_index is not None:
                                             try:
-                                                pulse.module_unload(pa_module_index)
+                                                await pulse.module_unload(pa_module_index)
                                             except Exception as unload_err:
                                                 data_logger.error(f"Failed to unload module {pa_module_index}: {unload_err}")
                                             pa_module_index = None
 
                                 if mic_setup_done:
                                     current_source_list = (
-                                        pulse.source_list()
+                                        await pulse.source_list()
                                     )
                                     if self.is_pcmflux_capturing:
                                         try:
-                                            source_outputs = pulse.source_output_list()
+                                            source_outputs = await pulse.source_output_list()
                                             pcmflux_output = None
                                             
                                             for output in source_outputs:
@@ -2007,7 +2008,7 @@ class DataStreamingServer(BaseStreamingService):
                                                             correct_source = source
                                                             break
                                                     if correct_source:
-                                                        pulse.source_output_move(pcmflux_output.index, correct_source.index)
+                                                        await pulse.source_output_move(pcmflux_output.index, correct_source.index)
                                                         data_logger.info(
                                                             f"Successfully moved pcmflux from '{connected_source.name}' to '{correct_source.name}'"
                                                         )
@@ -2038,7 +2039,7 @@ class DataStreamingServer(BaseStreamingService):
                                         data_logger.info(
                                             f"Attempting to unload module {pa_module_index} due to setup error."
                                         )
-                                        pulse.module_unload(pa_module_index)
+                                        await pulse.module_unload(pa_module_index)
                                     except Exception as e_unload_err:
                                         data_logger.error(
                                             f"Error unloading module {pa_module_index} after setup failure: {e_unload_err}"
@@ -2049,9 +2050,9 @@ class DataStreamingServer(BaseStreamingService):
                         if not mic_setup_done or not payload:
                             if not mic_setup_done and len(payload) > 0:
                                 data_logger.warning(
-                                    "Mic setup not complete, setting microphone error."
+                                    "Mic setup not complete, skipping mic data."
                                 )
-                            mic_error = True
+                            continue
 
                         try:
                             if pa_stream is None:
@@ -2500,6 +2501,7 @@ class DataStreamingServer(BaseStreamingService):
                                         await _broadcast_to_clients(self.clients, "AUDIO_STARTED")
                                 else:
                                     data_logger.warning("START_AUDIO: Cannot start server-to-client audio (pcmflux not available).")
+                                    await websocket.send_str("AUDIO_DISABLED")
                         asyncio.create_task(_handle_start_audio_request())
 
                     elif message == "STOP_AUDIO":
@@ -2787,7 +2789,7 @@ class DataStreamingServer(BaseStreamingService):
                         data_logger.info(
                             f"Unloading PulseAudio module {_local_pa_module_index} for virtual mic (client: {raddr})."
                         )
-                        _local_pulse.module_unload(_local_pa_module_index)
+                        await _local_pulse.module_unload(_local_pa_module_index)
                     except Exception as e_unload_final:
                         data_logger.error(
                             f"Error unloading PulseAudio module {_local_pa_module_index} for {raddr}: {e_unload_final}"
@@ -2845,7 +2847,7 @@ class DataStreamingServer(BaseStreamingService):
         """Asynchronous polling loop for PipeWire source"""
         max_retries = int(timeout / poll_interval)
         for _ in range(max_retries):
-            source_list_after_load = pulse.source_list()
+            source_list_after_load = await pulse.source_list()
             for source_obj_after in source_list_after_load:
                 if source_obj_after.name in valid_source_names:
                     return source_obj_after
@@ -2854,11 +2856,9 @@ class DataStreamingServer(BaseStreamingService):
     
     async def _poll_audio_sink(self, pulse, valid_sink_names, poll_interval=0.1, timeout=2.0):
         """Asynchronous polling loop for PipeWire sink"""
-        # as pipewire takes time to create and register it.
         sink_retries = int(timeout / poll_interval)
-        sink_verified = False
         for _ in range(sink_retries):
-            for s in pulse.sink_list():
+            for s in await pulse.sink_list():
                 if s.name in valid_sink_names:
                     return s
             await asyncio.sleep(poll_interval)

--- a/src/selkies/settings.py
+++ b/src/selkies/settings.py
@@ -58,7 +58,7 @@ SETTING_DEFINITIONS = [
         "name": "audio_enabled",
         "type": "bool",
         "default": True,
-        "help": "Enable server-to-client audio streaming.",
+        "help": "Enable server-to-client audio streaming. Disabling this will also disable microphone support.",
     },
     {
         "name": "microphone_enabled",
@@ -778,6 +778,7 @@ class AppSettings:
         self._add_arguments(parser)
         args, _ = parser.parse_known_args()
         self._process_and_set_attributes(args)
+        self._post_process_settings()
 
     def _add_arguments(self, parser):
         """Programmatically add arguments to the parser from definitions."""
@@ -907,6 +908,14 @@ class AppSettings:
         for name, value in processed.items():
             setattr(self, name, value)
 
+    def _post_process_settings(self):
+        """Additional processing of config data after initial parsing."""
+        audio_enabled = self.audio_enabled[0]
+        if not audio_enabled and self.microphone_enabled[0]:
+            logging.warning(
+                "Microphone support requires audio to be enabled. Disabling microphone support."
+            )
+            self.microphone_enabled = (False, self.microphone_enabled[1])
 
 settings = AppSettings(SETTING_DEFINITIONS)
 


### PR DESCRIPTION
**Reference the issue numbers and reviewers**
#227 @ehfd 

**Explain relevant issues and how this pull request solves them**
This PR resolves the 4th issue from Tier 1 list of #227.

**Describe the changes in code and its dependencies and justify that they work as intended after testing**
- Audio disabling:
  - The `audio_enabled` setting is used to stop audio capturing altogether. The same setting is used to handle microphone as well, since microphone feature does require an audio server(pulse or pipewire-pulse) thus disabling microphone is a reasonable choice, if `audio_enabled` is set to `false`. Thus `audio_enabled` setting becomes the high level guard for handling anything related to audio.
  - Appropriate logs have been added if audio is disabled.
- Exposing audio latency to selkies
  - The latency property has already been integrated into Selkies. Nothing much to do here.    
- Added guards for limiting the UI resource utilization if audio or microphone is explicitly disabled
- Updated websockets mode to be compatible with pipewire-pulse layer.
- The custom audio_device name flow is preserved. So user provided 'custom.monitor' for sink is managed as required. 
 
**Describe alternatives you've considered**
Since we've moved from gstreamer, the pcmflux doesn't crash even if an audio server isn't running actively. So we could simply handle the audio disabling part from the Selkies application.

Also the input and output audio device(sinks) creation is handled from the application layer itself rather than relying on the config setup for robust device handling and ease of portable application deployment.
 
**Additional context**
NA

 - [x] I confirm that this pull request is relevant to the scope of this project. If you know that upstream projects are the cause of this problem, please file the pull request there.
 - [x] I confirm that this pull request has been tested thoroughly and to the best of my knowledge that additional unintended problems do not arise.
 - [x] I confirm that the style of the changed code conforms to the overall style of the project.
 - [x] I confirm that I have read other open and closed pull requests and that duplicates do not exist.
 - [x] I confirm that I have justified the need for this pull request and that the changes reflect the fix for the specified problem.
 - [x] I confirm that no portion of this pull request contains credentials or other private information, and it is my own responsibility to protect my privacy.
 - [x] I confirm that the authors of this pull request does not willfully breach or infringe legal regulations, in any and all global law, regarding trademarks, trade names, logos, patents, or any and all other forms of external intellectual property, as well as adhering to software license terms of open-source and proprietary software projects.