### PR TITLE
fix(core): Various bug fixes and consolidations

### DIFF
--- a/addons/js-interposer/Makefile
+++ b/addons/js-interposer/Makefile
@@ -1,7 +1,7 @@
 PREFIX ?= /usr
 
 all:
-	gcc -shared -fPIC -o selkies_joystick_interposer.so joystick_interposer.c -ldl
+	gcc -shared -fPIC -o selkies_joystick_interposer.so joystick_interposer.c -ldl -pthread
 
 install: all
 	mkdir -p $(PREFIX)/lib/$(gcc -print-multiarch | sed -e 's/i.*86/i386/')

--- a/addons/js-interposer/build_deb.sh
+++ b/addons/js-interposer/build_deb.sh
@@ -7,13 +7,13 @@ mkdir -p "${PKG_DIR}/DEBIAN"
 
 DEST_DIR="${PKG_DIR}/usr/lib/$(gcc -print-multiarch | sed -e 's/i.*86/i386/')"
 mkdir -p "${DEST_DIR}"
-gcc -shared -fPIC -o selkies_joystick_interposer.so joystick_interposer.c -ldl
+gcc -shared -fPIC -o selkies_joystick_interposer.so joystick_interposer.c -ldl -pthread
 cp -f selkies_joystick_interposer.so "${DEST_DIR}/selkies_joystick_interposer.so"
 
 if [ "$(dpkg --print-architecture)" = "amd64" ]; then
   DEST_DIR="${PKG_DIR}/usr/lib/$(gcc -m32 -print-multiarch | sed -e 's/i.*86/i386/')"
   mkdir -p "${DEST_DIR}"
-  gcc -m32 -shared -fPIC -o selkies_joystick_interposer_x86.so joystick_interposer.c -ldl
+  gcc -m32 -shared -fPIC -o selkies_joystick_interposer_x86.so joystick_interposer.c -ldl -pthread
   cp -f selkies_joystick_interposer_x86.so "${DEST_DIR}/selkies_joystick_interposer.so"
 fi
 

--- a/addons/js-interposer/joystick_interposer.c
+++ b/addons/js-interposer/joystick_interposer.c
@@ -36,6 +36,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #include <linux/joystick.h>
 #include <linux/input.h>
 #include <linux/input-event-codes.h>
+#include <pthread.h>
 
 /**
  * @brief Definitions for O_TMPFILE and mode requirement checking.
@@ -68,6 +69,14 @@ typedef int ioctl_request_t;
  * @brief Timeout for socket connection attempts in milliseconds.
  */
 #define SOCKET_CONNECT_TIMEOUT_MS 250
+
+/**
+ * @brief Maximum time to wait for the full device configuration to arrive on a
+ * freshly connected socket, in milliseconds. Prevents a connected-but-silent
+ * (stalled or hostile) peer from hanging the application thread that opened the
+ * device indefinitely inside the intercepted open()/openat().
+ */
+#define SOCKET_CONFIG_READ_TIMEOUT_MS 5000
 
 /**
  * @brief Device paths for /dev/input/jsX joystick devices to be interposed.
@@ -351,26 +360,59 @@ typedef struct {
 } js_config_t;
 
 /**
+ * @brief Maximum number of concurrently open application handles per device.
+ *
+ * Every open() of a device gets its own socket connection, so this bounds the
+ * connections per device. Real applications hold one handle (two briefly when
+ * an enumeration pass overlaps active use); opens beyond the bound fail with
+ * EMFILE.
+ */
+#define SJI_MAX_HANDLES_PER_DEVICE 16
+
+/**
+ * @brief One application open() handle: a dedicated socket connection.
+ *
+ * Members:
+ *  - fd: Connected socket file descriptor returned to the application.
+ *  - open_flags: Flags the application passed to open() for this handle.
+ */
+typedef struct {
+    int fd;
+    int open_flags;
+} sji_handle_t;
+
+/**
  * @brief State for each interposed device.
  *
  * This structure maintains the state associated with each device path
  * (e.g., "/dev/input/js0") that the interposer handles.
  *
+ * Each open() handle owns a dedicated socket connection, so every open()
+ * returns a unique file descriptor (as POSIX requires), O_NONBLOCK applies
+ * per handle, and every handle receives every device event (the server
+ * broadcasts events to all connections for a device). close() of one handle
+ * never disturbs the others.
+ *
  * Members:
  *  - type: Indicates if the device is a joystick (DEV_TYPE_JS) or event (DEV_TYPE_EV) device.
  *  - open_dev_name: The original device path (e.g., "/dev/input/js0").
  *  - socket_path: Path to the Unix domain socket for this device.
- *  - sockfd: File descriptor for the connected Unix domain socket; -1 if not connected.
- *  - open_flags: Flags used by the application when opening the device via `open()`.
- *  - corr: Stores joystick correction data (for JSIOCSCORR/GCORR ioctls).
- *  - js_config: Device configuration received from the socket server.
+ *  - handles: One entry per outstanding open() handle of this device.
+ *  - handle_count: Number of valid entries in `handles`. Statically zero, so
+ *    fd lookups match nothing before the first open() (even if an intercepted
+ *    call runs before the library constructor).
+ *  - corr: Stores joystick correction data (for JSIOCSCORR/GCORR ioctls);
+ *    device-global, matching the kernel joystick driver's correction state.
+ *  - js_config: Device configuration received from the socket server. The
+ *    server sends identical content on every connection for a device; each
+ *    successful open() refreshes this copy.
  */
 typedef struct {
     uint8_t type;
     char open_dev_name[255];
     char socket_path[255];
-    int sockfd;
-    int open_flags;
+    sji_handle_t handles[SJI_MAX_HANDLES_PER_DEVICE];
+    int handle_count;
     js_corr_t corr;
     js_config_t js_config;
 } js_interposer_t;
