### PR TITLE
Fix WebSocket reconnect cleanup and clipboard subprocess timeouts

### DIFF
--- a/src/selkies/input_handler.py
+++ b/src/selkies/input_handler.py
@@ -1715,6 +1715,45 @@ class WebRTCInput:
             logger_webrtc_input.warning("Failed to access clipboard file %s: %s", file_path, e)
             return None, None
 
+    async def _kill_and_reap_process(self, proc, description):
+        logger_webrtc_input.warning(
+            "Timed out waiting for clipboard command '%s' pid=%s; killing it.",
+            description,
+            getattr(proc, "pid", "unknown"),
+        )
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=1.0)
+        except (asyncio.TimeoutError, ProcessLookupError):
+            logger_webrtc_input.warning(
+                "Timed-out clipboard command '%s' pid=%s could not be reaped promptly.",
+                description,
+                getattr(proc, "pid", "unknown"),
+            )
+
+    async def _communicate_or_kill(self, proc, timeout, description):
+        try:
+            return await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        except asyncio.TimeoutError:
+            await self._kill_and_reap_process(proc, description)
+            raise
+
+    async def _wait_or_kill(self, proc, timeout, description):
+        try:
+            return await asyncio.wait_for(proc.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            await self._kill_and_reap_process(proc, description)
+            raise
+
+    def _clipboard_has_consumers(self):
+        if getattr(self.gst_webrtc_app, "mode", None) != "websockets":
+            return True
+        server = self.data_server_instance or getattr(self.gst_webrtc_app, "data_streaming_server", None)
+        return bool(server and getattr(server, "clients", None))
+
     async def read_clipboard(self, use_binary=False):
         """Reads clipboard. Supports Wayland (wl-paste) and X11 (xclip)."""
         if self.is_wayland:
@@ -1724,7 +1763,7 @@ class WebRTCInput:
                     stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                     env=self._get_wl_env()
                 )
-                stdout_types, _ = await asyncio.wait_for(proc_types.communicate(), timeout=1.0)
+                stdout_types, _ = await self._communicate_or_kill(proc_types, 1.0, "wl-paste --list-types")
                 
                 if proc_types.returncode != 0:
                     return None, None
@@ -1740,7 +1779,7 @@ class WebRTCInput:
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                             env=self._get_wl_env()
                         )
-                        stdout_data, _ = await asyncio.wait_for(proc_data.communicate(), timeout=2.0)
+                        stdout_data, _ = await self._communicate_or_kill(proc_data, 2.0, f"wl-paste --type {target_mime}")
                         if proc_data.returncode == 0 and stdout_data:
                             return stdout_data, target_mime
                 text_mimes = ['text/plain', 'text/plain;charset=utf-8', 'UTF8_STRING', 'STRING']
@@ -1750,7 +1789,7 @@ class WebRTCInput:
                         stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                         env=self._get_wl_env()
                     )
-                    stdout_text, _ = await asyncio.wait_for(proc_text.communicate(), timeout=1.0)
+                    stdout_text, _ = await self._communicate_or_kill(proc_text, 1.0, "wl-paste --no-newline")
                     if proc_text.returncode == 0:
                         return stdout_text.decode('utf-8', errors='replace'), 'text/plain'
 
@@ -1764,7 +1803,7 @@ class WebRTCInput:
                 "xclip", "-selection", "clipboard", "-o", "-t", "TARGETS",
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE
             )
-            stdout_targets, _ = await asyncio.wait_for(proc_targets.communicate(), timeout=1)
+            stdout_targets, _ = await self._communicate_or_kill(proc_targets, 1, "xclip TARGETS")
             if proc_targets.returncode != 0:
                 return None, None
             targets = stdout_targets.decode().strip().split('\n')
@@ -1775,7 +1814,7 @@ class WebRTCInput:
                             "xclip", "-selection", "clipboard", "-o", "-t", mime_type,
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE
                         )
