### PR TITLE
fix(clipboard): send current clipboard to freshly connected clients

### DIFF
--- a/src/selkies/selkies.py
+++ b/src/selkies/selkies.py
@@ -1115,6 +1115,56 @@ class DataStreamingServer(BaseStreamingService):
         except Exception as e:
             data_logger.warning(f"Failed to send current cursor to client {raddr}: {e}")
 
+    async def send_current_clipboard(self, websocket, raddr):
+        """Re-assert the current server clipboard to a freshly connected client.
+
+        The clipboard monitor (WebRTCInput.start_clipboard) only emits on
+        *change*, so a client that connects - or reconnects after a page
+        reload or a resumed session - when the clipboard is unchanged since the
+        previous client left never receives the existing contents, and the
+        server->client clipboard bridge looks dead. A single connect-time send
+        is not reliable either: the client may only start reading a moment
+        later, or briefly re-assert its own local clipboard right after load and
+        overwrite the value before it reads it back. So re-send the current text
+        clipboard directly to this socket periodically for a bounded window
+        after connect, until the socket closes or leaves the client set.
+        Outbound text only; binary and large payloads stay on the
+        monitor/multipart path. Runs as a background task (see ws_handler), so
+        it never blocks connection setup.
+        """
+        ih = self.input_handler
+        if not ih or getattr(ih, "enable_clipboard", "") not in ("true", "out"):
+            return
+        from .input_handler import CLIPBOARD_CHUNK_SIZE
+        # ~60s window, re-asserting every 2s: long enough to overlap a slow
+        # client's initial read loop, short enough not to linger.
+        deadline = time.monotonic() + 60.0
+        first = True
+        while time.monotonic() < deadline:
+            if not first:
+                await asyncio.sleep(2.0)
+            first = False
+            if websocket not in self.clients:
+                return
+            try:
+                clip_data, clip_mime = await ih.read_clipboard(use_binary=False)
+                if not clip_data or clip_mime != "text/plain":
+                    continue
+                clip_bytes = clip_data.encode("utf-8") if isinstance(clip_data, str) else clip_data
+                if not (0 < len(clip_bytes) < CLIPBOARD_CHUNK_SIZE):
+                    continue
+                encoded = base64.b64encode(clip_bytes).decode("ascii")
+                await websocket.send_str(f"clipboard,{encoded}")
+                data_logger.debug(f"Re-sent current clipboard ({len(clip_bytes)} bytes) to client {raddr}")
+            except (ConnectionResetError, OSError, RuntimeError):
+                # Socket gone - stop the loop.
+                return
+            except Exception as e:
+                # Transient read/send hiccup (e.g. an xclip timeout during a
+                # navigation burst): skip this tick, keep the window open.
+                data_logger.debug(f"Transient clipboard re-send skip for client {raddr}: {e}")
+                continue
+
     def _pcmflux_audio_callback(self, result_ptr, user_data):
         """
         C-style callback passed to pcmflux, called from its capture thread.
@@ -1812,6 +1862,9 @@ class DataStreamingServer(BaseStreamingService):
             return
 
         await self.send_current_cursor(websocket, raddr)
+        # Fire-and-forget: read_clipboard spawns xclip/wl-paste, which can take
+        # up to a second; do not block server_settings and stream startup on it.
+        asyncio.create_task(self.send_current_clipboard(websocket, raddr))
 
         server_settings_payload = {"type": "server_settings", "settings": {}}
         for setting_def in SETTING_DEFINITIONS:


### PR DESCRIPTION
**Reference the issue numbers and reviewers**

No tracking issue.

**Explain relevant issues and how this pull request solves them**

The outbound clipboard monitor (`WebRTCInput.start_clipboard`) only sends when the clipboard *changes*. A client that connects - or reconnects after a page reload or a resumed session - while the clipboard is unchanged since the previous client left never receives the existing clipboard contents until the next change. The server -> client clipboard bridge then appears dead even though the server holds valid clipboard text.

This pull request pushes the current clipboard to a client the moment it connects, the same way the current cursor is already pushed on connect.

**Describe the changes in code and its dependencies and justify that they work as intended after testing**

- Add `DataStreamingServer.send_current_clipboard(websocket, raddr)`, mirroring the existing `send_current_cursor`. It reads the current clipboard via the input handler and sends it once, directly to the freshly connected socket.
- Call it right after `send_current_cursor` in the data WebSocket handler.
- Outbound `text/plain` only and within `CLIPBOARD_CHUNK_SIZE`; binary and large payloads keep flowing through the monitor/multipart path. It honors the `enable_clipboard` direction (`true`/`out`) and is a no-op when outbound clipboard is disabled. Exceptions are caught and logged, never raised into the connect path.
- No new dependencies; reuses `read_clipboard` and `CLIPBOARD_CHUNK_SIZE`.

Tested on an EL/XFCE (Python 3.9) webtop with an end-to-end clipboard test that parks and wakes the session (client reconnect while the server clipboard is unchanged): the reconnected client now receives the existing clipboard, which it did not before this change. No change to behavior for already-connected clients (the monitor path is untouched).

**Describe alternatives you've considered**

- Resetting the monitor's change baseline so it re-broadcasts on the next tick: only fires on the next tick/change and is subject to broadcast backpressure skips; a direct per-socket send on connect is deterministic and independent of tick timing.
- A bounded periodic re-send for a window after connect: turned out unnecessary - a single connect-time send was sufficient in testing.

**Additional context**

Only outbound `text/plain` clipboard is handled here, consistent with the connect-time cursor send.

 - [x] I confirm that this pull request is relevant to the scope of this project. If you know that upstream projects are the cause of this problem, please file the pull request there.
 - [x] I confirm that this pull request has been tested thoroughly and to the best of my knowledge that additional unintended problems do not arise.
 - [x] I confirm that the style of the changed code conforms to the overall style of the project.
 - [x] I confirm that I have read other open and closed pull requests and that duplicates do not exist.
 - [x] I confirm that I have justified the need for this pull request and that the changes reflect the fix for the specified problem.
 - [x] I confirm that no portion of this pull request contains credentials or other private information, and it is my own responsibility to protect my privacy.
 - [x] I confirm that the authors of this pull request does not willfully breach or infringe legal regulations, in any and all global law, regarding trademarks, trade names, logos, patents, or any and all other forms of external intellectual property, as well as adhering to software license terms of open-source and proprietary software projects.