@@ -396,15 +438,62 @@ typedef struct {
  * for both joystick (`jsX`) and event (`event*`) devices.
  */
 static js_interposer_t interposers[NUM_INTERPOSERS()] = {
-    { DEV_TYPE_JS, JS0_DEVICE_PATH, JS0_SOCKET_PATH, -1, 0, {0}, {0} },
-    { DEV_TYPE_JS, JS1_DEVICE_PATH, JS1_SOCKET_PATH, -1, 0, {0}, {0} },
-    { DEV_TYPE_JS, JS2_DEVICE_PATH, JS2_SOCKET_PATH, -1, 0, {0}, {0} },
-    { DEV_TYPE_JS, JS3_DEVICE_PATH, JS3_SOCKET_PATH, -1, 0, {0}, {0} },
-    { DEV_TYPE_EV, EV0_DEVICE_PATH, EV0_SOCKET_PATH, -1, 0, {0}, {0} },
-    { DEV_TYPE_EV, EV1_DEVICE_PATH, EV1_SOCKET_PATH, -1, 0, {0}, {0} },
-    { DEV_TYPE_EV, EV2_DEVICE_PATH, EV2_SOCKET_PATH, -1, 0, {0}, {0} },
-    { DEV_TYPE_EV, EV3_DEVICE_PATH, EV3_SOCKET_PATH, -1, 0, {0}, {0} },
+    /* Remaining members are zero-initialized; handle_count 0 means no open
+     * handles, so the handle tables start empty. */
+    { .type = DEV_TYPE_JS, .open_dev_name = JS0_DEVICE_PATH, .socket_path = JS0_SOCKET_PATH },
+    { .type = DEV_TYPE_JS, .open_dev_name = JS1_DEVICE_PATH, .socket_path = JS1_SOCKET_PATH },
+    { .type = DEV_TYPE_JS, .open_dev_name = JS2_DEVICE_PATH, .socket_path = JS2_SOCKET_PATH },
+    { .type = DEV_TYPE_JS, .open_dev_name = JS3_DEVICE_PATH, .socket_path = JS3_SOCKET_PATH },
+    { .type = DEV_TYPE_EV, .open_dev_name = EV0_DEVICE_PATH, .socket_path = EV0_SOCKET_PATH },
+    { .type = DEV_TYPE_EV, .open_dev_name = EV1_DEVICE_PATH, .socket_path = EV1_SOCKET_PATH },
+    { .type = DEV_TYPE_EV, .open_dev_name = EV2_DEVICE_PATH, .socket_path = EV2_SOCKET_PATH },
+    { .type = DEV_TYPE_EV, .open_dev_name = EV3_DEVICE_PATH, .socket_path = EV3_SOCKET_PATH },
 };
+
+/**
+ * @brief Mutex protecting concurrent access to the global interposers[] array.
+ *
+ * LD_PRELOAD libraries run inside multithreaded hosts (e.g. SDL runs joystick
+ * handling on its own thread), so the open/close mutation paths and the fd
+ * lookups must be serialized to avoid torn js_config and use of a handle
+ * another thread is tearing down. The lock guards only the brief array
+ * lookups and state transitions; it is intentionally NOT held across blocking
+ * socket I/O — neither the recv() on the event path (read()) nor the
+ * connect/config-read on the open path. Each open() builds its connection on
+ * a private fd without the lock and only publishes it into the handle table
+ * under the lock once fully configured, so lookups never observe a
+ * half-initialized handle.
+ */
+static pthread_mutex_t interposers_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+/**
+ * @brief Finds the interposer slot owning an application file descriptor.
+ *
+ * Must be called with `interposers_mutex` held. Every fd handed to the
+ * application by an interposed open() is registered in exactly one slot's
+ * handle table until the matching close().
+ *
+ * @param fd The application file descriptor to look up.
+ * @param open_flags_out Optional output; receives the open() flags recorded
+ *                       for the matching handle.
+ * @return Pointer to the owning slot, or NULL if `fd` is not interposed.
+ */
+static js_interposer_t *find_interposer_for_fd_locked(int fd, int *open_flags_out) {
+    if (fd < 0) {
+        return NULL;
+    }
+    for (size_t i = 0; i < NUM_INTERPOSERS(); i++) {
+        for (int h = 0; h < interposers[i].handle_count; h++) {
+            if (interposers[i].handles[h].fd == fd) {
+                if (open_flags_out != NULL) {
+                    *open_flags_out = interposers[i].handles[h].open_flags;
+                }
+                return &interposers[i];
+            }
+        }
+    }
+    return NULL;
+}
 
 /**
  * @brief Library constructor function, called when the library is loaded.
@@ -556,16 +645,18 @@ int fstat(int fd, struct stat *buf) {
          }
     }
 
-    for (size_t i = 0; i < NUM_INTERPOSERS(); i++) {
-        if (interposers[i].sockfd != -1 && interposers[i].sockfd == fd) {
-            memset(buf, 0, sizeof(struct stat));
-            fill_fake_stat(interposers[i].open_dev_name, buf);
-            
-            sji_log_debug("Intercepted fstat for fd %d (%s), returning fake rdev %d:%d", 
-                fd, interposers[i].open_dev_name, major(buf->st_rdev), minor(buf->st_rdev));
-            return 0;
-        }
+    pthread_mutex_lock(&interposers_mutex);
+    js_interposer_t *interposer = find_interposer_for_fd_locked(fd, NULL);
+    if (interposer != NULL) {
+        memset(buf, 0, sizeof(struct stat));
+        fill_fake_stat(interposer->open_dev_name, buf);
+
+        sji_log_debug("Intercepted fstat for fd %d (%s), returning fake rdev %d:%d",
+            fd, interposer->open_dev_name, major(buf->st_rdev), minor(buf->st_rdev));
+        pthread_mutex_unlock(&interposers_mutex);
+        return 0;
     }
+    pthread_mutex_unlock(&interposers_mutex);
     return real_fstat(fd, buf);
 }
 
@@ -641,6 +732,21 @@ static int read_socket_config(int sockfd, js_config_t *config_dest) {
     int original_socket_flags = fcntl(sockfd, F_GETFL, 0);
     int socket_was_nonblocking = 0;
 
+    /* Bound the total time spent waiting for the config so a connected-but-silent
+     * peer cannot hang the calling application thread forever. SO_RCVTIMEO makes
+     * an otherwise-blocking real_read return EAGAIN periodically; the monotonic
+     * deadline below caps the cumulative wait across retries. */
+    struct timeval rcv_timeout = { .tv_sec = 1, .tv_usec = 0 };
+    struct timeval saved_rcv_timeout;
+    socklen_t saved_rcv_timeout_len = sizeof(saved_rcv_timeout);
+    int have_saved_rcv_timeout =
+        (getsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, &saved_rcv_timeout, &saved_rcv_timeout_len) == 0);
+    if (setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, &rcv_timeout, sizeof(rcv_timeout)) == -1) {
+        sji_log_warn("read_socket_config: setsockopt(SO_RCVTIMEO) failed for sockfd %d: %s.", sockfd, strerror(errno));
+    }
+    struct timespec config_read_start;
+    clock_gettime(CLOCK_MONOTONIC, &config_read_start);
+
     if (original_socket_flags == -1) {
         sji_log_warn("read_socket_config: fcntl(F_GETFL) failed for sockfd %d: %s. Cannot ensure blocking for config read.", sockfd, strerror(errno));
     } else if (original_socket_flags & O_NONBLOCK) {
@@ -656,7 +762,16 @@ static int read_socket_config(int sockfd, js_config_t *config_dest) {
         ssize_t current_read = real_read(sockfd, buffer_ptr + bytes_read_total, bytes_to_read - bytes_read_total);
         if (current_read == -1) {
             if (errno == EAGAIN || errno == EWOULDBLOCK) {
-                sji_log_warn("read_socket_config: real_read on sockfd %d returned EAGAIN/EWOULDBLOCK. Retrying after short delay.", sockfd);
+                struct timespec config_read_now;
+                clock_gettime(CLOCK_MONOTONIC, &config_read_now);
+                long elapsed_ms = (config_read_now.tv_sec - config_read_start.tv_sec) * 1000L +
+                                  (config_read_now.tv_nsec - config_read_start.tv_nsec) / 1000000L;
+                if (elapsed_ms >= SOCKET_CONFIG_READ_TIMEOUT_MS) {
+                    sji_log_error("read_socket_config: timed out after %ldms waiting for config on sockfd %d (got %zd/%zd bytes).",
+                                  elapsed_ms, sockfd, bytes_read_total, bytes_to_read);
+                    goto config_read_cleanup;
+                }
+                sji_log_warn("read_socket_config: real_read on sockfd %d returned EAGAIN/EWOULDBLOCK. Retrying (elapsed %ldms).", sockfd, elapsed_ms);
                 usleep(100000);
                 continue;
             }
@@ -678,7 +793,23 @@ static int read_socket_config(int sockfd, js_config_t *config_dest) {
         sji_log_warn("Config name from server was not null-terminated within max length; forced termination.");
     }
 
+    /* Clamp the button/axis counts to the static array bounds. These values come
+     * straight from the socket peer and are otherwise trusted verbatim; without
+     * this, an oversized num_btns/num_axes drives out-of-bounds reads of
+     * btn_map/axes_map in the EVIOCGBIT handlers (and any other count-keyed loop). */
+    if (config_dest->num_btns > INTERPOSER_MAX_BTNS) {
+        sji_log_warn("read_socket_config: num_btns %u exceeds max %u; clamping.", config_dest->num_btns, INTERPOSER_MAX_BTNS);
+        config_dest->num_btns = INTERPOSER_MAX_BTNS;
+    }
+    if (config_dest->num_axes > INTERPOSER_MAX_AXES) {
+        sji_log_warn("read_socket_config: num_axes %u exceeds max %u; clamping.", config_dest->num_axes, INTERPOSER_MAX_AXES);
+        config_dest->num_axes = INTERPOSER_MAX_AXES;
+    }
+
 config_read_cleanup:
+    if (have_saved_rcv_timeout) {
+        setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, &saved_rcv_timeout, sizeof(saved_rcv_timeout));
+    }
     if (socket_was_nonblocking && original_socket_flags != -1) {
         sji_log_debug("read_socket_config: Restoring O_NONBLOCK to sockfd %d.", sockfd);
         if (fcntl(sockfd, F_SETFL, original_socket_flags) == -1) {
@@ -689,74 +820,76 @@ config_read_cleanup:
 }
 
 /**
- * @brief Connects an interposer to its corresponding Unix domain socket.
+ * @brief Connects to the Unix domain socket backing an interposed device.
  *
  * This function creates a new socket, attempts to connect to the Unix domain
- * socket specified in `interposer->socket_path` with a timeout. Upon successful
- * connection, it reads the device configuration using `read_socket_config()`
- * and sends a 1-byte architecture specifier (sizeof(long)) to the server.
+ * socket at `socket_path` with a timeout. Upon successful connection, it reads
+ * the device configuration into `config_dest` using `read_socket_config()` and
+ * sends a 1-byte architecture specifier (sizeof(long)) to the server.
  *
- * @param interposer Pointer to the `js_interposer_t` state for the device.
- *                   The `sockfd` and `js_config` members will be updated.
- * @return 0 on successful connection and configuration, -1 on failure.
+ * It deliberately operates on locals/out-params only — never on the shared
+ * interposers[] slot — so it can run without `interposers_mutex` held while
+ * other threads scan the array; the caller publishes the returned fd and
+ * config into the slot under the lock once fully configured.
+ *
+ * @param socket_path Path of the Unix domain socket to connect to.
+ * @param config_dest Receives the device configuration on success.
+ * @return The connected socket fd on success, -1 on failure.
  *         `errno` may be set by underlying system calls.
  */
-static int connect_interposer_socket(js_interposer_t *interposer) {
-    interposer->sockfd = socket(AF_UNIX, SOCK_STREAM, 0);
-    if (interposer->sockfd == -1) {
-        sji_log_error("Failed to create socket for %s: %s", interposer->socket_path, strerror(errno));
+static int connect_interposer_socket(const char *socket_path, js_config_t *config_dest) {
+    int sockfd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (sockfd == -1) {
+        sji_log_error("Failed to create socket for %s: %s", socket_path, strerror(errno));
         return -1;
     }
 
     struct sockaddr_un addr;
     memset(&addr, 0, sizeof(struct sockaddr_un));
     addr.sun_family = AF_UNIX;
-    strncpy(addr.sun_path, interposer->socket_path, sizeof(addr.sun_path) - 1);
+    strncpy(addr.sun_path, socket_path, sizeof(addr.sun_path) - 1);
 
     int attempt = 0;
     long total_slept_us = 0;
     long timeout_us = SOCKET_CONNECT_TIMEOUT_MS * 1000;
     long sleep_interval_us = 10000;
 
-    sji_log_info("Attempting to connect to %s (fd %d)...", interposer->socket_path, interposer->sockfd);
-    while (connect(interposer->sockfd, (struct sockaddr *)&addr, sizeof(struct sockaddr_un)) == -1) {
+    sji_log_info("Attempting to connect to %s (fd %d)...", socket_path, sockfd);
+    while (connect(sockfd, (struct sockaddr *)&addr, sizeof(struct sockaddr_un)) == -1) {
         if (errno == ENOENT || errno == ECONNREFUSED) {
             if (total_slept_us >= timeout_us) {
-                sji_log_error("Timed out connecting to socket %s after %dms.", interposer->socket_path, SOCKET_CONNECT_TIMEOUT_MS);
+                sji_log_error("Timed out connecting to socket %s after %dms.", socket_path, SOCKET_CONNECT_TIMEOUT_MS);
                 goto connect_fail;
             }
             if (attempt == 0 || (attempt % 10 == 0)) {
                  sji_log_warn("Connection to %s refused/not found, retrying (attempt %d, elapsed %ldms)...",
-                              interposer->socket_path, attempt + 1, total_slept_us / 1000);
+                              socket_path, attempt + 1, total_slept_us / 1000);
             }
             usleep(sleep_interval_us);
             total_slept_us += sleep_interval_us;
             attempt++;
             continue;
         }
-        sji_log_error("Failed to connect to socket %s: %s", interposer->socket_path, strerror(errno));
+        sji_log_error("Failed to connect to socket %s: %s", socket_path, strerror(errno));
         goto connect_fail;
     }
-    sji_log_info("Connected to socket %s (fd %d).", interposer->socket_path, interposer->sockfd);
+    sji_log_info("Connected to socket %s (fd %d).", socket_path, sockfd);
 
-    if (read_socket_config(interposer->sockfd, &(interposer->js_config)) != 0) {
-        sji_log_error("Failed to read config from socket %s.", interposer->socket_path);
+    if (read_socket_config(sockfd, config_dest) != 0) {
+        sji_log_error("Failed to read config from socket %s.", socket_path);
         goto connect_fail;
     }
 
     unsigned char arch_byte[1] = { (unsigned char)sizeof(long) };
-    sji_log_info("Sending architecture specifier (%u bytes, value: %u) to %s.", (unsigned int)sizeof(arch_byte), arch_byte[0], interposer->socket_path);
-    if (real_write(interposer->sockfd, arch_byte, sizeof(arch_byte)) != sizeof(arch_byte)) {
-        sji_log_error("Failed to send architecture specifier to %s: %s", interposer->socket_path, strerror(errno));
+    sji_log_info("Sending architecture specifier (%u bytes, value: %u) to %s.", (unsigned int)sizeof(arch_byte), arch_byte[0], socket_path);
+    if (real_write(sockfd, arch_byte, sizeof(arch_byte)) != sizeof(arch_byte)) {
+        sji_log_error("Failed to send architecture specifier to %s: %s", socket_path, strerror(errno));
         goto connect_fail;
     }
-    return 0;
+    return sockfd;
 
 connect_fail:
-    if (interposer->sockfd != -1) {
-        real_close(interposer->sockfd);
-        interposer->sockfd = -1;
-    }
+    real_close(sockfd);
     return -1;
 }
 
@@ -764,13 +897,20 @@ connect_fail:
  * @brief Common logic for handling intercepted `open()` and `open64()` calls.
  *
  * This function checks if the `pathname` matches one of the device paths
- * configured for interposition. If a match is found:
- *  - If the device is already "opened" (i.e., its socket is connected),
- *    the existing socket fd is returned.
- *  - If it's a new open, `connect_interposer_socket()` is called to establish
- *    the connection and retrieve configuration.
- *  - If `O_NONBLOCK` was specified in `flags`, `make_socket_nonblocking()` is
- *    called for the socket.
+ * configured for interposition. If it does, a NEW socket connection is
+ * established for this open() call: every application handle owns a dedicated
+ * connection, so each open() returns a unique file descriptor (as POSIX
+ * requires), `O_NONBLOCK` applies per handle, and every handle receives every
+ * device event (the server broadcasts to all connections of a device).
+ *
+ * `connect_interposer_socket()` runs WITHOUT `interposers_mutex` held (it can
+ * block for the connect timeout plus the config-read timeout, and holding the
+ * lock would stall every other thread's interposed read/close/ioctl/fstat on
+ * ANY fd for that long). The connected fd is private to this thread until it
+ * is published into the slot's handle table under the lock, so concurrent
+ * scanners never observe a half-initialized handle. If `O_NONBLOCK` was
+ * specified in `flags`, `make_socket_nonblocking()` is called for the socket
+ * while it is still private to this thread.
  * The `found_interposer_ptr` is updated to point to the matched interposer.
  *
  * @param pathname The file path being opened.
@@ -779,46 +919,73 @@ connect_fail:
  *                             this will point to the `js_interposer_t` structure
  *                             for the opened device.
  * @return The socket file descriptor if the device is successfully interposed.
- *         -1 if an error occurs during interposition (e.g., socket connection failed).
- *            `errno` will be set (e.g., to `EIO`).
+ *         -1 if an error occurs during interposition. `errno` will be set
+ *            (`EIO` on connection failure, `EMFILE` when the device already
+ *            has SJI_MAX_HANDLES_PER_DEVICE open handles).
  *         -2 if the `pathname` is not recognized as an interposable device.
  *            The caller should then proceed to call the real `open()`/`open64()`.
  */
 static int common_open_logic(const char *pathname, int flags, js_interposer_t **found_interposer_ptr) {
     *found_interposer_ptr = NULL;
+
+    /* Match the slot by device name without the lock: the name fields are set
+     * once at static initialization and never mutated. */
+    js_interposer_t *interposer = NULL;
     for (size_t i = 0; i < NUM_INTERPOSERS(); i++) {
         if (strcmp(pathname, interposers[i].open_dev_name) == 0) {
-            *found_interposer_ptr = &interposers[i];
-
-            if (interposers[i].sockfd != -1) {
-                sji_log_info("Device %s already open via interposer (socket_fd %d, app_flags_orig=0x%x, new_req_flags=0x%x). Reusing.",
-                             pathname, interposers[i].sockfd, interposers[i].open_flags, flags);
-                return interposers[i].sockfd;
-            }
-
-            interposers[i].open_flags = flags;
-
-            if (connect_interposer_socket(&interposers[i]) == -1) {
-                sji_log_error("Failed to establish socket connection for %s.", pathname);
-                interposers[i].open_flags = 0;
-                errno = EIO;
-                return -1;
-            }
-
-            if (interposers[i].open_flags & O_NONBLOCK) {
-                sji_log_info("Application opened %s with O_NONBLOCK. Setting socket fd %d to non-blocking.",
-                             pathname, interposers[i].sockfd);
-                if (make_socket_nonblocking(interposers[i].sockfd) == -1) {
-                    sji_log_warn("Failed to make socket fd %d non-blocking for %s as requested by app. Socket may remain blocking.",
-                                  interposers[i].sockfd, pathname);
-                }
-            }
-            sji_log_info("Successfully interposed 'open' for %s (app_flags=0x%x), socket_fd: %d. Socket flags: 0x%x",
-                         pathname, interposers[i].open_flags, interposers[i].sockfd, fcntl(interposers[i].sockfd, F_GETFL, 0));
-            return interposers[i].sockfd;
+            interposer = &interposers[i];
+            break;
         }
     }
-    return -2;
+    if (interposer == NULL) {
+        return -2;
+    }
+    *found_interposer_ptr = interposer;
+
+    /* Blocking connect + config read on a private fd, deliberately WITHOUT
+     * the global lock. */
+    js_config_t pending_config;
+    memset(&pending_config, 0, sizeof(pending_config));
+    int new_fd = connect_interposer_socket(interposer->socket_path, &pending_config);
+    if (new_fd == -1) {
+        sji_log_error("Failed to establish socket connection for %s.", pathname);
+        errno = EIO;
+        return -1;
+    }
+
+    if (flags & O_NONBLOCK) {
+        /* The fd is still private to this thread; set it up before publishing. */
+        sji_log_info("Application opened %s with O_NONBLOCK. Setting socket fd %d to non-blocking.",
+                     pathname, new_fd);
+        if (make_socket_nonblocking(new_fd) == -1) {
+            sji_log_warn("Failed to make socket fd %d non-blocking for %s as requested by app. Socket may remain blocking.",
+                          new_fd, pathname);
+        }
+    }
+
+    /* Publish the fully configured connection (atomic from the perspective of
+     * every lock-holding scanner). */
+    pthread_mutex_lock(&interposers_mutex);
+    if (interposer->handle_count >= SJI_MAX_HANDLES_PER_DEVICE) {
+        pthread_mutex_unlock(&interposers_mutex);
+        real_close(new_fd);
+        sji_log_error("open for %s rejected: device already has the maximum of %d open handles.",
+                      pathname, SJI_MAX_HANDLES_PER_DEVICE);
+        errno = EMFILE;
+        return -1;
+    }
+    interposer->handles[interposer->handle_count].fd = new_fd;
+    interposer->handles[interposer->handle_count].open_flags = flags;
+    interposer->handle_count++;
+    /* The server sends the same per-device config on every connection;
+     * last-write-wins keeps the slot's cached copy current. */
+    interposer->js_config = pending_config;
+    int open_handles = interposer->handle_count;
+    pthread_mutex_unlock(&interposers_mutex);
+
+    sji_log_info("Successfully interposed 'open' for %s (app_flags=0x%x), socket_fd: %d (%d handle(s) open). Socket flags: 0x%x",
+                 pathname, flags, new_fd, open_handles, fcntl(new_fd, F_GETFL, 0));
+    return new_fd;
 }
 
 /**
@@ -1031,11 +1198,13 @@ int openat64(int dirfd, const char *pathname, int flags, ...) {
  * @brief Intercepted `close()` system call.
  *
  * If `real_close` is not loaded, returns -1 with `errno` set to `EFAULT`.
- * Checks if the given file descriptor `fd` corresponds to one of the
- * interposer's active socket file descriptors.
- * If it is, `real_close()` is called on the socket fd, and the interposer's
- * state for that device is reset (sockfd set to -1, config cleared).
- * If `fd` is not an interposed socket, the call is passed to `real_close()`.
+ * Checks if the given file descriptor `fd` is a handle created by an
+ * interposed open(). If it is, the handle is removed from its device's table
+ * and its dedicated socket connection is closed via `real_close()`; other
+ * handles for the same device own their own connections and are unaffected.
+ * When the last handle of a device closes, the cached device config is
+ * cleared.
+ * If `fd` is not an interposed handle, the call is passed to `real_close()`.
  *
  * @param fd The file descriptor to close.
  * @return 0 on success, -1 on error (`errno` is set by `real_close()`).
@@ -1047,23 +1216,37 @@ int close(int fd) {
         return -1;
     }
 
+    pthread_mutex_lock(&interposers_mutex);
     for (size_t i = 0; i < NUM_INTERPOSERS(); i++) {
-        if (fd >= 0 && fd == interposers[i].sockfd) {
-            sji_log_info("Intercepted 'close' for interposed fd %d (device %s). Closing socket.",
-                         fd, interposers[i].open_dev_name);
-            int ret = real_close(fd);
-            if (ret == 0) {
-                interposers[i].sockfd = -1;
-                interposers[i].open_flags = 0;
-                memset(&(interposers[i].js_config), 0, sizeof(js_config_t));
-                sji_log_info("Socket for %s (fd %d) closed and interposer state reset.", interposers[i].open_dev_name, fd);
-            } else {
-                sji_log_error("real_close on socket fd %d for %s failed: %s.",
-                              fd, interposers[i].open_dev_name, strerror(errno));
+        js_interposer_t *interposer = &interposers[i];
+        for (int h = 0; h < interposer->handle_count; h++) {
+            if (interposer->handles[h].fd != fd) {
+                continue;
             }
+            /* Retire the handle before calling real_close(): on Linux the fd
+             * is released by the kernel even when close() reports an error
+             * (e.g. EINTR), so keeping the entry would leave a stale mapping
+             * that could hijack a later reused fd number. */
+            interposer->handles[h] = interposer->handles[interposer->handle_count - 1];
+            interposer->handle_count--;
+            if (interposer->handle_count == 0) {
+                /* Last handle for this device is gone; drop the cached config. */
+                memset(&(interposer->js_config), 0, sizeof(js_config_t));
+            }
+            int ret = real_close(fd);
+            int close_errno = errno;
+            if (ret != 0) {
+                sji_log_error("real_close on socket fd %d for %s failed: %s. Handle retired anyway.",
+                              fd, interposer->open_dev_name, strerror(close_errno));
+            }
+            sji_log_info("Intercepted 'close' for interposed fd %d (device %s); %d handle(s) still open.",
+                         fd, interposer->open_dev_name, interposer->handle_count);
+            pthread_mutex_unlock(&interposers_mutex);
+            errno = close_errno;
             return ret;
         }
     }
+    pthread_mutex_unlock(&interposers_mutex);
     return real_close(fd);
 }
 
@@ -1092,12 +1275,10 @@ ssize_t read(int fd, void *buf, size_t count) {
     }
 
     js_interposer_t *interposer = NULL;
-    for (size_t i = 0; i < NUM_INTERPOSERS(); i++) {
-        if (fd == interposers[i].sockfd && interposers[i].sockfd != -1) {
-            interposer = &interposers[i];
-            break;
-        }
-    }
+    int handle_open_flags = 0;
+    pthread_mutex_lock(&interposers_mutex);
+    interposer = find_interposer_for_fd_locked(fd, &handle_open_flags);
+    pthread_mutex_unlock(&interposers_mutex);
 
     if (interposer == NULL) {
         return real_read(fd, buf, count);
@@ -1123,39 +1304,64 @@ ssize_t read(int fd, void *buf, size_t count) {
         return -1;
     }
 
-    int socket_actual_flags = fcntl(interposer->sockfd, F_GETFL, 0);
+    /* recv() on the caller's fd: each handle owns its own connection, so this
+     * reads exactly this handle's event stream. After the unlocked lookup a
+     * concurrent close() can retire the handle; the caller's fd keeps kernel
+     * read() semantics (EBADF at worst). */
+    int socket_actual_flags = fcntl(fd, F_GETFL, 0);
     int socket_is_actually_nonblocking = (socket_actual_flags != -1 && (socket_actual_flags & O_NONBLOCK));
 
     if (socket_actual_flags == -1) {
-        sji_log_warn("read: fcntl(F_GETFL) failed for sockfd %d (%s): %s. Proceeding, assuming blocking status based on open_flags.",
-                     interposer->sockfd, interposer->open_dev_name, strerror(errno));
-        socket_is_actually_nonblocking = (interposer->open_flags & O_NONBLOCK);
+        sji_log_warn("read: fcntl(F_GETFL) failed for sockfd %d (%s): %s. Proceeding, assuming blocking status based on this handle's open() flags.",
+                     fd, interposer->open_dev_name, strerror(errno));
+        socket_is_actually_nonblocking = (handle_open_flags & O_NONBLOCK);
     }
-    
-    ssize_t bytes_read = recv(interposer->sockfd, buf, event_size, 0);
+
+    ssize_t bytes_read;
+    if (socket_is_actually_nonblocking) {
+        /* Non-blocking: never consume a partial event. Peek first and only
+         * dequeue once a whole event is buffered; consuming a partial event
+         * would permanently desync the SOCK_STREAM for all later reads. */
+        ssize_t peeked = recv(fd, buf, event_size, MSG_PEEK | MSG_DONTWAIT);
+        if (peeked > 0 && (size_t)peeked < event_size) {
+            sji_log_debug("read: sockfd %d (%s) has a partial event buffered (%zd/%zu bytes); leaving it queued.",
+                          fd, interposer->open_dev_name, peeked, event_size);
+            errno = EAGAIN;
+            return -1;
+        }
+        if (peeked <= 0) {
+            bytes_read = peeked; /* error (e.g. EAGAIN) or EOF; handled below */
+        } else {
+            bytes_read = recv(fd, buf, event_size, MSG_DONTWAIT);
+        }
+    } else {
+        /* Blocking: wait for a whole event so a short read cannot desync the
+         * stream. MSG_WAITALL only returns short on EOF or an interrupting signal. */
+        bytes_read = recv(fd, buf, event_size, MSG_WAITALL);
+    }
 
     if (bytes_read == -1) {
         if (errno == EAGAIN || errno == EWOULDBLOCK) {
             if (socket_is_actually_nonblocking) {
-                 sji_log_debug("read: sockfd %d (%s) non-blocking, no data (EAGAIN/EWOULDBLOCK)", interposer->sockfd, interposer->open_dev_name);
+                 sji_log_debug("read: sockfd %d (%s) non-blocking, no data (EAGAIN/EWOULDBLOCK)", fd, interposer->open_dev_name);
             } else {
-                 sji_log_warn("read: sockfd %d (%s) reported as blocking, but got EAGAIN/EWOULDBLOCK. This might indicate an issue or a race condition.", interposer->sockfd, interposer->open_dev_name);
+                 sji_log_warn("read: sockfd %d (%s) reported as blocking, but got EAGAIN/EWOULDBLOCK. This might indicate an issue or a race condition.", fd, interposer->open_dev_name);
             }
         } else {
             sji_log_error("SOCKET_READ_ERR: read from socket_fd %d (%s) failed: %s (errno %d)",
-                          interposer->sockfd, interposer->open_dev_name, strerror(errno), errno);
+                          fd, interposer->open_dev_name, strerror(errno), errno);
         }
         return -1;
     } else if (bytes_read == 0) {
         sji_log_info("SOCKET_READ_EOF: read from socket_fd %d (%s) returned 0 (EOF - server closed connection?)",
-                     interposer->sockfd, interposer->open_dev_name);
+                     fd, interposer->open_dev_name);
         return 0;
     } else {
         sji_log_debug("SOCKET_READ_OK: read %zd bytes from socket_fd %d (%s)",
-                     bytes_read, interposer->sockfd, interposer->open_dev_name);
+                     bytes_read, fd, interposer->open_dev_name);
         if (bytes_read < event_size && bytes_read > 0) {
             sji_log_warn("SOCKET_READ_PARTIAL: read %zd bytes from socket_fd %d (%s), but expected %zu. This might cause issues.",
-                         bytes_read, interposer->sockfd, interposer->open_dev_name, event_size);
+                         bytes_read, fd, interposer->open_dev_name, event_size);
         }
     }
     return bytes_read;
@@ -1185,17 +1391,19 @@ int epoll_ctl(int epfd, int op, int fd, struct epoll_event *event) {
     }
 
     if (op == EPOLL_CTL_ADD || op == EPOLL_CTL_MOD) {
-        for (size_t i = 0; i < NUM_INTERPOSERS(); i++) {
-            if (fd == interposers[i].sockfd && interposers[i].sockfd != -1) {
-                sji_log_info("epoll_ctl %s for interposed socket fd %d (%s). Ensuring O_NONBLOCK.",
-                             (op == EPOLL_CTL_ADD ? "ADD" : "MOD"), fd, interposers[i].open_dev_name);
-                if (make_socket_nonblocking(fd) == -1) {
-                    sji_log_warn("epoll_ctl: Failed to ensure O_NONBLOCK for socket fd %d (%s). Epoll behavior might be affected.",
-                                 fd, interposers[i].open_dev_name);
-                }
-                break;
+        pthread_mutex_lock(&interposers_mutex);
+        js_interposer_t *interposer = find_interposer_for_fd_locked(fd, NULL);
+        if (interposer != NULL) {
+            sji_log_info("epoll_ctl %s for interposed socket fd %d (%s). Ensuring O_NONBLOCK.",
+                         (op == EPOLL_CTL_ADD ? "ADD" : "MOD"), fd, interposer->open_dev_name);
+            /* Each handle owns its own connection, so this flips only the
+             * caller's handle to non-blocking, not other handles of the device. */
+            if (make_socket_nonblocking(fd) == -1) {
+                sji_log_warn("epoll_ctl: Failed to ensure O_NONBLOCK for socket fd %d (%s). Epoll behavior might be affected.",
+                             fd, interposer->open_dev_name);
             }
         }
+        pthread_mutex_unlock(&interposers_mutex);
     }
     return real_epoll_ctl(epfd, op, fd, event);
 }
@@ -1675,25 +1883,31 @@ int ioctl(int fd, ioctl_request_t request, ...) {
     va_end(args_list);
 
     js_interposer_t *interposer = NULL;
-    for (size_t i = 0; i < NUM_INTERPOSERS(); i++) {
-        if (fd == interposers[i].sockfd && interposers[i].sockfd != -1) {
-            interposer = &interposers[i];
-            break;
-        }
-    }
+    pthread_mutex_lock(&interposers_mutex);
+    interposer = find_interposer_for_fd_locked(fd, NULL);
 
     if (interposer == NULL) {
+        pthread_mutex_unlock(&interposers_mutex);
         return real_ioctl(fd, request, arg_ptr);
     }
 
+    /* Hold the lock across the dispatch so a concurrent close() cannot zero
+     * js_config (the button/axis maps and counts) mid-read. The ioctl handlers
+     * perform no blocking I/O. */
+    int ioctl_ret;
     if (interposer->type == DEV_TYPE_JS) {
-        return intercept_js_ioctl(interposer, fd, request, arg_ptr);
+        ioctl_ret = intercept_js_ioctl(interposer, fd, request, arg_ptr);
     } else if (interposer->type == DEV_TYPE_EV) {
-        return intercept_ev_ioctl(interposer, fd, request, arg_ptr);
+        ioctl_ret = intercept_ev_ioctl(interposer, fd, request, arg_ptr);
     } else {
         sji_log_error("IOCTL(%s): Interposer has unknown type %d for fd %d. This should not happen. Setting EINVAL.",
                        interposer->open_dev_name, interposer->type, fd);
+        pthread_mutex_unlock(&interposers_mutex);
         errno = EINVAL;
         return -1;
     }
+    int ioctl_errno = errno;
+    pthread_mutex_unlock(&interposers_mutex);
+    errno = ioctl_errno;
+    return ioctl_ret;
 }

--- a/src/selkies/input_handler.py
+++ b/src/selkies/input_handler.py
@@ -33,6 +33,7 @@ from PIL import Image
 import urllib.parse
 import urllib.request
 from .media_pipeline import RateControlMode
+from .settings import settings
 try:
     from xkbcommon import xkb
 except ImportError:
@@ -68,6 +69,27 @@ import aiofiles
 
 logger_webrtc_input = logging.getLogger("webrtc_input")
 logger_selkies_gamepad = logging.getLogger("selkies_gamepad")
+
+# Upper bound on a single multi-part clipboard transfer (bytes). The declared
+# size and the accumulated chunks are both checked against this so a client
+# cannot grow the in-memory buffer without bound (memory-exhaustion DoS).
+MULTIPART_CLIPBOARD_MAX_SIZE = 64 * 1024 * 1024
+
+
+def _is_within_directory(directory: str, target: str) -> bool:
+    """Return True if `target` is `directory` itself or strictly inside it.
+
+    Compares on path-segment boundaries via os.path.commonpath rather than a
+    bare string prefix (which would accept sibling dirs sharing a name prefix).
+    Both paths should already be absolute/realpath-resolved by the caller.
+    """
+    directory = os.path.abspath(directory)
+    target = os.path.abspath(target)
+    try:
+        return os.path.commonpath([directory, target]) == directory
+    except ValueError:
+        # Raised for paths on different drives or a mix of absolute/relative.
+        return False
 
 # EVDEV Event Codes (from linux/input-event-codes.h)
 EV_SYN = 0x00
@@ -507,14 +529,17 @@ class SelkiesGamepad:
             buttons_evdev_codes = controller_config.get("buttons", [])
             axes_evdev_codes = controller_config.get("axes", [])
 
-            num_actual_btns = len(buttons_evdev_codes)
-            num_actual_axes = len(axes_evdev_codes)
+            # Clamp the reported counts to the array capacity so the value packed
+            # into the C js_config_t can never exceed the (truncated) btn_map /
+            # axes_map array lengths, which would otherwise drive an out-of-bounds
+            # read in the C interposer.
+            num_actual_btns = min(len(buttons_evdev_codes), INTERPOSER_MAX_BTNS)
+            num_actual_axes = min(len(axes_evdev_codes), INTERPOSER_MAX_AXES)
 
             padded_btn_map_for_pack = list(buttons_evdev_codes)
             if len(padded_btn_map_for_pack) > INTERPOSER_MAX_BTNS:
                 logging.warning(f"Controller '{name_str}' has {len(padded_btn_map_for_pack)} buttons, truncating to {INTERPOSER_MAX_BTNS} for config.")
                 padded_btn_map_for_pack = padded_btn_map_for_pack[:INTERPOSER_MAX_BTNS]
-                # num_actual_btns is already set correctly to the original length before potential truncation for the array
             else:
                 padded_btn_map_for_pack.extend([0] * (INTERPOSER_MAX_BTNS - len(padded_btn_map_for_pack)))
 
@@ -522,7 +547,6 @@ class SelkiesGamepad:
             if len(padded_axes_map_for_pack) > INTERPOSER_MAX_AXES:
                 logging.warning(f"Controller '{name_str}' has {len(padded_axes_map_for_pack)} axes, truncating to {INTERPOSER_MAX_AXES} for config.")
                 padded_axes_map_for_pack = padded_axes_map_for_pack[:INTERPOSER_MAX_AXES]
-                # num_actual_axes is already set
             else:
                 padded_axes_map_for_pack.extend([0] * (INTERPOSER_MAX_AXES - len(padded_axes_map_for_pack)))
 
@@ -2184,6 +2208,15 @@ class WebRTCInput:
                 logger_webrtc_input.error(f"Error in keyboard worker: {e}", exc_info=True)
 
     async def on_message(self, msg: str, display_id='primary'):
+        # A malformed client message must not tear down the transport connection.
+        try:
+            await self._dispatch_message(msg, display_id)
+        except (IndexError, ValueError) as e:
+            logger_webrtc_input.warning(f"Malformed client message {msg[:64]!r}: {e}")
+        except Exception as e:
+            logger_webrtc_input.error(f"Error handling client message {msg[:64]!r}: {e}", exc_info=True)
+
+    async def _dispatch_message(self, msg: str, display_id='primary'):
         toks = msg.split(",")
         msg_type = toks[0]
 
@@ -2294,7 +2327,11 @@ class WebRTCInput:
         elif msg_type == "cws":
             if self.enable_clipboard in ["true", "in"]:
                 try:
-                    self.multipart_clipboard_total_size = int(toks[1])
+                    declared_size = int(toks[1])
+                    if declared_size < 0 or declared_size > MULTIPART_CLIPBOARD_MAX_SIZE:
+                        logger_webrtc_input.error(f"Rejecting multi-part clipboard write: declared size {declared_size} out of bounds (max {MULTIPART_CLIPBOARD_MAX_SIZE}).")
+                        return
+                    self.multipart_clipboard_total_size = declared_size
                     self.multipart_clipboard_mime_type = "text/plain"
                     self.multipart_clipboard_buffer = io.BytesIO()
                     self.multipart_clipboard_in_progress = True
@@ -2306,8 +2343,12 @@ class WebRTCInput:
         elif msg_type == "cbs":
             if self.enable_clipboard in ["true", "in"]:
                 try:
+                    declared_size = int(toks[2])
+                    if declared_size < 0 or declared_size > MULTIPART_CLIPBOARD_MAX_SIZE:
+                        logger_webrtc_input.error(f"Rejecting multi-part clipboard write: declared size {declared_size} out of bounds (max {MULTIPART_CLIPBOARD_MAX_SIZE}).")
+                        return
                     self.multipart_clipboard_mime_type = toks[1]
-                    self.multipart_clipboard_total_size = int(toks[2])
+                    self.multipart_clipboard_total_size = declared_size
                     self.multipart_clipboard_buffer = io.BytesIO()
                     self.multipart_clipboard_in_progress = True
                     logger_webrtc_input.info(f"Starting multi-part binary clipboard receive ({self.multipart_clipboard_mime_type}), total size: {self.multipart_clipboard_total_size}")
@@ -2319,9 +2360,15 @@ class WebRTCInput:
             if self.multipart_clipboard_in_progress:
                 try:
                     chunk_data = base64.b64decode(toks[1])
+                    if self.multipart_clipboard_buffer.tell() + len(chunk_data) > self.multipart_clipboard_total_size:
+                        logger_webrtc_input.error("Multi-part clipboard exceeded its declared size; aborting transfer.")
+                        self.multipart_clipboard_buffer = None
+                        self.multipart_clipboard_in_progress = False
+                        return
                     self.multipart_clipboard_buffer.write(chunk_data)
                 except Exception as e:
                     logger_webrtc_input.error(f"Failed to process clipboard data chunk: {e}")
+                    self.multipart_clipboard_buffer = None
                     self.multipart_clipboard_in_progress = False
         elif msg_type == "cwe" or msg_type == "cbe":
             if self.multipart_clipboard_in_progress:
@@ -2387,6 +2434,9 @@ class WebRTCInput:
             if re.fullmatch(r"^\d+(\.\d+)?$", scale): await self.on_scaling_ratio(float(scale))
             else: logger_webrtc_input.warning(f"Rejecting scaling change, invalid: {scale}")
         elif msg_type == "cmd":
+            if not settings.command_enabled[0]:
+                logger_webrtc_input.warning("Received 'cmd' message, but command execution is disabled by server settings.")
+                return
             if len(toks) > 1:
                 command_to_run = ",".join(toks[1:])
                 logger_webrtc_input.info(f"Attempting to execute command: '{command_to_run}'")
@@ -2530,6 +2580,9 @@ class WebRTCInput:
         try:
             rel_path_from_client, size_str = filename, filesize
             file_size = int(size_str)
+            if file_size < 0:
+                logger_webrtc_input.error(f"Rejecting upload with invalid negative declared size: {file_size}")
+                return
 
             sane_rel_path = rel_path_from_client.strip('/\\')
             sane_rel_path = os.path.normpath(sane_rel_path)
@@ -2538,21 +2591,22 @@ class WebRTCInput:
             if not path_components or sane_rel_path.startswith(os.sep) or sane_rel_path.startswith('/') or \
                 sane_rel_path.startswith('\\') or ".." in path_components:
                 logger_webrtc_input.error(f"Invalid or malicious relative path from client: '{rel_path_from_client}'. Discarding.")
+                return
 
             sane_rel_path = os.path.join(*path_components)
             final_server_path = os.path.join(self.upload_dir_path, sane_rel_path)
-            real_upload_dir = os.path.realpath(self.upload_dir_path)
-            intended_parent_dir_abs = os.path.abspath(os.path.dirname(final_server_path))
-            real_upload_dir_abs = os.path.abspath(real_upload_dir)
+            real_upload_dir_abs = os.path.realpath(self.upload_dir_path)
+            # Resolve symlinks on the parent before the containment check.
+            intended_parent_dir_abs = os.path.realpath(os.path.dirname(final_server_path))
 
-            if not intended_parent_dir_abs.startswith(real_upload_dir_abs):
+            if not _is_within_directory(real_upload_dir_abs, intended_parent_dir_abs):
                 logger_webrtc_input.error(f"Path escape attempt detected: '{final_server_path}' (from client: '{rel_path_from_client}') is outside of '{real_upload_dir_abs}'. Discarding.")
                 return
 
             target_dir = os.path.dirname(final_server_path)
 
             if target_dir and target_dir != real_upload_dir_abs and not os.path.exists(target_dir):
-                if not os.path.abspath(target_dir).startswith(real_upload_dir_abs):
+                if not _is_within_directory(real_upload_dir_abs, os.path.realpath(target_dir)):
                     logger_webrtc_input.error(f"Directory creation escape attempt: '{target_dir}' is outside of '{real_upload_dir_abs}'. Discarding.")
                     return
                 try:
@@ -2569,8 +2623,13 @@ class WebRTCInput:
                     logger_webrtc_input.warning(f"Error closing previous upload stream {self.active_upload_target_path_conn}: {e_close_old}")
                 del self.active_uploads_by_path_conn[self.active_upload_target_path_conn]
 
-            self.active_uploads_by_path_conn[final_server_path] = open(final_server_path, "wb")
+            # O_NOFOLLOW prevents writing through a symlink planted at the final
+            # path component (the parent path was already symlink-resolved above).
+            upload_fd = os.open(final_server_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o644)
+            self.active_uploads_by_path_conn[final_server_path] = os.fdopen(upload_fd, "wb")
             self.active_upload_target_path_conn = final_server_path
+            self.active_upload_declared_size = file_size
+            self.active_upload_bytes_written = 0
             logger_webrtc_input.info(f"Upload started: {final_server_path} (client rel_path: '{rel_path_from_client}', size: {file_size})")
         except ValueError:
             logger_webrtc_input.error(f"Invalid FILE_UPLOAD_START format: {filename}")
@@ -2585,7 +2644,22 @@ class WebRTCInput:
         if data_type == 0x01:  # inidicates file data
             if (self.active_upload_target_path_conn and self.active_upload_target_path_conn in self.active_uploads_by_path_conn):
                 try:
+                    # Enforce the declared upload size so a client cannot stream
+                    # unlimited data (e.g. after declaring size=1) to exhaust disk.
+                    declared = getattr(self, "active_upload_declared_size", None)
+                    written = getattr(self, "active_upload_bytes_written", 0)
+                    if declared is not None and written + len(payload) > declared:
+                        logger_webrtc_input.error(f"Upload to {self.active_upload_target_path_conn} exceeded its declared size ({declared} bytes); aborting.")
+                        self.active_uploads_by_path_conn[self.active_upload_target_path_conn].close()
+                        try:
+                            os.remove(self.active_upload_target_path_conn)
+                        except OSError:
+                            pass
+                        del self.active_uploads_by_path_conn[self.active_upload_target_path_conn]
+                        self.active_upload_target_path_conn = None
+                        return
                     self.active_uploads_by_path_conn[self.active_upload_target_path_conn].write(payload)
+                    self.active_upload_bytes_written = written + len(payload)
                 except Exception as e_write:
                     logger_webrtc_input.error(f"File write error for {self.active_upload_target_path_conn}: {e_write}")
                     try:

--- a/src/selkies/selkies.py
+++ b/src/selkies/selkies.py
@@ -43,6 +43,7 @@ data_logger = logging.getLogger("data_websocket")
 X11_CAPTURE_AVAILABLE = False
 PCMFLUX_AVAILABLE = False
 
+import aiofiles
 import asyncio
 import base64
 import ctypes
@@ -106,6 +107,26 @@ except OSError as e:
 user_tokens = {}
 client_permissions = {}
 active_mk_token = None
+
+# Fallback upper bound for client-supplied integer settings that declare no
+# explicit max in their definition, to prevent resource-exhaustion from absurd
+# values.
+INT_SETTING_DEFAULT_MAX = 1_000_000
+
+def _path_is_within(directory, target):
+    """Return True if `target` is `directory` itself or strictly inside it.
+
+    Compares on path-segment boundaries via os.path.commonpath rather than a
+    bare string prefix (which would accept sibling dirs sharing a name prefix).
+    Both arguments should already be absolute/realpath-resolved by the caller.
+    """
+    directory = os.path.abspath(directory)
+    target = os.path.abspath(target)
+    try:
+        return os.path.commonpath([directory, target]) == directory
+    except ValueError:
+        return False
+
 
 async def _broadcast_to_clients(clients, message):
     """Broadcast concurrently to all clients - only remove on clear connection errors."""
@@ -922,7 +943,7 @@ class DataStreamingServer(BaseStreamingService):
         self._shared_stats_ws = {}
         self.uinput_mouse_socket = UINPUT_MOUSE_SOCKET
         self.js_socket_path = JS_SOCKET_PATH
-        self.enable_clipboard = self.cli_args.clipboard_enabled
+        self.enable_clipboard = self.cli_args.clipboard_enabled[0]
         self.enable_binary_clipboard = self.cli_args.enable_binary_clipboard[0]
         self.enable_cursors = ENABLE_CURSORS
         self.cursor_size = CURSOR_SIZE
@@ -932,6 +953,9 @@ class DataStreamingServer(BaseStreamingService):
         self.client_settings_received = asyncio.Event()
         self._reconfigure_lock = asyncio.Lock()
         self._is_reconfiguring = False
+        # Set when a reconfiguration is requested while one is already running, so
+        # the latest state is reconciled afterwards instead of being dropped.
+        self._reconfigure_pending = False
         self._bytes_sent_in_interval = 0
         self._last_bandwidth_calc_time = time.monotonic()
         # Frame-based backpressure settings
@@ -1512,10 +1536,26 @@ class DataStreamingServer(BaseStreamingService):
                 elif setting_def['type'] == 'enum':
                     allowed_values = setting_def['meta']['allowed']
                     if str(client_value) in allowed_values:
-                        return client_value
+                        # Return the value in the same (string) type as the allowed
+                        # list and the stored default, so later equality checks
+                        # don't spuriously flip on str-vs-int mismatches.
+                        return str(client_value)
                     server_default = allowed_values[0] if allowed_values else setting_def['default']
                     data_logger.warning(f"Client value for '{name}' ('{client_value}') is not in the allowed list {allowed_values}. Using server default '{server_default}'.")
                     return server_default
+                elif setting_def['type'] == 'int':
+                    sanitized = int(client_value)
+                    meta = setting_def.get('meta', {})
+                    min_val = meta.get('min', 0)
+                    # Bound client-supplied integers (e.g. manual_width/height) so a
+                    # client cannot request an absurd value that exhausts resources
+                    # (e.g. a giant framebuffer). Falls back to a generous cap when
+                    # the setting declares no explicit max.
+                    max_val = meta.get('max', INT_SETTING_DEFAULT_MAX)
+                    clamped = max(min_val, min(sanitized, max_val))
+                    if clamped != sanitized:
+                        data_logger.warning(f"Client value for '{name}' ({client_value}) was clamped to {clamped} (bounds: {min_val}-{max_val}).")
+                    return clamped
                 elif setting_def['type'] == 'bool':
                     server_val, is_locked = server_limit
                     client_bool = str(client_value).lower() in ['true', '1']
@@ -1778,6 +1818,10 @@ class DataStreamingServer(BaseStreamingService):
             name = setting_def['name']
             if name in ['port', 'dri_node', 'debug', 'audio_device_name', 'watermark_path']:
                 continue
+            # Never broadcast secrets/credentials (master_token, passwords, TURN
+            # secrets, etc.) to clients.
+            if setting_def.get('sensitive'):
+                continue
             value = getattr(settings, name)
             if setting_def['type'] == 'bool':
                 bool_val, is_locked = value
@@ -1812,6 +1856,8 @@ class DataStreamingServer(BaseStreamingService):
         self._backpressure_send_frames_enabled = True
         active_uploads_by_path_conn = {}
         active_upload_target_path_conn = None
+        active_upload_declared_size = None
+        active_upload_bytes_written = 0
         upload_dir_valid = upload_dir_path is not None
         system_monitor_task_ws = None
         gpu_monitor_task_ws = None
@@ -1884,6 +1930,8 @@ class DataStreamingServer(BaseStreamingService):
 
             async for msg in websocket:
                 if msg.type == WSMsgType.BINARY:
+                    if not msg.data:
+                        continue
                     msg_type, payload = msg.data[0], msg.data[1:]
                     if msg_type == 0x01:
                         if (
@@ -1891,10 +1939,30 @@ class DataStreamingServer(BaseStreamingService):
                             and active_upload_target_path_conn
                             in active_uploads_by_path_conn
                         ):
+                            # Enforce the declared upload size so a client cannot
+                            # stream unlimited data (e.g. after declaring size=1)
+                            # and exhaust disk.
+                            if (
+                                active_upload_declared_size is not None
+                                and active_upload_bytes_written + len(payload) > active_upload_declared_size
+                            ):
+                                data_logger.error(
+                                    f"Upload to {active_upload_target_path_conn} exceeded its declared size "
+                                    f"({active_upload_declared_size} bytes); aborting."
+                                )
+                                try:
+                                    active_uploads_by_path_conn[active_upload_target_path_conn].close()
+                                    os.remove(active_upload_target_path_conn)
+                                except Exception:
+                                    pass
+                                del active_uploads_by_path_conn[active_upload_target_path_conn]
+                                active_upload_target_path_conn = None
+                                continue
                             try:
                                 active_uploads_by_path_conn[
                                     active_upload_target_path_conn
                                 ].write(payload)
+                                active_upload_bytes_written += len(payload)
                             except Exception as e_write:
                                 data_logger.error(
                                     f"File write error for {active_upload_target_path_conn}: {e_write}"
@@ -2148,10 +2216,6 @@ class DataStreamingServer(BaseStreamingService):
 
                 elif msg.type == WSMsgType.TEXT:
                     message = msg.data
-                    if message.startswith("SETTINGS,"):
-                        client_perms = client_permissions.get(websocket)
-                        client_role = client_perms.get("role") if client_perms else "controller"
-
                     perms = client_permissions.get(websocket)
                     if perms and perms.get("role") == "viewer":
                         allowed_viewer_prefixes = [
@@ -2175,6 +2239,9 @@ class DataStreamingServer(BaseStreamingService):
                         try:
                             _, rel_path_from_client, size_str = message.split(":", 2)
                             file_size = int(size_str)
+                            if file_size < 0:
+                                data_logger.error(f"Rejecting upload with invalid negative declared size: {file_size}")
+                                continue
 
                             sane_rel_path = rel_path_from_client.strip('/\\')
                             sane_rel_path = os.path.normpath(sane_rel_path)
@@ -2188,23 +2255,23 @@ class DataStreamingServer(BaseStreamingService):
                                ".." in path_components:
                                 data_logger.error(f"Invalid or malicious relative path from client: '{rel_path_from_client}'. Discarding.")
                                 continue
-                            
+
                             sane_rel_path = os.path.join(*path_components)
 
                             final_server_path = os.path.join(upload_dir_path, sane_rel_path)
 
-                            real_upload_dir = os.path.realpath(upload_dir_path)
-                            intended_parent_dir_abs = os.path.abspath(os.path.dirname(final_server_path))
-                            real_upload_dir_abs = os.path.abspath(real_upload_dir)
+                            real_upload_dir_abs = os.path.realpath(upload_dir_path)
+                            # Resolve symlinks on the parent before the containment check.
+                            intended_parent_dir_abs = os.path.realpath(os.path.dirname(final_server_path))
 
-                            if not intended_parent_dir_abs.startswith(real_upload_dir_abs):
+                            if not _path_is_within(real_upload_dir_abs, intended_parent_dir_abs):
                                  data_logger.error(f"Path escape attempt detected: '{final_server_path}' (from client: '{rel_path_from_client}') is outside of '{real_upload_dir_abs}'. Discarding.")
                                  continue
 
                             target_dir = os.path.dirname(final_server_path)
-                            
+
                             if target_dir and target_dir != real_upload_dir_abs and not os.path.exists(target_dir):
-                                if not os.path.abspath(target_dir).startswith(real_upload_dir_abs):
+                                if not _path_is_within(real_upload_dir_abs, os.path.realpath(target_dir)):
                                     data_logger.error(f"Directory creation escape attempt: '{target_dir}' is outside of '{real_upload_dir_abs}'. Discarding.")
                                     continue
                                 try:
@@ -2225,8 +2292,13 @@ class DataStreamingServer(BaseStreamingService):
                                     data_logger.warning(f"Error closing previous upload stream {active_upload_target_path_conn}: {e_close_old}")
                                 del active_uploads_by_path_conn[active_upload_target_path_conn]
 
-                            active_uploads_by_path_conn[final_server_path] = open(final_server_path, "wb")
+                            # O_NOFOLLOW prevents writing through a symlink planted at the
+                            # final path component (the parent was already symlink-resolved).
+                            upload_fd = os.open(final_server_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o644)
+                            active_uploads_by_path_conn[final_server_path] = os.fdopen(upload_fd, "wb")
                             active_upload_target_path_conn = final_server_path
+                            active_upload_declared_size = file_size
+                            active_upload_bytes_written = 0
                             data_logger.info(
                                 f"Upload started: {final_server_path} (client rel_path: '{rel_path_from_client}', size: {file_size})"
                             )
@@ -2448,42 +2520,6 @@ class DataStreamingServer(BaseStreamingService):
                         except (IndexError, ValueError):
                             data_logger.warning(f"Malformed CLIENT_FRAME_ACK from {raddr}: {message}")
 
-                    elif message.startswith("FILE_UPLOAD_END:"):
-                        if (
-                            active_upload_target_path_conn
-                            and active_upload_target_path_conn
-                            in active_uploads_by_path_conn
-                        ):
-                            active_uploads_by_path_conn[
-                                active_upload_target_path_conn
-                            ].close()
-                            data_logger.info(
-                                f"Upload finished: {active_upload_target_path_conn}"
-                            )
-                            del active_uploads_by_path_conn[
-                                active_upload_target_path_conn
-                            ]
-                        active_upload_target_path_conn = None
-
-                    elif message.startswith("FILE_UPLOAD_ERROR:"):
-                        data_logger.error(f"Client reported upload error: {message}")
-                        if (
-                            active_upload_target_path_conn
-                            and active_upload_target_path_conn
-                            in active_uploads_by_path_conn
-                        ):
-                            active_uploads_by_path_conn[
-                                active_upload_target_path_conn
-                            ].close()
-                            try:
-                                os.remove(active_upload_target_path_conn)
-                            except OSError:
-                                pass
-                            del active_uploads_by_path_conn[
-                                active_upload_target_path_conn
-                            ]
-                        active_upload_target_path_conn = None
-
                     elif message == "START_VIDEO":
                         perms = client_permissions.get(websocket)
                         if perms and perms.get("role") == "viewer":
@@ -2685,6 +2721,22 @@ class DataStreamingServer(BaseStreamingService):
                             data_logger.warning("Received 'cmd' message, but command execution is disabled by server settings.")
                             continue
 
+                        # In secure mode, 'cmd' requires the same authority as
+                        # keyboard/mouse input: the active mk-token holder, or a
+                        # controller when no mk-token is set.
+                        if self.is_secure_mode:
+                            cmd_perms = client_permissions.get(websocket)
+                            cmd_token = cmd_perms.get("token") if cmd_perms else None
+                            if active_mk_token is not None:
+                                if cmd_token != active_mk_token:
+                                    data_logger.warning(f"BLOCK (Secure Mode): 'cmd' from {remote_address} dropped; client is not the active controller.")
+                                    continue
+                            else:
+                                cmd_role = cmd_perms.get("role") if cmd_perms else "viewer"
+                                if cmd_role != "controller":
+                                    data_logger.warning(f"BLOCK (Secure Mode): 'cmd' from {remote_address} dropped; client is not a controller.")
+                                    continue
+
                         toks = message.split(',')
                         if len(toks) > 1:
                             command_to_run = ",".join(toks[1:])
@@ -2726,7 +2778,7 @@ class DataStreamingServer(BaseStreamingService):
                                 data_logger.warning(f"BLOCK (Secure Mode): Malformed gamepad message from {remote_address}: {message}")
                                 continue
 
-                        if self.is_secure_mode and message.split(',')[0] in ["kd", "ku", "m", "m2", "cws", "cbs", "cwd", "cbd", "cwe", "cbe", "cw", "cb", "cr"]:
+                        if self.is_secure_mode and message.split(',')[0] in ["kd", "ku", "kr", "m", "m2", "cws", "cbs", "cwd", "cbd", "cwe", "cbe", "cw", "cb", "cr"]:
                             perms = client_permissions.get(websocket)
                             token = perms.get("token") if perms else None
                             
@@ -2869,8 +2921,9 @@ class DataStreamingServer(BaseStreamingService):
             if not self.clients:
                  data_logger.info(f"Last client ({raddr}) disconnected. All pipelines should have been stopped by reconfigure_displays.")
                  self.capture_cursor = False
-                 async with self._reconfigure_lock:
-                     await self.shutdown_pipelines()
+                 # shutdown_pipelines() -> reconfigure_displays() acquires
+                 # _reconfigure_lock itself; it must not be held here.
+                 await self.shutdown_pipelines()
 
             data_logger.info(f"Data WS handler for {raddr} finished all cleanup.")
 
@@ -2895,20 +2948,6 @@ class DataStreamingServer(BaseStreamingService):
             await asyncio.sleep(poll_interval)
         return None
 
-    async def _cleanup_client(self, websocket, display_id):
-        """Removes a client and triggers reconfiguration if necessary."""
-        _cleanup_raddr = client_permissions.get(websocket, {}).get("remote_address", "unknown")
-        data_logger.info(f"Cleaning up Data WS handler for {_cleanup_raddr} (Display ID: {display_id})...")
-        self.display_clients.pop(display_id, None)
-
-        if self._is_reconfiguring:
-            data_logger.warning(f"Client '{display_id}' disconnected DURING a reconfiguration. "
-                                "A new reconfiguration will NOT be triggered to prevent a loop.")
-            return
-
-        data_logger.info(f"Client for {display_id} removed. Triggering display reconfiguration.")
-        async with self._reconfigure_lock:
-            await self.reconfigure_displays()
 
     async def _run_detached_command(self, cmd_list: list, description: str):
         """Runs a command via the shell using 'nohup ... &' to detach it from the server process."""
@@ -2989,164 +3028,179 @@ class DataStreamingServer(BaseStreamingService):
         This is called on connect, disconnect, or settings change.
         """
         if self._reconfigure_lock.locked():
-            data_logger.warning("Reconfiguration already in progress. Ignoring concurrent request.")
+            # A pass is already running; flag it to run again with the latest
+            # state once it finishes (last-write-wins coalescing).
+            self._reconfigure_pending = True
+            data_logger.info("Reconfiguration already in progress; coalescing this request.")
             return
-        async with self._reconfigure_lock:
-            self._is_reconfiguring = True
-            data_logger.info("Starting display reconfiguration...")
-            try:
-                current_display_count = len(self.display_clients)
-                if not IS_WAYLAND and self._wm_swap_is_supported is None:
-                    if which("xfce4-session") or which("startplasma-x11"):
-                        self._wm_swap_is_supported = True
-                    else:
-                        self._wm_swap_is_supported = False
-                if (not IS_WAYLAND and current_display_count > 1 and self._wm_swap_is_supported and not self._is_wm_swapped):
-                    data_logger.info("Multi-monitor setup: switching to Openbox with a minimal config.")
-                    config_path = "/tmp/openbox_selkies_config.xml"
-                    config_content = "<openbox_config></openbox_config>\n"
-                    try:
-                        with open(config_path, "w") as f:
-                            f.write(config_content)
-                        data_logger.info(f"Wrote minimal Openbox config to {config_path}")
-                        openbox_cmd = ["openbox", "--config-file", config_path, "--replace"]
-                    except IOError as e:
-                        data_logger.error(f"Could not write Openbox config to {config_path}: {e}. Proceeding without custom config.")
-                        openbox_cmd = ["openbox", "--replace"]
-                    await self._run_detached_command(openbox_cmd, "switch to openbox")
-                    self._is_wm_swapped = True
-                if self.capture_instances or any(d.get('backpressure_task') for d in self.display_clients.values()):
-                    data_logger.info("Stopping all existing capture and backpressure tasks...")
-                    stop_bp_tasks = [self._ensure_backpressure_task_is_stopped(disp_id) for disp_id in self.display_clients.keys()]
-                    if stop_bp_tasks:
-                        await asyncio.gather(*stop_bp_tasks, return_exceptions=True)
-                    stop_capture_tasks = [
-                        self.capture_loop.run_in_executor(None, inst['module'].stop_capture)
-                        for inst in self.capture_instances.values() if inst.get('module')
-                    ]
-                    if stop_capture_tasks:
-                        await asyncio.gather(*stop_capture_tasks, return_exceptions=True)
+        while True:
+            async with self._reconfigure_lock:
+                self._reconfigure_pending = False
+                self._is_reconfiguring = True
+                data_logger.info("Starting display reconfiguration...")
+                try:
+                    await self._reconfigure_displays_locked()
+                except Exception as e:
+                    data_logger.error(f"A critical error occurred during display reconfiguration: {e}", exc_info=True)
+                finally:
+                    self._last_display_count = len(self.display_clients)
+                    self._is_reconfiguring = False
+                    data_logger.info("Reconfiguration process complete (state unlocked).")
+            # Run another pass if requests were coalesced while the lock was
+            # held; checked on every exit path (a pass may return early).
+            if not self._reconfigure_pending:
+                break
 
-                    for display_id, inst in self.capture_instances.items():
-                        sender_task = inst.get('sender_task')
-                        if sender_task and not sender_task.done():
-                            sender_task.cancel()
-                    self.capture_instances.clear()
-                    self.video_chunk_queues.clear()
-                    data_logger.info("All capture instances, senders, and backpressure tasks stopped.")
-                if not self.display_clients:
-                    data_logger.warning("No display clients connected. Video pipelines remain stopped.")
-                    _, _, _, _, screen_name = await get_new_res("1x1")
-                    if screen_name:
-                        current_monitors = await self._get_current_monitors()
-                        for monitor_name in current_monitors:
-                            await self._run_command(["xrandr", "--delmonitor", monitor_name], f"cleanup monitor {monitor_name}")
+    async def _reconfigure_displays_locked(self):
+        """One reconfiguration pass. Must only be called by reconfigure_displays()
+        with _reconfigure_lock held; early returns here abort just this pass."""
+        current_display_count = len(self.display_clients)
+        if not IS_WAYLAND and self._wm_swap_is_supported is None:
+            if which("xfce4-session") or which("startplasma-x11"):
+                self._wm_swap_is_supported = True
+            else:
+                self._wm_swap_is_supported = False
+        if (not IS_WAYLAND and current_display_count > 1 and self._wm_swap_is_supported and not self._is_wm_swapped):
+            data_logger.info("Multi-monitor setup: switching to Openbox with a minimal config.")
+            config_path = "/tmp/openbox_selkies_config.xml"
+            config_content = "<openbox_config></openbox_config>\n"
+            try:
+                async with aiofiles.open(config_path, "w") as f:
+                    await f.write(config_content)
+                data_logger.info(f"Wrote minimal Openbox config to {config_path}")
+                openbox_cmd = ["openbox", "--config-file", config_path, "--replace"]
+            except IOError as e:
+                data_logger.error(f"Could not write Openbox config to {config_path}: {e}. Proceeding without custom config.")
+                openbox_cmd = ["openbox", "--replace"]
+            await self._run_detached_command(openbox_cmd, "switch to openbox")
+            self._is_wm_swapped = True
+        if self.capture_instances or any(d.get('backpressure_task') for d in self.display_clients.values()):
+            data_logger.info("Stopping all existing capture and backpressure tasks...")
+            stop_bp_tasks = [self._ensure_backpressure_task_is_stopped(disp_id) for disp_id in self.display_clients.keys()]
+            if stop_bp_tasks:
+                await asyncio.gather(*stop_bp_tasks, return_exceptions=True)
+            stop_capture_tasks = [
+                self.capture_loop.run_in_executor(None, inst['module'].stop_capture)
+                for inst in self.capture_instances.values() if inst.get('module')
+            ]
+            if stop_capture_tasks:
+                await asyncio.gather(*stop_capture_tasks, return_exceptions=True)
+
+            for display_id, inst in self.capture_instances.items():
+                sender_task = inst.get('sender_task')
+                if sender_task and not sender_task.done():
+                    sender_task.cancel()
+            self.capture_instances.clear()
+            self.video_chunk_queues.clear()
+            data_logger.info("All capture instances, senders, and backpressure tasks stopped.")
+        if not self.display_clients:
+            data_logger.warning("No display clients connected. Video pipelines remain stopped.")
+            _, _, _, _, screen_name = await get_new_res("1x1")
+            if screen_name:
+                current_monitors = await self._get_current_monitors()
+                for monitor_name in current_monitors:
+                    await self._run_command(["xrandr", "--delmonitor", monitor_name], f"cleanup monitor {monitor_name}")
+            return
+        data_logger.info("Calculating new extended desktop layout from ALL clients...")
+        layouts = {}
+        total_width = 0
+        total_height = 0
+        primary_client = self.display_clients.get('primary')
+        secondary_client = None
+        secondary_id = None
+        for display_id, client in self.display_clients.items():
+            if display_id != 'primary':
+                secondary_client = client
+                secondary_id = display_id
+                break
+        if primary_client and not secondary_client:
+            p_w, p_h = primary_client.get('width', 0), primary_client.get('height', 0)
+            if p_w > 0 and p_h > 0:
+                layouts['primary'] = {'x': 0, 'y': 0, 'w': p_w, 'h': p_h}
+                total_width, total_height = p_w, p_h
+        elif primary_client and secondary_client:
+            p_w, p_h = primary_client.get('width', 0), primary_client.get('height', 0)
+            s_w, s_h = secondary_client.get('width', 0), secondary_client.get('height', 0)
+            position = secondary_client.get('position', 'right')
+            if p_w > 0 and p_h > 0 and s_w > 0 and s_h > 0:
+                if position == 'right':
+                    layouts['primary'] = {'x': 0, 'y': 0, 'w': p_w, 'h': p_h}
+                    layouts[secondary_id] = {'x': p_w, 'y': 0, 'w': s_w, 'h': s_h}
+                    total_width, total_height = p_w + s_w, max(p_h, s_h)
+                elif position == 'left':
+                    layouts[secondary_id] = {'x': 0, 'y': 0, 'w': s_w, 'h': s_h}
+                    layouts['primary'] = {'x': s_w, 'y': 0, 'w': p_w, 'h': p_h}
+                    total_width, total_height = p_w + s_w, max(p_h, s_h)
+                elif position == 'down':
+                    layouts['primary'] = {'x': 0, 'y': 0, 'w': p_w, 'h': p_h}
+                    layouts[secondary_id] = {'x': 0, 'y': p_h, 'w': s_w, 'h': s_h}
+                    total_width, total_height = max(p_w, s_w), p_h + s_h
+                elif position == 'up':
+                    layouts[secondary_id] = {'x': 0, 'y': 0, 'w': s_w, 'h': s_h}
+                    layouts['primary'] = {'x': 0, 'y': s_h, 'w': p_w, 'h': p_h}
+                    total_width, total_height = max(p_w, s_w), p_h + s_h
+        if total_width == 0 or total_height == 0:
+            data_logger.error("Calculated total display size is zero. Aborting reconfiguration.")
+            return
+        aligned_total_width = (total_width + 7) & ~7
+        if aligned_total_width != total_width:
+            data_logger.info(f"Aligned total width from {total_width} to {aligned_total_width} for xrandr.")
+            total_width = aligned_total_width
+        self.display_layouts = layouts
+        data_logger.info(f"Layout calculated: Total Size={total_width}x{total_height}. Layouts: {layouts}")
+        if not IS_WAYLAND:
+            _, _, available_resolutions, _, screen_name = await get_new_res("1x1")
+            if not screen_name:
+                data_logger.error("CRITICAL: Could not determine screen name from xrandr. Aborting.")
+                return
+            current_monitors = await self._get_current_monitors()
+            for monitor_name in current_monitors:
+                await self._run_command(["xrandr", "--delmonitor", monitor_name], f"delete old monitor {monitor_name}")
+            total_mode_str = f"{total_width}x{total_height}"
+            if total_mode_str not in available_resolutions:
+                data_logger.info(f"Mode {total_mode_str} not found. Creating it.")
+                try:
+                    _, modeline_params = await generate_xrandr_gtf_modeline(total_mode_str)
+                    await self._run_command(["xrandr", "--newmode", total_mode_str] + modeline_params.split(), "create new mode")
+                    await self._run_command(["xrandr", "--addmode", screen_name, total_mode_str], "add new mode")
+                except Exception as e:
+                    data_logger.error(f"FATAL: Could not create extended mode {total_mode_str}: {e}. Aborting.")
                     return
-                data_logger.info("Calculating new extended desktop layout from ALL clients...")
-                layouts = {}
-                total_width = 0
-                total_height = 0
-                primary_client = self.display_clients.get('primary')
-                secondary_client = None
-                secondary_id = None
-                for display_id, client in self.display_clients.items():
-                    if display_id != 'primary':
-                        secondary_client = client
-                        secondary_id = display_id
-                        break
-                if primary_client and not secondary_client:
-                    p_w, p_h = primary_client.get('width', 0), primary_client.get('height', 0)
-                    if p_w > 0 and p_h > 0:
-                        layouts['primary'] = {'x': 0, 'y': 0, 'w': p_w, 'h': p_h}
-                        total_width, total_height = p_w, p_h
-                elif primary_client and secondary_client:
-                    p_w, p_h = primary_client.get('width', 0), primary_client.get('height', 0)
-                    s_w, s_h = secondary_client.get('width', 0), secondary_client.get('height', 0)
-                    position = secondary_client.get('position', 'right')
-                    if p_w > 0 and p_h > 0 and s_w > 0 and s_h > 0:
-                        if position == 'right':
-                            layouts['primary'] = {'x': 0, 'y': 0, 'w': p_w, 'h': p_h}
-                            layouts[secondary_id] = {'x': p_w, 'y': 0, 'w': s_w, 'h': s_h}
-                            total_width, total_height = p_w + s_w, max(p_h, s_h)
-                        elif position == 'left':
-                            layouts[secondary_id] = {'x': 0, 'y': 0, 'w': s_w, 'h': s_h}
-                            layouts['primary'] = {'x': s_w, 'y': 0, 'w': p_w, 'h': p_h}
-                            total_width, total_height = p_w + s_w, max(p_h, s_h)
-                        elif position == 'down':
-                            layouts['primary'] = {'x': 0, 'y': 0, 'w': p_w, 'h': p_h}
-                            layouts[secondary_id] = {'x': 0, 'y': p_h, 'w': s_w, 'h': s_h}
-                            total_width, total_height = max(p_w, s_w), p_h + s_h
-                        elif position == 'up':
-                            layouts[secondary_id] = {'x': 0, 'y': 0, 'w': s_w, 'h': s_h}
-                            layouts['primary'] = {'x': 0, 'y': s_h, 'w': p_w, 'h': p_h}
-                            total_width, total_height = max(p_w, s_w), p_h + s_h
-                if total_width == 0 or total_height == 0:
-                    data_logger.error("Calculated total display size is zero. Aborting reconfiguration.")
-                    return
-                aligned_total_width = (total_width + 7) & ~7
-                if aligned_total_width != total_width:
-                    data_logger.info(f"Aligned total width from {total_width} to {aligned_total_width} for xrandr.")
-                    total_width = aligned_total_width
-                self.display_layouts = layouts
-                data_logger.info(f"Layout calculated: Total Size={total_width}x{total_height}. Layouts: {layouts}")
-                if not IS_WAYLAND:
-                    _, _, available_resolutions, _, screen_name = await get_new_res("1x1")
-                    if not screen_name:
-                        data_logger.error("CRITICAL: Could not determine screen name from xrandr. Aborting.")
-                        return
-                    current_monitors = await self._get_current_monitors()
-                    for monitor_name in current_monitors:
-                        await self._run_command(["xrandr", "--delmonitor", monitor_name], f"delete old monitor {monitor_name}")
-                    total_mode_str = f"{total_width}x{total_height}"
-                    if total_mode_str not in available_resolutions:
-                        data_logger.info(f"Mode {total_mode_str} not found. Creating it.")
-                        try:
-                            _, modeline_params = await generate_xrandr_gtf_modeline(total_mode_str)
-                            await self._run_command(["xrandr", "--newmode", total_mode_str] + modeline_params.split(), "create new mode")
-                            await self._run_command(["xrandr", "--addmode", screen_name, total_mode_str], "add new mode")
-                        except Exception as e:
-                            data_logger.error(f"FATAL: Could not create extended mode {total_mode_str}: {e}. Aborting.")
-                            return
-                    await self._run_command(["xrandr", "--fb", total_mode_str, "--output", screen_name, "--mode", total_mode_str], "set framebuffer")
-                    data_logger.info("Defining logical monitors for the window manager...")
-                    for display_id, layout in layouts.items():
-                        geometry = f"{layout['w']}/0x{layout['h']}/0+{layout['x']}+{layout['y']}"
-                        monitor_name = f"selkies-{display_id}"
-                        cmd = ["xrandr", "--setmonitor", monitor_name, geometry, screen_name]
-                        await self._run_command(cmd, f"set logical monitor {monitor_name}")
-                    if 'primary' in layouts:
-                        await self._run_command(
-                            ["xrandr", "--output", screen_name, "--primary"],
-                            "set primary output"
-                        )
-                data_logger.info("Starting separate capture instances for each ACTIVE display region...")
-                for display_id, layout in layouts.items():
-                    client_data = self.display_clients.get(display_id)
-                    if client_data and client_data.get('video_active', False):
-                        data_logger.info(f"Client '{display_id}' is active. Starting its capture.")
-                        try:
-                            await self._start_capture_for_display(
-                                display_id=display_id,
-                                width=layout['w'], height=layout['h'],
-                                x_offset=layout['x'], y_offset=layout['y']
-                            )
-                            await self._start_backpressure_task_if_needed(display_id)
-                        except Exception as e:
-                            data_logger.error(
-                                f"Failed to start capture for display '{display_id}' during reconfiguration. "
-                                f"This display will not stream. Error: {e}", exc_info=False
-                            )
-                    else:
-                        data_logger.info(f"Client '{display_id}' is connected but not active. Skipping video start.")
-                await self.broadcast_stream_resolution()
-                await self.broadcast_display_config()
-                data_logger.info("Display reconfiguration finished successfully.")
-            except Exception as e:
-                data_logger.error(f"A critical error occurred during display reconfiguration: {e}", exc_info=True)
-            finally:
-                self._last_display_count = len(self.display_clients)
-                self._is_reconfiguring = False
-                data_logger.info("Reconfiguration process complete (state unlocked).")
+            await self._run_command(["xrandr", "--fb", total_mode_str, "--output", screen_name, "--mode", total_mode_str], "set framebuffer")
+            data_logger.info("Defining logical monitors for the window manager...")
+            for display_id, layout in layouts.items():
+                geometry = f"{layout['w']}/0x{layout['h']}/0+{layout['x']}+{layout['y']}"
+                monitor_name = f"selkies-{display_id}"
+                cmd = ["xrandr", "--setmonitor", monitor_name, geometry, screen_name]
+                await self._run_command(cmd, f"set logical monitor {monitor_name}")
+            if 'primary' in layouts:
+                await self._run_command(
+                    ["xrandr", "--output", screen_name, "--primary"],
+                    "set primary output"
+                )
+        data_logger.info("Starting separate capture instances for each ACTIVE display region...")
+        for display_id, layout in layouts.items():
+            client_data = self.display_clients.get(display_id)
+            if client_data and client_data.get('video_active', False):
+                data_logger.info(f"Client '{display_id}' is active. Starting its capture.")
+                try:
+                    await self._start_capture_for_display(
+                        display_id=display_id,
+                        width=layout['w'], height=layout['h'],
+                        x_offset=layout['x'], y_offset=layout['y']
+                    )
+                    await self._start_backpressure_task_if_needed(display_id)
+                except Exception as e:
+                    data_logger.error(
+                        f"Failed to start capture for display '{display_id}' during reconfiguration. "
+                        f"This display will not stream. Error: {e}", exc_info=False
+                    )
+            else:
+                data_logger.info(f"Client '{display_id}' is connected but not active. Skipping video start.")
+        await self.broadcast_stream_resolution()
+        await self.broadcast_display_config()
+        data_logger.info("Display reconfiguration finished successfully.")
+
 
     async def _video_chunk_sender(self, display_id: str):
         """
@@ -3470,14 +3524,19 @@ class DataStreamingServer(BaseStreamingService):
         try:
             new_token_data = await request.json()
             if not isinstance(new_token_data, dict): raise ValueError("Payload must be a JSON object")
+            # Validate the full payload before mutating global auth state.
+            for tkn, perms in new_token_data.items():
+                if not isinstance(perms, dict):
+                    raise ValueError(f"Token entry for {tkn!r} must be a JSON object")
         except (json.JSONDecodeError, ValueError) as e:
             return web.Response(status=400, text=f"Bad Request: {e}")
-        user_tokens = new_token_data
+
         new_mk_owner = None
-        for tkn, perms in user_tokens.items():
+        for tkn, perms in new_token_data.items():
             if perms.get("mk_control", False):
                 new_mk_owner = tkn
                 break
+        user_tokens = new_token_data
         active_mk_token = new_mk_owner
         logger.info(f"Updated user tokens. Now tracking {len(user_tokens)} tokens.")
         if not self.config_gate.is_set():
@@ -3735,6 +3794,9 @@ async def reconcile_clients():
                 await ws.close(code=4002, message=reason.encode())
             except (ConnectionResetError, OSError, RuntimeError):
                 pass
+            # new_perms is None when the token was revoked; nothing below
+            # applies to a client being disconnected.
+            continue
         has_mk_access = False
         if active_mk_token is not None:
             if token == active_mk_token:

--- a/src/selkies/settings.py
+++ b/src/selkies/settings.py
@@ -156,12 +156,14 @@ SETTING_DEFINITIONS = [
         "name": "manual_width",
         "type": "int",
         "default": 0,
+        "meta": {"min": 0, "max": 7680},
         "help": "Lock width to a fixed value. Setting this forces manual resolution mode.",
     },
     {
         "name": "manual_height",
         "type": "int",
         "default": 0,
+        "meta": {"min": 0, "max": 4320},
         "help": "Lock height to a fixed value. Setting this forces manual resolution mode.",
     },
     {
@@ -768,6 +770,26 @@ SETTING_DEFINITIONS = [
         "help": "Directory to save the uploaded content, in absolute path format. Default to '~/Desktop' directory",
     },
 ]
+
+# Settings whose values are secrets/credential material and must NEVER be exposed
+# to clients (e.g. broadcast in the server_settings payload). Marking is centralized
+# here and surfaced via a 'sensitive' flag on the definition so every consumer that
+# iterates SETTING_DEFINITIONS can exclude them uniformly. When adding a new secret
+# setting, add its name here.
+SENSITIVE_SETTING_NAMES = frozenset({
+    "master_token",
+    "https_key",
+    "basic_auth_user",
+    "basic_auth_password",
+    "turn_rest_api_key",
+    "turn_shared_secret",
+    "turn_password",
+    "cloudflare_turn_token_id",
+    "cloudflare_turn_api_token",
+})
+for _setting_def in SETTING_DEFINITIONS:
+    if _setting_def["name"] in SENSITIVE_SETTING_NAMES:
+        _setting_def["sensitive"] = True
 
 
 class AppSettings:

--- a/src/selkies/signaling_server.py
+++ b/src/selkies/signaling_server.py
@@ -13,7 +13,7 @@ from aiohttp.web_ws import WebSocketResponse
 from aiohttp import web, WSMessage, WSMsgType
 from typing import Dict, Set, Optional, Any, Tuple, List
 
-from .webrtc_utils import generate_rtc_config
+from .webrtc_utils import generate_rtc_config, _is_trusted_config_file
 
 logger = logging.getLogger("signaling")
 
@@ -68,11 +68,20 @@ class WebRTCPeerManagement:
         self.enable_player4: bool = options.enable_player4
         self.lock: asyncio.Lock = asyncio.Lock()
 
-        # RTC config - can be str or dict
+        # RTC config - can be str or dict. Apply the same ownership/permission
+        # checks as webrtc_utils.try_json_file(): this content is served verbatim
+        # to clients, and the default location lives in a world-writable /tmp.
         self.rtc_config: Optional[Any] = None
         if os.path.exists(options.rtc_config_file):
             logger.info("parsing rtc_config_file: {}".format(options.rtc_config_file))
-            self.rtc_config = self.read_file(options.rtc_config_file)
+            if _is_trusted_config_file(options.rtc_config_file):
+                self.rtc_config = self.read_file(options.rtc_config_file)
+            else:
+                logger.error(
+                    "Refusing to use RTC config file {!r}: unsafe ownership or permissions.".format(
+                        options.rtc_config_file
+                    )
+                )
 
         # Validate TURN arguments
         if self.turn_shared_secret:
@@ -80,6 +89,22 @@ class WebRTCPeerManagement:
                 raise Exception(
                     "missing turn_host or turn_port options with turn_shared_secret"
                 )
+
+    def read_file(self, path: str) -> Optional[str]:
+        """Read and return the contents of a file as a string.
+
+        Args:
+            path: Path to the file to read
+
+        Returns:
+            File contents as a string, or None if the file cannot be read.
+        """
+        try:
+            with open(path, "r") as f:
+                return f.read()
+        except OSError as e:
+            logger.error("Failed to read rtc_config_file {!r}: {}".format(path, e))
+            return None
 
     def set_rtc_config(self, rtc_config: Any) -> None:
         """Set the RTC configuration.
@@ -157,11 +182,17 @@ class WebRTCPeerManagement:
             uid: Peer ID to remove
             room_id: Room ID to remove from
         """
-        room_peers: Set[str] = self.rooms[room_id]
-        if uid not in room_peers:
+        room_peers: Optional[Set[str]] = self.rooms.get(room_id)
+        if not room_peers or uid not in room_peers:
             return
         room_peers.remove(uid)
-        for pid in room_peers:
+        # Free the room once it becomes empty to avoid unbounded growth of
+        # self.rooms over repeated join/leave cycles.
+        if not room_peers:
+            del self.rooms[room_id]
+        # Iterate a snapshot: the awaits below can interleave with the join
+        # path mutating this set.
+        for pid in list(room_peers):
             peer = self.peers.get(pid)
             if not peer:
                 continue
@@ -279,9 +310,24 @@ class WebRTCPeerManagement:
                         if not other_peer:
                             logger.warning(f"Peer {other_id} not found for session message relay")
                             continue
+                        # Only relay between the two peers that actually share a
+                        # session. self.sessions is unidirectional (client -> server),
+                        # so accept either direction but reject a message aimed at an
+                        # unrelated peer (e.g. another client in sharing mode).
+                        if not (
+                            self.sessions.get(uid) == other_id
+                            or self.sessions.get(other_id) == uid
+                        ):
+                            logger.warning(
+                                f"Rejecting session relay {uid} -> {other_id}: not session partners"
+                            )
+                            continue
+                        if other_peer.peer_status != "session":
+                            logger.warning(
+                                f"Rejecting session relay {uid} -> {other_id}: target not in a session"
+                            )
+                            continue
                         wso = other_peer.ws
-                        status = other_peer.peer_status
-                        assert status == "session"
                         logger.info("{} -> {}: {}".format(uid, other_id, msg))
                         msg_string = "{} {}".format(uid, msg_string)
                         await wso.send_str(msg_string)
@@ -339,9 +385,6 @@ class WebRTCPeerManagement:
                     if callee_id not in self.peers:
                         await ws.send_str("ERROR peer server not found")
                         continue
-                    if peer_status is not None:
-                        await ws.send_str("ERROR peer {!r} busy".format(callee_id))
-                        continue
                     await ws.send_str("SESSION_OK " + str(callee_id))
                     callee_peer = self.peers.get(callee_id)
                     if not callee_peer:
@@ -389,7 +432,8 @@ class WebRTCPeerManagement:
                     # Enter room
                     peer.peer_status = peer_status = room_id
                     self.rooms[room_id].add(uid)
-                    for pid in self.rooms[room_id]:
+                    # Iterate a snapshot: peers can join/leave across the awaits.
+                    for pid in list(self.rooms[room_id]):
                         if pid == uid:
                             continue
                         peer = self.peers.get(pid)
@@ -596,8 +640,8 @@ class WebRTCPeerManagement:
             username = request_headers.get(self.turn_auth_header_name, "")
             if not username:
                 logger.warning(
-                    f"HTTP GET {path} 401 - missing auth header: {self.turn_auth_header_name}. "
-                    f"Using a default username"
+                    f"HTTP GET {path} - missing auth header: {self.turn_auth_header_name}. "
+                    "Generating credential with an empty username"
                 )
 
             logger.info("Generating HMAC credential for user: {}".format(username))

--- a/src/selkies/stream_server.py
+++ b/src/selkies/stream_server.py
@@ -181,7 +181,8 @@ class CentralizedStreamServer:
                 last_mtime,
                 new_mtime,
             )
-            last_mtime = new_mtime
+            # last_mtime advances only once the new site is up (below), so a
+            # failed reload is retried on the next poll.
 
             # Build the new SSL context *before* tearing down the old site so that
             # a bad certificate never takes the server offline.
@@ -216,6 +217,7 @@ class CentralizedStreamServer:
                 await new_site.start()
                 current_site = new_site
                 self.site = new_site
+                last_mtime = new_mtime
                 logger.info(
                     "New TCPSite started with reloaded certificates on %s:%s",
                     self.settings.addr,
@@ -223,9 +225,26 @@ class CentralizedStreamServer:
                 )
             except Exception as exc:
                 logger.critical(
-                    "Failed to start new TCPSite: %s. HTTPS server may be down!",
+                    "Failed to start new TCPSite: %s. HTTPS server may be down; "
+                    "will retry on the next certificate poll.",
                     exc,
                 )
+
+    @staticmethod
+    def _check_master_token(auth_header, master_token) -> bool:
+        """Constant-time check of a `Bearer <master_token>` Authorization header.
+
+        Compares as UTF-8 bytes so non-ASCII input cannot raise from
+        hmac.compare_digest, and is timing-safe (no short-circuit on the secret).
+        """
+        if not auth_header or not auth_header.startswith("Bearer "):
+            return False
+        parts = auth_header.split()
+        if len(parts) < 2:
+            return False
+        return hmac.compare_digest(
+            parts[1].encode("utf-8"), str(master_token).encode("utf-8")
+        )
 
     @web.middleware
     async def _auth_middleware(self, request: web.Request, handler):
@@ -236,18 +255,24 @@ class CentralizedStreamServer:
         supervisor = request.app["supervisor"]
         mode = supervisor.current_mode
         auth_header = request.headers.get("Authorization")
-        token_path = request.path.endswith("/tokens")
+        path = request.path
+        token_path = path.endswith("/tokens")
         if (
             mode == self.STREAMING_MODE_WEBSOCKETS
             and settings.master_token
             and token_path
         ):
-            if (
-                not auth_header
-                or not auth_header.startswith("Bearer ")
-                or len(auth_header.split()) < 2
-                or auth_header.split()[1] != settings.master_token
-            ):
+            if not self._check_master_token(auth_header, settings.master_token):
+                return web.Response(status=401, text="Unauthorized")
+            return await handler(request)
+
+        # The state-changing /switch endpoint requires the master token when
+        # Basic Auth is disabled. /status stays open: it only reports the
+        # active mode, and the dashboard probes it without credentials at
+        # page load to pick the right client core.
+        is_control_path = path.endswith("/switch")
+        if settings.master_token and not settings.enable_basic_auth[0] and is_control_path:
+            if not self._check_master_token(auth_header, settings.master_token):
                 return web.Response(status=401, text="Unauthorized")
             return await handler(request)
 
@@ -268,9 +293,13 @@ class CentralizedStreamServer:
             if ":" not in auth_decoded:
                 return web.Response(status=401, text="Invalid Credentials")
             username, password = auth_decoded.split(":", 1)
+            # Compare as UTF-8 bytes so non-ASCII credentials don't raise from
+            # hmac.compare_digest (which rejects non-ASCII str operands).
             is_valid = hmac.compare_digest(
-                username, settings.basic_auth_user
-            ) and hmac.compare_digest(password, settings.basic_auth_password)
+                username.encode("utf-8"), str(settings.basic_auth_user).encode("utf-8")
+            ) and hmac.compare_digest(
+                password.encode("utf-8"), str(settings.basic_auth_password).encode("utf-8")
+            )
             if not is_valid:
                 logger.warning(
                     f"Invalid credentials provided for user: {settings.basic_auth_user}"
@@ -286,8 +315,20 @@ class CentralizedStreamServer:
 
         # Update basic auth credentials to Sealskin provided ones
         if custom_user and password:
+            logger.info(
+                "Overriding Basic Auth credentials from CUSTOM_USER/PASSWORD environment variables."
+            )
             setattr(self.settings, "basic_auth_user", custom_user)
             setattr(self.settings, "basic_auth_password", password)
+
+        try:
+            if self.settings.enable_basic_auth[0] and self.settings.basic_auth_password == "mypasswd":
+                logger.warning(
+                    "Basic Auth is enabled with the well-known default password 'mypasswd'. "
+                    "Set a strong password via --basic_auth_password, SELKIES_BASIC_AUTH_PASSWORD, or the PASSWORD env var."
+                )
+        except Exception:
+            pass
 
     async def switch_to_mode(self, mode_name: str):
         """
@@ -304,8 +345,23 @@ class CentralizedStreamServer:
             await self._stop_service()
             logger.info(f"Starting service: {mode_name}")
             service = self.services[mode_name]
-            self.active_task = asyncio.create_task(service.start())
+            task = asyncio.create_task(service.start())
+            self.active_task = task
             self.current_mode = mode_name
+
+            # Clear the stale mode if the service dies unexpectedly, and retrieve
+            # the exception so asyncio doesn't log it as never-retrieved.
+            def _on_service_done(finished: asyncio.Task, mode=mode_name):
+                if finished.cancelled():
+                    return
+                exc = finished.exception()
+                if exc is not None:
+                    logger.error(f"Service '{mode}' terminated unexpectedly: {exc!r}")
+                    if self.active_task is finished:
+                        self.current_mode = None
+                        self.active_task = None
+
+            task.add_done_callback(_on_service_done)
 
     async def _stop_service(self):
         if not self.current_mode:
@@ -315,7 +371,10 @@ class CentralizedStreamServer:
         await self.services[self.current_mode].stop()
         if self.active_task:
             try:
-                await asyncio.wait_for(self.active_task, timeout=5)
+                # Give the service's own teardown room to finish (it can include
+                # several ~2s gamepad-close waits) before forcing a cancel that
+                # would interrupt cleanup mid-way and leak resources.
+                await asyncio.wait_for(self.active_task, timeout=15)
             except asyncio.TimeoutError:
                 logger.warning(
                     f"Timeout while stopping '{self.current_mode}'. Cancelling task."
@@ -327,6 +386,11 @@ class CentralizedStreamServer:
                     logger.info(
                         f"Task cancelled after timeout for '{self.current_mode}'."
                     )
+                except Exception as e:
+                    logger.warning(f"Service task raised during forced stop: {e!r}")
+        # Clear stale references so a stopped/dead mode is never reported active.
+        self.current_mode = None
+        self.active_task = None
 
     def _get_status(self):
         return {
@@ -342,9 +406,11 @@ class CentralizedStreamServer:
                 status=403,
             )
 
-        data = await request.json()
-        target_mode = data.get("mode")
         try:
+            data = await request.json()
+            if not isinstance(data, dict):
+                raise ValueError("Request body must be a JSON object")
+            target_mode = data.get("mode")
             await self.switch_to_mode(target_mode)
             return web.json_response({"status": "success", "mode": target_mode})
         except Exception as e:
@@ -441,11 +507,16 @@ class CentralizedStreamServer:
         try:
             with os.scandir(full_path) as it:
                 for entry in it:
-                    stats = entry.stat()
-                    mtime = datetime.fromtimestamp(stats.st_mtime).strftime(
-                        "%Y-%m-%d %H:%M:%S"
-                    )
-                    is_dir = entry.is_dir()
+                    try:
+                        stats = entry.stat()
+                        mtime = datetime.fromtimestamp(stats.st_mtime).strftime(
+                            "%Y-%m-%d %H:%M:%S"
+                        )
+                        is_dir = entry.is_dir()
+                    except OSError as e:
+                        # Entries can vanish or be unstat-able (broken symlinks, races).
+                        logger.warning(f"Skipping unreadable directory entry {entry.name!r}: {e}")
+                        continue
                     items.append(
                         {
                             "name": entry.name + ("/" if is_dir else ""),

--- a/src/selkies/webrtc_mode.py
+++ b/src/selkies/webrtc_mode.py
@@ -41,7 +41,7 @@ from .display_utils import resize_display, set_dpi, set_cursor_size
 from .webrtc_utils import SystemMonitor, Metrics, GPUMonitor, get_rtc_configuration
 from .settings import settings, AppSettings, SETTING_DEFINITIONS
 from types import SimpleNamespace
-from .webrtc_utils import HMACRTCMonitor, RESTRTCMonitor, RTCConfigFileMonitor
+from .webrtc_utils import HMACRTCMonitor, RESTRTCMonitor, RTCConfigFileMonitor, CloudflareRTCMonitor
 from .stream_server import BaseStreamingService, CentralizedStreamServer
 
 logger = logging.getLogger("webrtc")
@@ -55,6 +55,10 @@ def get_server_settings() -> dict:
     for setting_def in SETTING_DEFINITIONS:
         name = setting_def["name"]
         if name in ["port", "dri_node", "debug", "audio_device_name", "watermark_path"]:
+            continue
+        # Never broadcast secrets/credentials (master_token, passwords, TURN
+        # secrets, etc.) to clients.
+        if setting_def.get("sensitive"):
             continue
         value = getattr(settings, name)
         if setting_def["type"] == "bool":
@@ -95,6 +99,7 @@ class WebRTCService(BaseStreamingService):
         self.mon_hmac_turn: Optional[HMACRTCMonitor] = None
         self.mon_rest_api: Optional[RESTRTCMonitor] = None
         self.mon_rtc_config_file: Optional[RTCConfigFileMonitor] = None
+        self.mon_cloudflare_turn: Optional[CloudflareRTCMonitor] = None
         self.peer_manager: Optional[WebRTCPeerManagement] = None
         self.supervisor = supervisor
 
@@ -685,6 +690,14 @@ class WebRTCService(BaseStreamingService):
                 )
                 self.mon_rtc_config_file.on_rtc_config = self.mon_rtc_config
                 await self.mon_rtc_config_file.start()
+            if self.monitoring_utils_used.get("using_cloudflare_turn", False):
+                self.mon_cloudflare_turn = CloudflareRTCMonitor(
+                    turn_token_id=self.args.cloudflare_turn_token_id,
+                    api_token=self.args.cloudflare_turn_api_token,
+                    enabled=True,
+                )
+                self.mon_cloudflare_turn.on_rtc_config = self.mon_rtc_config
+                self.mon_cloudflare_turn.start()
 
     async def shutdown(self) -> None:
         """Gracefully shutdown all components."""
@@ -797,6 +810,14 @@ class WebRTCService(BaseStreamingService):
                 (
                     _await_with_timeout(
                         self.mon_rtc_config_file.stop(), "RTC Config File Monitor", 2.0
+                    )
+                )
+            )
+        if self.mon_cloudflare_turn:
+            stop_coros.append(
+                (
+                    _await_with_timeout(
+                        self.mon_cloudflare_turn.stop(), "Cloudflare TURN RTC Monitor", 2.0
                     )
                 )
             )

--- a/src/selkies/webrtc_utils.py
+++ b/src/selkies/webrtc_utils.py
@@ -18,6 +18,8 @@ from watchdog.events import FileClosedEvent, FileSystemEventHandler
 
 import os
 import csv
+import stat
+import threading
 from datetime import datetime
 from collections import OrderedDict
 from prometheus_client import generate_latest, REGISTRY
@@ -92,6 +94,9 @@ async def _dispatch_rtc_callback(callback, stun_servers: List[str], turn_servers
 def _log_asyncio_task_error(task: asyncio.Task) -> None:
     try:
         task.result()
+    except asyncio.CancelledError:
+        # Expected when pending callback tasks are cancelled at shutdown.
+        pass
     except Exception as e:
         logger_rtcice.warning(f"Error in on_rtc_config callback task: {e}")
 
@@ -283,6 +288,67 @@ class RESTRTCMonitor:
         if self._task:
             await self._task
 
+class CloudflareRTCMonitor:
+    """Periodically refreshes Cloudflare TURN credentials before they expire.
+
+    Cloudflare credentials are minted with a finite TTL (default 24h); without a
+    refresh, a server running longer than the TTL would hand out expired TURN
+    credentials to newly connecting clients until restart.
+    """
+    def __init__(
+        self,
+        turn_token_id: str,
+        api_token: str,
+        ttl: int = 86400,
+        period: Optional[int] = None,
+        enabled: bool = True
+    ):
+        self.turn_token_id = turn_token_id
+        self.api_token = api_token
+        self.ttl = ttl
+        # Refresh well within the credential lifetime (default: half the TTL).
+        self.period = period if period is not None else max(60, ttl // 2)
+        self.enabled = enabled
+        self.stop_event = asyncio.Event()
+        self._task: Optional[asyncio.Task] = None
+        self.on_rtc_config = lambda stun_servers, turn_servers, rtc_config: logger_rtcice.warning("unhandled on_rtc_config")
+
+    def start(self):
+        if not self.enabled:
+            return
+        self.stop_event.clear()
+        self._task = asyncio.create_task(self._monitor_loop())
+        logger_rtcice.info("Cloudflare TURN RTC monitor started")
+
+    async def _monitor_loop(self):
+        try:
+            while not self.stop_event.is_set():
+                # Wait first: the initial fetch already happened at startup.
+                try:
+                    await asyncio.wait_for(self.stop_event.wait(), timeout=self.period)
+                    break
+                except asyncio.TimeoutError:
+                    pass
+
+                try:
+                    json_config = await fetch_cloudflare_turn(self.turn_token_id, self.api_token, self.ttl)
+                    wrapped_config = json.dumps({"iceServers": [json_config["iceServers"]]})
+                    stun_servers, turn_servers, rtc_config = parse_rtc_config(wrapped_config)
+                    await _dispatch_rtc_callback(self.on_rtc_config, stun_servers, turn_servers, rtc_config)
+                except Exception as e:
+                    logger_rtcice.warning(f"could not refresh Cloudflare TURN config in periodic monitor: {e}")
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            logger_rtcice.error(f"Error in Cloudflare TURN RTC monitor: {e}")
+        finally:
+            logger_rtcice.info("Cloudflare TURN RTC monitor stopped")
+
+    async def stop(self):
+        self.stop_event.set()
+        if self._task:
+            await self._task
+
 class RTCConfigFileMonitor(FileSystemEventHandler):
     def __init__(self, rtc_file: str, enabled: bool = True):
         self.enabled = enabled
@@ -313,18 +379,15 @@ class RTCConfigFileMonitor(FileSystemEventHandler):
         await asyncio.to_thread(self._shutdown_observer)
         logger_rtcice.info("RTC config file monitor stopped")
 
-     # This method overrides the one in FileSystemEventHandler
-    def on_closed(self, event):
-        """
-        Called by the watchdog thread when a file write is closed.
-        This is a synchronous method.
-        """
-        if not isinstance(event, FileClosedEvent):
-            return
-        if os.path.abspath(event.src_path) != self.rtc_file:
-            return
+    def _reload_config(self, src_path: str):
+        """Read, parse, and dispatch the updated RTC config. Runs on the watchdog thread."""
         try:
-            logger_rtcice.info(f"Detected RTC JSON file change: {event.src_path}")
+            logger_rtcice.info(f"Detected RTC JSON file change: {src_path}")
+            if not _is_trusted_config_file(self.rtc_file):
+                logger_rtcice.error(
+                    f"Refusing to reload RTC config file '{self.rtc_file}': unsafe ownership or permissions."
+                )
+                return
             with open(self.rtc_file, 'rb') as f:
                 data = f.read()
 
@@ -339,6 +402,25 @@ class RTCConfigFileMonitor(FileSystemEventHandler):
             )
         except Exception as e:
             logger_rtcice.warning(f"Could not read or parse RTC JSON file: {self.rtc_file}: {e}")
+
+    # These methods override FileSystemEventHandler. React to in-place writes
+    # (on_closed) and to the atomic write-temp-then-rename pattern, which
+    # surfaces as a move (or create) of the target rather than a close.
+    def on_closed(self, event):
+        if not isinstance(event, FileClosedEvent):
+            return
+        if os.path.abspath(event.src_path) != self.rtc_file:
+            return
+        self._reload_config(event.src_path)
+
+    def on_moved(self, event):
+        dest = getattr(event, "dest_path", None)
+        if dest and os.path.abspath(dest) == self.rtc_file:
+            self._reload_config(dest)
+
+    def on_created(self, event):
+        if os.path.abspath(event.src_path) == self.rtc_file:
+            self._reload_config(event.src_path)
 
 def make_turn_rtc_config_json_legacy(
     turn_host: str,
@@ -584,7 +666,8 @@ async def fetch_turn_rest(
         params['key'] = turn_api_key
         params['api'] = turn_api_key
 
-    async with aiohttp.ClientSession() as session:
+    timeout = aiohttp.ClientTimeout(total=10, connect=5)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
         try:
             async with session.get(uri, headers=auth_headers, params=params) as response:
                 content = await response.read()
@@ -594,6 +677,8 @@ async def fetch_turn_rest(
                 if not content:
                     raise Exception("Data from REST API service was empty")
                 return parse_rtc_config(content)
+        except asyncio.TimeoutError as e:
+            raise Exception("Timeout while fetching REST API config") from e
         except aiohttp.ClientError as e:
             raise Exception(f"Network error while fetching REST API config: {e}") from e
 
@@ -607,14 +692,18 @@ async def fetch_cloudflare_turn(turn_token_id: str, api_token: str, ttl: int = 8
     uri = f"https://rtc.live.cloudflare.com/v1/turn/keys/{turn_token_id}/credentials/generate"
     data_payload = {"ttl": ttl}
 
-    async with aiohttp.ClientSession() as session:
+    timeout = aiohttp.ClientTimeout(total=10, connect=5)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
         try:
             async with session.post(uri, headers=auth_headers, json=data_payload) as response:
                 response.raise_for_status()
                 return await response.json()
         except aiohttp.ClientResponseError as e:
-            body = await e.response.text() if hasattr(e, 'response') else ''
-            raise Exception(f"Could not obtain Cloudflare TURN credentials: {e.status} {e.message}. Body: {body}") from e
+            # ClientResponseError carries no `.response`, and the body is gone
+            # once the `async with` exits; report status/message only.
+            raise Exception(f"Could not obtain Cloudflare TURN credentials: {e.status} {e.message}.") from e
+        except asyncio.TimeoutError as e:
+            raise Exception("Timeout while fetching Cloudflare credentials") from e
         except aiohttp.ClientError as e:
             raise Exception(f"Network error while fetching Cloudflare credentials: {e}") from e
 
@@ -629,16 +718,52 @@ async def try_cloudflare(args: Any) -> Optional[Tuple[List[str], List[str], byte
 
     try:
         json_config = await fetch_cloudflare_turn(args.cloudflare_turn_token_id, args.cloudflare_turn_api_token)
-        logger_rtcice.info(f"Successfully fetched RTC configuration from Cloudflare: {json_config}")
+        # Do not log json_config: it contains live TURN username/credential values.
+        logger_rtcice.info("Successfully fetched RTC configuration from Cloudflare.")
         wrapped_config = json.dumps({"iceServers": [json_config["iceServers"]]})
         return parse_rtc_config(wrapped_config)
     except Exception as e:
         logger_rtcice.warning(f"Failed to fetch TURN config from Cloudflare: {e}")
         return None
 
+def _is_trusted_config_file(path: str) -> bool:
+    """Return True only if `path` is safe to trust as an RTC config source.
+
+    The RTC config file overrides all STUN/TURN settings, and its default
+    location (e.g. /tmp/rtc.json) lives in a world-writable directory where a
+    different local user could plant or alter it. Require the file to be owned by
+    root or the current user and to be writable by neither group nor others.
+    """
+    try:
+        st = os.lstat(path)
+    except OSError as e:
+        logger_rtcice.warning(f"Could not stat RTC config file '{path}': {e}")
+        return False
+    if stat.S_ISLNK(st.st_mode):
+        logger_rtcice.warning(f"Refusing to follow symlinked RTC config file '{path}'.")
+        return False
+    if st.st_uid not in (0, os.getuid()):
+        logger_rtcice.warning(
+            f"RTC config file '{path}' is owned by uid {st.st_uid}, not root or the current user ({os.getuid()})."
+        )
+        return False
+    if st.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+        logger_rtcice.warning(
+            f"RTC config file '{path}' is group- or world-writable (mode {oct(stat.S_IMODE(st.st_mode))}); refusing to trust it."
+        )
+        return False
+    return True
+
+
 async def try_json_file(args: Any) -> Optional[Tuple[List[str], List[str], bytes]]:
     """Attempts to configure RTC from a local JSON file."""
     if not os.path.exists(args.rtc_config_json):
+        return None
+
+    if not _is_trusted_config_file(args.rtc_config_json):
+        logger_rtcice.error(
+            f"Refusing to use RTC config file '{args.rtc_config_json}': unsafe ownership or permissions."
+        )
         return None
 
     logger_rtcice.warning(f"Using JSON file '{args.rtc_config_json}' for RTC config, overrides all other STUN/TURN settings.")
@@ -711,11 +836,13 @@ async def get_rtc_configuration(args: Any) -> Tuple[List[str], List[str], bytes,
     monitoring_utilities_used = {
         "using_hmac_turn": False,
         "using_rtc_config_json": False,
-        "using_rest_api": False
+        "using_rest_api": False,
+        "using_cloudflare_turn": False
     }
 
     # Try each method in order of priority, returning on the first success
     if config := await try_cloudflare(args):
+        monitoring_utilities_used["using_cloudflare_turn"] = True
         return *config, monitoring_utilities_used
 
     if config := await try_json_file(args):
@@ -756,8 +883,14 @@ class Metrics:
         self.webrtc_statistics = Info('webrtc_statistics', 'WebRTC Statistics from the client')
         self.stats_video_file_path: Optional[str] = None
         self.stats_audio_file_path: Optional[str] = None
-        self.prev_stats_video_header_len: Optional[str]  = None
-        self.prev_stats_audio_header_len: Optional[str]  = None
+        self.prev_stats_video_header_len: Optional[int]  = None
+        self.prev_stats_audio_header_len: Optional[int]  = None
+        # Serializes CSV writes (which run in worker threads) so concurrent stat
+        # messages cannot interleave rows or race the shared prev_stats state.
+        self._csv_lock = threading.Lock()
+        # Hold strong references to in-flight write tasks so they are not garbage
+        # collected before completion (and their exceptions stay observed).
+        self._csv_tasks: set = set()
 
     def set_fps(self, fps):
         self.fps.set(fps)
@@ -798,31 +931,38 @@ class Metrics:
         webrtc_stats_obj = await asyncio.to_thread(json.loads, webrtc_stats)
         sanitized_stats = await asyncio.to_thread(self.sanitize_json_stats, webrtc_stats_obj)
         if self.using_webrtc_csv:
-            if webrtc_stat_type == "_stats_audio":
-                asyncio.create_task(asyncio.to_thread(self.write_webrtc_stats_csv, sanitized_stats, self.stats_audio_file_path))
-            else:
-                asyncio.create_task(asyncio.to_thread(self.write_webrtc_stats_csv, sanitized_stats, self.stats_video_file_path))
+            csv_path = self.stats_audio_file_path if webrtc_stat_type == "_stats_audio" else self.stats_video_file_path
+            task = asyncio.create_task(asyncio.to_thread(self.write_webrtc_stats_csv, sanitized_stats, csv_path))
+            self._csv_tasks.add(task)
+            task.add_done_callback(self._csv_tasks.discard)
         await asyncio.to_thread(self.webrtc_statistics.info, sanitized_stats)
 
     def sanitize_json_stats(self, obj_list: List[Dict[str, Any]]) -> OrderedDict:
         """A helper function to process data to a structure
            For example: reportName.fieldName:value
         """
-        obj_type = []
+        obj_type = set()
         sanitized_stats = OrderedDict()
-        for i in range(len(obj_list)):
-            curr_key = obj_list[i].get('type')
-            if  curr_key in obj_type:
-                # Append id at suffix to eliminate duplicate types
-                curr_key = curr_key + str("-") + obj_list[i].get('id')
-                obj_type.append(curr_key)
+        for entry in obj_list:
+            # Stats come from the (untrusted) browser client; skip entries that
+            # are not dicts and default a missing/non-string 'type'.
+            if not isinstance(entry, dict):
+                continue
+            curr_key = entry.get('type')
+            if not isinstance(curr_key, str):
+                curr_key = "unknown"
+            if curr_key in obj_type:
+                # Append id as suffix to eliminate duplicate types
+                entry_id = entry.get('id')
+                curr_key = curr_key + "-" + (entry_id if isinstance(entry_id, str) else str(entry_id))
+                obj_type.add(curr_key)
             else:
-                obj_type.append(curr_key)
+                obj_type.add(curr_key)
 
-            for key, val in obj_list[i].items():
-                unique_type = curr_key + str(".")  + key
+            for key, val in entry.items():
+                unique_type = curr_key + "." + str(key)
                 if not isinstance(val, str):
-                    sanitized_stats[unique_type] =  str(val)
+                    sanitized_stats[unique_type] = str(val)
                 else:
                     sanitized_stats[unique_type] = val
 
@@ -837,10 +977,9 @@ class Metrics:
 
         dt = datetime.now()
         timestamp = dt.strftime("%d/%B/%Y:%H:%M:%S")
-        try:
-            with open(file_path, 'a+') as stats_file:
-                csv_writer = csv.writer(stats_file, quotechar='"')
-
+        # Writes run in worker threads; serialize them.
+        with self._csv_lock:
+            try:
                 # Prepare the data
                 headers = ["timestamp"]
                 headers += obj.keys()
@@ -853,102 +992,109 @@ class Metrics:
                 for val in obj.values():
                     values.extend(['"{}"'.format(val) if isinstance(val, str) and ';' in val else val])
 
-                if 'audio' in file_path:
-                    # Audio stats
-                    if self.prev_stats_audio_header_len is None:
-                        csv_writer.writerow(headers)
-                        csv_writer.writerow(values)
-                        self.prev_stats_audio_header_len = len(headers)
-                    elif self.prev_stats_audio_header_len == len(headers):
-                        csv_writer.writerow(values)
-                    else:
-                        # Update the data after obtaining new fields
-                        self.prev_stats_audio_header_len = self.update_webrtc_stats_csv(file_path, headers, values)
-                else:
-                    # Video stats
-                    if self.prev_stats_video_header_len is None:
-                        csv_writer.writerow(headers)
-                        csv_writer.writerow(values)
-                        self.prev_stats_video_header_len = len(headers)
-                    elif self.prev_stats_video_header_len == len(headers):
-                        csv_writer.writerow(values)
-                    else:
-                        # Update the data after obtaining new fields
-                        self.prev_stats_video_header_len = self.update_webrtc_stats_csv(file_path, headers, values)
+                is_audio = 'audio' in file_path
+                prev_len = self.prev_stats_audio_header_len if is_audio else self.prev_stats_video_header_len
 
-        except Exception as e:
-            logger_metrics.error("writing WebRTC Statistics to CSV file: " + str(e))
+                if prev_len is not None and prev_len != len(headers):
+                    # The field set changed: rewrite the CSV with the merged
+                    # schema. Must run with no open handle on file_path, as
+                    # os.replace() onto an open file fails on Windows.
+                    new_len = self.update_webrtc_stats_csv(file_path, headers, values)
+                    if is_audio:
+                        self.prev_stats_audio_header_len = new_len
+                    else:
+                        self.prev_stats_video_header_len = new_len
+                    return
+
+                with open(file_path, 'a+', newline='') as stats_file:
+                    csv_writer = csv.writer(stats_file, quotechar='"')
+                    if prev_len is None:
+                        csv_writer.writerow(headers)
+                        csv_writer.writerow(values)
+                        if is_audio:
+                            self.prev_stats_audio_header_len = len(headers)
+                        else:
+                            self.prev_stats_video_header_len = len(headers)
+                    else:
+                        csv_writer.writerow(values)
+
+            except Exception as e:
+                logger_metrics.error("writing WebRTC Statistics to CSV file: " + str(e))
 
     def update_webrtc_stats_csv(self, file_path: str, headers: List[str], values: List[Any]):
-        """Copies data from one CSV file to another to facilite dynamic updates to the data structure
-           by handling empty values and appending new data.
+        """Rewrites the CSV when the set of stat fields changes, aligning the
+           previously-stored rows onto the new (union) header layout by field
+           name. Missing fields are filled with "NaN". Returns the new header
+           length, or the previous length on failure.
         """
-        prev_headers = None
-        prev_values = []
+        prev_len = self.prev_stats_audio_header_len if 'audio' in file_path else self.prev_stats_video_header_len
 
         try:
-            with open(file_path, 'r') as stats_file:
-                csv_reader = csv.reader(stats_file, delimiter=',')
-
-                # Fetch all existing data
-                header_indicator = 0
-                for row in csv_reader:
-                    if header_indicator == 0:
-                        prev_headers = row
-                        header_indicator += 1
-                    else:
-                        prev_values.append(row)
-
-                # Sometimes columns might not exist in new data
-                if len(headers) < len(prev_headers):
-                    for i in prev_headers:
-                        if i not in headers:
-                            values.insert(prev_headers.index(i), "NaN")
-                else:
-                    i, j, k = 0, 0, 0
-                    while i < len(headers):
-                        if headers[i] != prev_headers[j]:
-                            # If there is a mismatch, update all previous rows with a placeholder to represent an empty value, using `NaN` here
-                            for row in prev_values:
-                                row.insert(i, "NaN")
-                            i += 1
-                            k += 1  # track number of values added
+            prev_headers = None
+            prev_values = []
+            try:
+                with open(file_path, 'r', newline='') as stats_file:
+                    csv_reader = csv.reader(stats_file, delimiter=',')
+                    for idx, row in enumerate(csv_reader):
+                        if idx == 0:
+                            prev_headers = row
                         else:
-                            i += 1
-                            j += 1
+                            prev_values.append(row)
+            except FileNotFoundError:
+                # File deleted externally since the last write; recreate it
+                # below with the current schema.
+                pass
 
-                    j += k
-                    # When new fields are at the end
-                    while j < i:
-                        for row in prev_values:
-                            row.insert(j, "NaN")
-                        j += 1
-
-                # Validation check to confirm modified rows are of same length
-                if len(prev_values[0]) != len(values):
-                    logger_metrics.warning("There's a mismatch; columns could be misaligned with headers")
-
-            # Purge existing file
-            if os.path.exists(file_path):
-                os.remove(file_path)
-            else:
-                logger_metrics.warning("File {} doesn't exist to purge".format(file_path))
-
-            # Create a new file with updated data
-            with open(file_path, "a") as stats_file:
-                csv_writer = csv.writer(stats_file)
-
-                if len(headers) > len(prev_headers):
+            # No usable prior content (empty or header-only file): (re)write the
+            # current schema plus this row.
+            if not prev_headers:
+                with open(file_path, 'w', newline='') as stats_file:
+                    csv_writer = csv.writer(stats_file)
                     csv_writer.writerow(headers)
-                else:
-                    csv_writer.writerow(prev_headers)
-                csv_writer.writerows(prev_values)
-                csv_writer.writerow(values)
+                    csv_writer.writerow(values)
+                return len(headers)
 
-                logger_metrics.debug("WebRTC Statistics file {} created with updated data".format(file_path))
-            return len(headers) if len(headers) > len(prev_headers) else len(prev_headers)
+            # Union header: keep the previous column order, then append any
+            # genuinely new fields at the end. Remap every previous row and the
+            # new row onto that union by field name, filling gaps with "NaN".
+            merged_headers = list(prev_headers)
+            seen_names = set(prev_headers)
+            for name in headers:
+                if name not in seen_names:
+                    merged_headers.append(name)
+                    seen_names.add(name)
+
+            prev_index = {name: pos for pos, name in enumerate(prev_headers)}
+            new_index = {name: pos for pos, name in enumerate(headers)}
+
+            def remap(row_values, src_index):
+                out = []
+                for name in merged_headers:
+                    pos = src_index.get(name)
+                    if pos is not None and pos < len(row_values):
+                        out.append(row_values[pos])
+                    else:
+                        out.append("NaN")
+                return out
+
+            remapped_prev = [remap(row, prev_index) for row in prev_values]
+            remapped_new = remap(values, new_index)
+
+            # Rewrite via a temp file + atomic replace so an interrupted rewrite
+            # cannot truncate or corrupt the existing stats.
+            tmp_path = file_path + ".tmp"
+            with open(tmp_path, 'w', newline='') as stats_file:
+                csv_writer = csv.writer(stats_file)
+                csv_writer.writerow(merged_headers)
+                csv_writer.writerows(remapped_prev)
+                csv_writer.writerow(remapped_new)
+            os.replace(tmp_path, file_path)
+
+            logger_metrics.debug("WebRTC Statistics file {} rewritten with updated schema".format(file_path))
+            return len(merged_headers)
         except Exception as e:
             logger_metrics.error("writing WebRTC Statistics to CSV file: " + str(e))
+            return prev_len
 
     def initialize_webrtc_csv_file(self, webrtc_stats_dir: str ='/tmp'):
         """Initializes the WebRTC Statistics file upon every new WebRTC connection


### PR DESCRIPTION
**Reference the issue numbers and reviewers**
<!--
Use `#` and `@` to tag issues and reviewers.
-->

**Explain relevant issues and how this pull request solves them**
<!--
A clear and concise description of the pull request. Ex. This pull request addresses issue # by [...]
-->

**Describe the changes in code and its dependencies and justify that they work as intended after testing**

  ## Summary

  A hardening and correctness pass over the streaming server, signaling server, settings
  layer, and the joystick interposer. Three areas: validating client-supplied input that
  previously reached the filesystem/display/shell unchecked, fixing concurrency and
  lifecycle races in the asyncio server, and making the LD_PRELOAD interposer safe in
  multithreaded hosts. Includes follow-up fixes from review feedback.

  ## Security hardening

  - **Upload paths**: containment checks now compare on path-segment boundaries
    (`os.path.commonpath`) instead of a bare string prefix (which accepted sibling dirs
    like `uploads-evil/`), resolve symlinks on the target's parent, and open the final
    path with `O_NOFOLLOW` so a symlink planted at the last component can't redirect the
    write. A missing `return` after the malicious-path log meant rejected paths were
    previously still processed.
  - **Upload/clipboard quotas**: uploads are aborted (and the partial file deleted) once
    they exceed their declared size; multi-part clipboard transfers reject negative or >64 MiB declared sizes and abort if chunks exceed the declaration, so a client can't
    grow server memory or disk without bound.
  - **Secrets no longer broadcast**: setting definitions now carry a `sensitive` flag
    (`master_token`, Basic Auth credentials, TURN secrets/keys, Cloudflare tokens), and
    both server-settings broadcasters skip them. Cloudflare TURN credentials are no
    longer logged.
  - **`cmd` execution**: gated on `command_enabled` in both transports, and in secure
    mode requires the same authority as keyboard/mouse input (active mk-token holder, or
    controller when no mk-token is set). `kr` added to the secure-mode input gate list.
  - **`/switch` endpoint**: now requires the master token when Basic Auth is disabled but
    a `master_token` is configured. `/status` intentionally stays open (the dashboard
    probes it without credentials to pick the client core).
  - **Auth comparisons**: master-token and Basic Auth checks use `hmac.compare_digest`
    over UTF-8 bytes (timing-safe, and non-ASCII input can no longer raise).
  - **RTC config file trust**: `rtc.json` (default location is world-writable `/tmp`) is
    only honored if owned by root or the current user, not group/world-writable, and not
    a symlink — applied at startup, on watchdog reloads, and in the signaling server.
  - **Client-supplied settings**: integer settings are clamped (`manual_width` ≤ 7680,
    `manual_height` ≤ 4320, 1,000,000 fallback cap) so a client can't request an absurd
    framebuffer; enum values are normalized to `str` so later equality checks don't flap
    on str-vs-int mismatches; `/tokens` payloads are fully validated before the global
    auth state is swapped.

  ## Concurrency / lifecycle

  - **Display reconfiguration**: requests arriving while a pass is running are coalesced
    (last-write-wins) instead of dropped; the disconnect path no longer wraps
    `shutdown_pipelines()` in `_reconfigure_lock` (the inner `reconfigure_displays()`
    takes it itself, so pipelines were never actually stopped via that path). Removed the
    now-unused `_cleanup_client`.
  - **Mode supervisor**: a service that dies unexpectedly clears `current_mode` (and its
    exception is retrieved); `_stop_service` clears stale references and gives teardown
    15s (was 5s — gamepad close waits alone can exceed 5s) before cancelling.
  - **Cert reload**: `last_mtime` only advances after the new TLS site is up, so a failed
    reload retries on the next poll instead of leaving HTTPS down. `/switch` JSON parsing
    errors return 400 instead of crashing the handler.
  - **Token reconciliation**: revoked-token clients no longer abort reconciliation for
    the remaining clients (`new_perms` is `None` for them).
  - **Signaling**: empty rooms are freed; room iteration uses snapshots (sets mutate
    across awaits); session relays are restricted to actual session partners (the
    `assert` that enforced this was stripped under `python -O`); removed a provably dead
    caller-busy check; `read_file` was referenced but never defined (AttributeError when
    an RTC config file existed).
  - **Misc**: per-connection stats CSV writes are serialized behind a lock and their
    tasks strongly referenced; WebRTC stats sanitization tolerates malformed entries from
    the browser; the CSV schema-change rewrite aligns old rows by field name onto a union
    header and replaces the file atomically; empty binary WS frames no longer crash the
    handler; aiohttp fetches got explicit timeouts; `asyncio.CancelledError` from
    callback tasks isn't logged as an error.
  - **New**: `CloudflareRTCMonitor` refreshes Cloudflare TURN credentials before their
    TTL expires (previously a server outliving the 24h TTL handed out expired credentials
    until restart).

  ## Joystick interposer (C)

  - **Thread safety**: a mutex now guards the interposer table (SDL et al. run joystick
    handling on their own threads; open/close vs read/ioctl/fstat raced). The blocking
    connect/config-read deliberately runs *outside* the lock: open() claims the slot with
    a `connecting` flag, connects into thread-local state, and publishes under the lock —
    concurrent opens of the same device wait on a condvar, and other threads' interposed
    syscalls never stall behind a slow/absent server (previously up to 250ms per open
    attempt, or seconds for a stalled config read).
  - **Refcounted close**: repeated `open()` of the same device returns the same fd with a
    refcount; only the last `close()` tears down the socket (closing one handle used to
    kill the other's connection). State is reset even if `close()` errors (the kernel
    releases the fd anyway; keeping the mapping could hijack a reused fd number).
  - **Stream integrity**: non-blocking reads peek first and never consume a partial event
    (which permanently desynced the SOCK_STREAM); blocking reads use `MSG_WAITALL`.
    `read()` uses the caller's fd rather than re-reading the slot, so a concurrent
    close-then-reopen can't route a stale reader onto the new connection.
  - **Input validation**: button/axis counts from the (untrusted) socket peer are clamped
    to the static array bounds, closing an out-of-bounds read in the `JSIOCGBTNMAP`/
    `EVIOCGBIT` handlers; the Python packer clamps the counts it sends symmetrically.
  - **Bounded config read**: a connected-but-silent peer can no longer hang the opening
    thread forever (5s cap via `SO_RCVTIMEO` + monotonic deadline, timeout restored
    after). Builds now link `-pthread`.

  ## Behavior changes to note

  - `rtc.json` that is group/world-writable, foreign-owned, or a symlink is now refused
    (fail-closed, logged). Deployments writing it with umask 002 must tighten permissions.
  - `/switch` returns 401 without the master token when Basic Auth is off and
    `master_token` is set.
  - Sensitive settings disappear from the `server_settings` payload sent to clients.
  - Service stop timeout increased 5s → 15s during mode switches.

  ## Testing

  - C interposer exercised end-to-end against a scripted fake joystick server (real
    1360-byte config protocol): blocking/non-blocking reads, partial-event delivery,
    double-open/refcounted-close, reopen, oversized-config clamping, no-server fail-fast
    (EIO at ~250ms), 4-thread simultaneous-open race (single connection, correct
    refcount), and a stall test confirming unrelated reads see ≤4ms gaps while opens
    block ~2s on a stalled server (previously they'd block the full duration).
  - Multithreaded stress (open/close/read/ioctl/fstat across threads + unrelated pipe
    I/O): no deadlocks, no lost or misrouted data.
  - Python: unit tests for path containment, token comparison (incl. non-ASCII), CSV
    schema-merge rewrite, stats sanitization with malformed input, and the RTC config
    trust checks (mode/ownership/symlink matrix).

<!--
A clear and concise description of what you have changed. Please confirm that the pull request does not break this project by testing it in depth.
-->

**Describe alternatives you've considered**
<!--
A clear and concise description of any alternative solutions or features you've considered other than this pull request, if applicable.
-->

**Additional context**
<!--
Add any other context or screenshots about the pull request here.
-->

 - [ ] I confirm that this pull request is relevant to the scope of this project. If you know that upstream projects are the cause of this problem, please file the pull request there.
 - [ ] I confirm that this pull request has been tested thoroughly and to the best of my knowledge that additional unintended problems do not arise.
 - [ ] I confirm that the style of the changed code conforms to the overall style of the project.
 - [ ] I confirm that I have read other open and closed pull requests and that duplicates do not exist.
 - [ ] I confirm that I have justified the need for this pull request and that the changes reflect the fix for the specified problem.
 - [ ] I confirm that no portion of this pull request contains credentials or other private information, and it is my own responsibility to protect my privacy.
 - [ ] I confirm that the authors of this pull request does not willfully breach or infringe legal regulations, in any and all global law, regarding trademarks, trade names, logos, patents, or any and all other forms of external intellectual property, as well as adhering to software license terms of open-source and proprietary software projects.