-                        stdout_data, _ = await asyncio.wait_for(proc_data.communicate(), timeout=3)
+                        stdout_data, _ = await self._communicate_or_kill(proc_data, 3, f"xclip {mime_type}")
                         if proc_data.returncode == 0 and stdout_data:
                             return stdout_data, mime_type
 
@@ -1785,7 +1824,7 @@ class WebRTCInput:
                         "xclip", "-selection", "clipboard", "-o", "-t", "text/uri-list",
                         stdout=subprocess.PIPE, stderr=subprocess.PIPE
                     )
-                    stdout_data, _ = await asyncio.wait_for(proc_data.communicate(), timeout=1)
+                    stdout_data, _ = await self._communicate_or_kill(proc_data, 1, "xclip text/uri-list")
                     if proc_data.returncode == 0 and stdout_data:
                         lines = stdout_data.decode("utf-8", errors="replace").splitlines()
                         for line in lines:
@@ -1811,7 +1850,7 @@ class WebRTCInput:
                     "xclip", "-selection", "clipboard", "-o", "-t", "UTF8_STRING",
                     stdout=subprocess.PIPE, stderr=subprocess.PIPE
                 )
-                stdout_text, _ = await asyncio.wait_for(proc_text.communicate(), timeout=1)
+                stdout_text, _ = await self._communicate_or_kill(proc_text, 1, "xclip UTF8_STRING")
                 if proc_text.returncode == 0:
                     return stdout_text.decode(), 'text/plain'
             return None, None
@@ -1842,7 +1881,8 @@ class WebRTCInput:
                     process.stdin.write(input_bytes)
                     await process.stdin.drain()
                     process.stdin.close()
-                await asyncio.wait_for(process.communicate(), timeout=2.0)
+                # Should now return instantly instead of hitting the 2.0s timeout
+                await self._communicate_or_kill(process, 2.0, f"wl-copy --type {mime_type}")
                 if process.returncode == 0:
                     return True
                 else:
@@ -1865,7 +1905,7 @@ class WebRTCInput:
                 process.stdin.write(input_bytes)
                 await process.stdin.drain()
                 process.stdin.close()
-            return_code = await asyncio.wait_for(process.wait(), timeout=2.0)
+            return_code = await self._wait_or_kill(process, 2.0, f"xclip -i {target_mime}")
             if return_code == 0:
                 return True
             else:
@@ -1883,9 +1923,14 @@ class WebRTCInput:
         
         logger_webrtc_input.info(f"Clipboard monitor running (binary mode: {self.enable_binary_clipboard in ['true', 'out']})")
         self.clipboard_running = True
-        last_data_bytes = b""
+        last_data_bytes = None
         while self.clipboard_running:
             try:
+                if not self._clipboard_has_consumers():
+                    last_data_bytes = None
+                    await asyncio.sleep(0.5)
+                    continue
+
                 if getattr(self, 'clipboard_paused', False):
                     await asyncio.sleep(0.1)
                     continue

--- a/src/selkies/selkies.py
+++ b/src/selkies/selkies.py
@@ -1768,6 +1768,10 @@ class DataStreamingServer(BaseStreamingService):
         active_uploads_by_path_conn = {}
         active_upload_target_path_conn = None
         upload_dir_valid = upload_dir_path is not None
+        system_monitor_task_ws = None
+        gpu_monitor_task_ws = None
+        stats_sender_task_ws = None
+        network_monitor_task_ws = None
         
         mic_setup_done = False
         mic_disabled_sent = False
@@ -1793,21 +1797,25 @@ class DataStreamingServer(BaseStreamingService):
 
         self._shared_stats_ws = {}
         gpu_id_for_stats = getattr(self.app, "gpu_id", GPU_ID_DEFAULT)
