### PR TITLE
fix(video): bound client-side paint latency for slow decoders

### DIFF
--- a/addons/selkies-web-core/selkies-ws-core.js
+++ b/addons/selkies-web-core/selkies-ws-core.js
@@ -148,6 +148,10 @@ if (authToken) {
 let sharedClientState = 'idle'; // Possible states: 'idle', 'ready', 'error'
 let isSharedMode = detectedSharedModeType !== null;
 let sharedClientHasReceivedKeyframe = false;
+// Paint one decoded frame per rAF tick but allow this many to remain queued as a
+// cushion that absorbs frame-arrival jitter at ~60fps. Anything beyond is dropped, so
+// latency stays bounded to at most this many frames (~16ms each).
+const MAX_QUEUED_VIDEO_FRAMES = 1;
 
 if (isSharedMode) {
   console.log(`Client is running in ${detectedSharedModeType} mode.`);
@@ -2500,6 +2504,15 @@ function initWebsockets() {
         if ( (isSharedMode && sharedClientState === 'ready') || (!isSharedMode && isVideoPipelineActive) ) {
            const bufferLimit = 0;
            if (videoFrameBuffer.length > bufferLimit) {
+                // The painter runs once per rAF (~60/s) and would otherwise drain a
+                // backlog one frame per tick, so any burst that pushes the buffer to
+                // depth N stays N frames behind forever. Drop everything beyond a small
+                // cushion so latency stays bounded, then paint the oldest of what remains
+                // (the cushion smooths arrival jitter; excess frames are skipped).
+                while (videoFrameBuffer.length > MAX_QUEUED_VIDEO_FRAMES + 1) {
+                    const staleFrame = videoFrameBuffer.shift();
+                    try { staleFrame?.close(); } catch (e) { /* already closed */ }
+                }
                 const frameToPaint = videoFrameBuffer.shift();
                 if (frameToPaint) {
                     if (canvas.width > 0 && canvas.height > 0) {


### PR DESCRIPTION

## Problem

`paintVideoFrame()` drains `videoFrameBuffer` one frame per rAF tick. If a burst
(GC pause, slow decode, tab contention) pushes the buffer to depth N, the viewer
stays N frames behind forever — the painter can never catch up because frames
arrive at the same rate it paints. We observed multi-second, non-draining
input-to-photon latency in Firefox (whose software H.264 decode falls behind
during motion); Chrome tends to fast-forward past it.

## Fix

Each paint tick, drop every queued frame beyond a small cushion
(`MAX_QUEUED_VIDEO_FRAMES = 1`, closing the dropped `VideoFrame`s), then paint
the oldest of what remains. Latency is bounded to at most one extra frame
(~16 ms) while the one-frame cushion absorbs arrival jitter, avoiding stalls on
a late frame. This prioritises latency over smoothness, which fits the remote
desktop use case — skipped frames during motion are acceptable, unbounded
control lag is not.

## Testing

Running in our production deployment (lsio-based); eliminated the runaway
Firefox latency and no regression observed in Chrome. The hunk applies to `main`
verbatim (the paint loop is unchanged between the branches), but we have not yet
runtime-tested `main` itself.

## Note

Our production branch carries a companion fix for the *decoder-internal* queue
backing up (flush + request a fresh keyframe when `decodeQueueSize` grows). That
half needs a server-side on-demand-IDR mechanism (`REQUEST_KEYFRAME`), which
`comprehensive-fixes` appears to add — we've held it back rather than duplicate
that work, and can rebase it on top once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
