### PR TITLE
Send current cursor to websocket clients on connect

### DIFF
--- a/src/selkies/input_handler.py
+++ b/src/selkies/input_handler.py
@@ -1989,6 +1989,25 @@ class WebRTCInput:
         logger_webrtc_input.info("stopping cursor monitor")
         self.cursors_running = False
 
+    def get_current_cursor_data(self):
+        if self.is_wayland:
+            return None
+        if not self.enable_cursors or not self.xdisplay:
+            return None
+        try:
+            if not self.xdisplay.has_extension("XFIXES"):
+                if self.xdisplay.query_extension("XFIXES") is None:
+                    logger_webrtc_input.error(
+                        "XFIXES extension not supported, cannot fetch current cursor"
+                    )
+                    return None
+            screen = self.xdisplay.screen()
+            cursor_image = self.xdisplay.xfixes_get_cursor_image(screen.root)
+            return self.cursor_to_msg(cursor_image)
+        except Exception as e:
+            logger_webrtc_input.warning("exception from fetching current cursor image: %s", e)
+            return None
+
     def _cursor_image_to_pil(self, cursor):
         byte_data = b''.join(p.to_bytes(4, 'little') for p in cursor.cursor_image)
         return Image.frombytes("RGBA", (cursor.width, cursor.height), byte_data, "raw", "BGRA")

--- a/src/selkies/selkies.py
+++ b/src/selkies/selkies.py
@@ -1066,6 +1066,31 @@ class DataStreamingServer(BaseStreamingService):
         data_logger.info(f"Broadcasting display config update: {message_str}")
         await _broadcast_to_clients(self.clients, message_str)
 
+    def refresh_cursor_cache(self):
+        if not self.app:
+            return None
+
+        cursor_data = None
+        if self.input_handler and hasattr(self.input_handler, "get_current_cursor_data"):
+            cursor_data = self.input_handler.get_current_cursor_data()
+
+        if cursor_data is not None:
+            self.app.last_cursor_sent = cursor_data
+
+        return self.app.last_cursor_sent
+
+    async def send_current_cursor(self, websocket, raddr):
+        cursor_data = self.refresh_cursor_cache()
+        if not cursor_data:
+            return
+
+        data_logger.info(f"Sending current cursor to client {raddr}")
+        try:
+            msg_str = json.dumps(cursor_data)
+            await websocket.send_str(f"cursor,{msg_str}")
+        except Exception as e:
+            data_logger.warning(f"Failed to send current cursor to client {raddr}: {e}")
+
     def _pcmflux_audio_callback(self, result_ptr, user_data):
         """
         C-style callback passed to pcmflux, called from its capture thread.
@@ -1684,6 +1709,7 @@ class DataStreamingServer(BaseStreamingService):
                 "role": permissions.get("role"),
                 "slot": permissions.get("slot"),
                 "remote_address": remote_address,
+                "data_server": self,
             }
             data_logger.info(f"Client {remote_address} authenticated with token. Role: {permissions.get('role')}, Slot: {permissions.get('slot')}")
             auth_success_payload = json.dumps({
@@ -1745,13 +1771,7 @@ class DataStreamingServer(BaseStreamingService):
                 self.data_ws = None
             return
 
-        if self.app and self.app.last_cursor_sent:
-            data_logger.info(f"Sending last known cursor to new client {raddr}")
-            try:
-                msg_str = json.dumps(self.app.last_cursor_sent)
-                await websocket.send_str(f"cursor,{msg_str}")
-            except Exception as e:
-                data_logger.warning(f"Failed to send initial cursor to new client {raddr}: {e}")
+        await self.send_current_cursor(websocket, raddr)
 
         server_settings_payload = {"type": "server_settings", "settings": {}}
         for setting_def in SETTING_DEFINITIONS:
@@ -3739,5 +3759,9 @@ async def reconcile_clients():
         mk_msg = "MK_ACCESS,1" if has_mk_access else "MK_ACCESS,0"
         try:
             await ws.send_str(mk_msg)
+            if has_mk_access:
+                data_server = perms.get("data_server")
+                if data_server:
+                    await data_server.send_current_cursor(ws, remote_address)
         except (ConnectionResetError, OSError, RuntimeError):
             pass


### PR DESCRIPTION
**Reference the issue numbers and reviewers**

N/A

**Explain relevant issues and how this pull request solves them**

WebSocket clients can initially show a blank cursor until the remote desktop emits a cursor-change event. The server already caches and replays the last cursor payload, but that cache can be empty or stale when a
new client connects.

This pull request refreshes the cursor cache from the current XFixes cursor image before sending the initial cursor payload to a new websocket client. It also sends the current cursor immediately after granting
mouse/keyboard access, so control handoff receives an accurate cursor after input attaches.

**Describe the changes in code and its dependencies and justify that they work as intended after testing**

- Added `get_current_cursor_data()` to the input handler to snapshot the current X11 cursor through the existing XFixes and `cursor_to_msg()` path.
- Added websocket server helpers to refresh the cursor cache and send the current cursor to a specific client.
- Replaced initial “last cursor” replay with a fresh current-cursor send on websocket connection.
- After `MK_ACCESS,1`, sends the current cursor to the newly active input client.

Tested with:

- `python3 -m py_compile src/selkies/selkies.py src/selkies/input_handler.py`
- `git diff --check upstream/main..HEAD`
- Production-version branch testing confirmed the cursor appears correctly on initial connection/control handoff.

**Describe alternatives you've considered**

A frontend fallback was considered, where the browser default cursor is shown until a remote cursor update arrives. That is less accurate and may be undesirable for gaming or applications that intentionally hide
the cursor. Refreshing and sending the actual backend cursor is more accurate and avoids showing a browser default cursor over applications that have hidden their cursor.

**Additional context**

This change uses the existing cursor serialization path and does not introduce a new cursor format or client protocol message.