-        self._system_monitor_task_ws = asyncio.create_task(
+        system_monitor_task_ws = asyncio.create_task(
             _collect_system_stats_ws(self._shared_stats_ws)
         )
+        self._system_monitor_task_ws = system_monitor_task_ws
         if GPUtil.getGPUs():
-            self._gpu_monitor_task_ws = asyncio.create_task(
+            gpu_monitor_task_ws = asyncio.create_task(
                 _collect_gpu_stats_ws(self._shared_stats_ws, gpu_id=gpu_id_for_stats)
             )
-        self._stats_sender_task_ws = asyncio.create_task(
+            self._gpu_monitor_task_ws = gpu_monitor_task_ws
+        stats_sender_task_ws = asyncio.create_task(
             _send_stats_periodically_ws(
                 websocket, self._shared_stats_ws
             )
         )
-        self._network_monitor_task_ws = asyncio.create_task(
+        self._stats_sender_task_ws = stats_sender_task_ws
+        network_monitor_task_ws = asyncio.create_task(
             _collect_network_stats_ws(self._shared_stats_ws, self)
         )
+        self._network_monitor_task_ws = network_monitor_task_ws
 
         pulse = None
         try:
@@ -2718,35 +2726,13 @@ class DataStreamingServer(BaseStreamingService):
             else:
                 data_logger.info(f"Unregistered client at {raddr} disconnected. No display reconfiguration needed.")
 
-            if "_stats_sender_task_ws" in locals():
-                _task_to_cancel = locals()["_stats_sender_task_ws"]
-                if _task_to_cancel and not _task_to_cancel.done():
-                    _task_to_cancel.cancel()
-                    try:
-                        await _task_to_cancel
-                    except asyncio.CancelledError:
-                        pass
-
-            if "_system_monitor_task_ws" in locals():
-                _task_to_cancel = locals()["_system_monitor_task_ws"]
-                if _task_to_cancel and not _task_to_cancel.done():
-                    _task_to_cancel.cancel()
-                    try:
-                        await _task_to_cancel
-                    except asyncio.CancelledError:
-                        pass
-
-            if "_gpu_monitor_task_ws" in locals():
-                _task_to_cancel = locals()["_gpu_monitor_task_ws"]
-                if _task_to_cancel and not _task_to_cancel.done():
-                    _task_to_cancel.cancel()
-                    try:
-                        await _task_to_cancel
-                    except asyncio.CancelledError:
-                        pass
-
-            if "_network_monitor_task_ws" in locals():
-                _task_to_cancel = locals()["_network_monitor_task_ws"]
+            monitor_tasks = [
+                stats_sender_task_ws,
+                system_monitor_task_ws,
+                gpu_monitor_task_ws,
+                network_monitor_task_ws,
+            ]
+            for _task_to_cancel in monitor_tasks:
                 if _task_to_cancel and not _task_to_cancel.done():
                     _task_to_cancel.cancel()
                     try:


### PR DESCRIPTION
## Summary

Fix cleanup issues exposed by repeated WebSocket reconnects in websockets mode.

This PR addresses two related problems:

- Per-connection stats monitor tasks were not cancelled on WebSocket disconnect because cleanup looked for local variable names that were never assigned.
- Clipboard subprocesses (`xclip` / `wl-*`) were not killed and reaped after timeout, and outbound clipboard polling continued even when no WebSocket clients were connected.

## Details

Each WebSocket connection starts system, GPU, stats sender, and network monitor tasks. The task handles were stored on `self`, but the connection cleanup checked for underscored names in `locals()`. Those names
did not exist, so reconnect churn could leave monitor loops running after disconnect. On GPU hosts this is especially visible because the GPU monitor calls `GPUtil.getGPUs()`, which shells out to `nvidia-smi`.

Clipboard reads and writes already used timeouts, but a timeout only cancelled the Python wait; it did not terminate and reap the subprocess. This PR wraps clipboard subprocess waits so timed-out commands are
killed and reaped before the timeout is propagated.

In websocket mode, the outbound clipboard monitor now also skips host clipboard polling while there are no connected WebSocket clients. The last-sent marker is reset while idle so the next client receives the
current clipboard state after reconnect.

## Testing

- `python3 -m py_compile src/selkies/selkies.py src/selkies/input_handler.py`
- `git diff --check upstream/main..HEAD`
- Reconnect stress testing against a production-like container showed stable task/subprocess counts after applying these fixes.
