### PR TITLE
fix(websockets): reuse ScreenCapture instance across reconfigure cycles

### DIFF
--- a/src/selkies/selkies.py
+++ b/src/selkies/selkies.py
@@ -970,6 +970,10 @@ class DataStreamingServer(BaseStreamingService):
         self.display_clients = {}
         self.video_chunk_queues = {}
         self.capture_instances = {}
+        # Persistent ScreenCapture objects, one per display_id.  Kept alive across
+        # reconfigure_displays() cycles so that the underlying NVENC/CUDA context is
+        # only initialised once instead of being re-created on every reconnect.
+        self._persistent_capture_modules = {}
 
         # pcmflux audio capture state
         self.audio_device_name = self.cli_args.audio_device_name
@@ -3339,7 +3343,14 @@ class DataStreamingServer(BaseStreamingService):
             self.video_chunk_queues[display_id] = asyncio.Queue(maxsize=queue_size)
             sender_task = asyncio.create_task(self._video_chunk_sender(display_id))
             
-            capture_module = ScreenCapture()
+            if display_id not in self._persistent_capture_modules:
+                if not X11_CAPTURE_AVAILABLE:
+                    raise SelkiesAppError("ScreenCapture is not available because the pixelflux library is missing.")
+                self._persistent_capture_modules[display_id] = ScreenCapture()
+                data_logger.info(f"Created new ScreenCapture instance for '{display_id}'.")
+            else:
+                data_logger.info(f"Reusing existing ScreenCapture instance for '{display_id}' (CUDA context preserved).")
+            capture_module = self._persistent_capture_modules[display_id]
 
             if IS_WAYLAND:
                 if hasattr(capture_module, 'set_cursor_callback'):
@@ -3497,6 +3508,10 @@ class DataStreamingServer(BaseStreamingService):
                 self.input_handler.disconnect
             ):
                 await self.input_handler.disconnect()
+
+        # Drop the persistent ScreenCapture modules so their NVENC/CUDA contexts
+        # can be released now that the server is going away.
+        self._persistent_capture_modules.clear()
 
         self.app = None
         self.input_handler = None


### PR DESCRIPTION

## Problem

Every call to `_start_capture_for_display()` constructs a new pixelflux
`ScreenCapture()`. On NVIDIA hardware this initialises a fresh NVENC encoder and
CUDA context. `stop_capture()` releases XShm resources but leaves the CUDA
context alive, so every `reconfigure_displays()` cycle that reaches this path
leaks one CUDA context and its `cuda-EvtHandlr` threads permanently.

In a long-lived session with viewers connecting/disconnecting (each shared-viewer
START_VIDEO currently triggers a full reconfigure), GPU memory and thread count
grow without bound until the process is restarted.

## Fix

Keep one `ScreenCapture` per `display_id` in `_persistent_capture_modules` for the
lifetime of the `DataStreamingServer`. Subsequent `start_capture`/`stop_capture`
cycles reuse the same object, preserving the CUDA context rather than
accumulating new ones. The Wayland cursor-callback registration below the
construction site is an idempotent setter, so re-running it on reuse is safe.

## Testing

Developed and load-tested in our production deployment (lsio-based images, which
carry the same construction site); confirmed CUDA context count and
`cuda-EvtHandlr` thread count stay flat across many reconfigure cycles, where
previously each cycle added one. The port onto `main` is a clean cherry-pick
(surrounding code unchanged), but we have not yet runtime-tested the `main`
branch itself — flagging per our earlier PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
