### PR TITLE
Security: Vite Server Configured with Overly Permissive Host Settings

### DIFF
--- a/addons/selkies-web-core/vite.config.js
+++ b/addons/selkies-web-core/vite.config.js
@@ -6,8 +6,8 @@ import ViteRestart from 'vite-plugin-restart'
 export default defineConfig({
   base: '',
   server: {
-    host: '0.0.0.0',
-    allowedHosts: true,
+    host: '127.0.0.1',
+    allowedHosts: ['localhost', '127.0.0.1'],
   },
   plugins: [
     envCompatible(),


### PR DESCRIPTION
## Summary

Security: Vite Server Configured with Overly Permissive Host Settings

## Problem

**Severity**: `Medium` | **File**: `addons/selkies-web-core/vite.config.js:L7`

Multiple Vite configuration files (vite.config.js) have 'allowedHosts: true' which allows all hosts, and server host set to '0.0.0.0'. This could expose the development server to external networks and potentially allow DNS rebinding attacks or unauthorized access to the development environment.

## Solution

Restrict allowedHosts to specific trusted domains instead of allowing all hosts. Use environment-specific configurations to only allow broad access in development, never in production. Consider using a reverse proxy with proper host validation for production deployments.

## Changes

- `addons/selkies-web-core/vite.config.js` (modified)