### PR TITLE
fix(storage): key localStorage on origin+path, not the full URL

### DIFF
--- a/addons/selkies-dashboard/src/components/Sidebar.jsx
+++ b/addons/selkies-dashboard/src/components/Sidebar.jsx
@@ -523,7 +523,10 @@ function AppsModal({ isOpen, onClose, t }) {
 
 const getStorageAppName = () => {
   if (typeof window === 'undefined') return '';
-  const urlForKey = window.location.href.split('#')[0];
+  // Exclude the query string so the per-session ?token=... doesn't create a new
+  // localStorage namespace on every connect (that leak eventually exhausts the origin
+  // quota and blanks the iframe). Must match the core's derivation in selkies-ws-core.js.
+  const urlForKey = window.location.origin + window.location.pathname;
   return urlForKey.replace(/[^a-zA-Z0-9.-_]/g, '_');
 };
 const storageAppName = getStorageAppName();

--- a/addons/selkies-web-core/selkies-core.js
+++ b/addons/selkies-web-core/selkies-core.js
@@ -10,10 +10,19 @@ import websockets from "./selkies-ws-core";
 const STREAM_MODE_WEBRTC = "webrtc";
 const STREAM_MODE_WEBSOCKETS = "websockets";
 
-// Set storage key based on URL
-const urlForKey = window.location.href.split('#')[0];
+// Storage key namespace: origin + pathname only, NOT the full URL. The query string
+// carries a per-session token, so keying on href leaks a new localStorage namespace
+// every session and eventually exhausts the quota. Must match selkies-ws-core.js.
+const urlForKey = window.location.origin + window.location.pathname;
 const storageAppName = urlForKey.replace(/[^a-zA-Z0-9.-_]/g, '_');
 const getPrefixedKey = (key) => {return `${storageAppName}_${key}`}
+const safeSetItem = (key, value) => {
+    try {
+        localStorage.setItem(key, value);
+    } catch (e) {
+        console.warn(`Selkies: could not persist '${key}' to localStorage:`, e);
+    }
+};
 
 let mode = null;
 
@@ -31,7 +40,7 @@ function handleMessage(event) {
     let message = event.data;
     if (message.mode !== undefined && message.type === "mode") {
         console.log(`Switching streaming mode to: ${message.mode}`);
-        localStorage.setItem(getPrefixedKey('stream_mode'), message.mode);
+        safeSetItem(getPrefixedKey('stream_mode'), message.mode);
 
         // wait for a few seconds to let the server switch modes
         setTimeout(() => {
@@ -42,7 +51,7 @@ function handleMessage(event) {
 }
 
 function switchStreamingMode(newMode) {
-    localStorage.setItem(getPrefixedKey('stream_mode'), newMode);
+    safeSetItem(getPrefixedKey('stream_mode'), newMode);
     switch (newMode) {
         case STREAM_MODE_WEBRTC:
             mode = webrtc();

--- a/addons/selkies-web-core/selkies-wr-core.js
+++ b/addons/selkies-web-core/selkies-wr-core.js
@@ -336,9 +336,21 @@ export default function webrtc() {
 	const isSharedMode = detectedSharedModeType !== null;
 	const isStrictViewer = detectedSharedModeType === "shared";
 
-	// Set storage key based on URL
-	const urlForKey = window.location.href.split('#')[0];
+	// Storage key namespace: origin + pathname only, NOT the full URL, so a per-session
+	// token in the query string can't leak a new localStorage namespace each session.
+	// Must match selkies-ws-core.js / selkies-core.js.
+	const urlForKey = window.location.origin + window.location.pathname;
 	const storageAppName = urlForKey.replace(/[^a-zA-Z0-9.-_]/g, '_');
+
+	// Guarded write: a full or unavailable store degrades to a warning instead of
+	// throwing QuotaExceededError into the caller.
+	const safeSetItem = (key, value) => {
+		try {
+			window.localStorage.setItem(key, value);
+		} catch (e) {
+			console.warn(`Selkies: could not persist '${key}' to localStorage:`, e);
+		}
+	};
 
 	const getIntParam = (key, default_value) => {
 		const prefixedKey = `${storageAppName}_${key}`;
@@ -350,7 +362,7 @@ export default function webrtc() {
 		if (value === null || value === undefined) {
 				window.localStorage.removeItem(prefixedKey);
 		} else {
-				window.localStorage.setItem(prefixedKey, value.toString());
+				safeSetItem(prefixedKey, value.toString());
 		}
 	};
 	const getBoolParam = (key, default_value) => {
@@ -366,7 +378,7 @@ export default function webrtc() {
 		if (value === null || value === undefined) {
 				window.localStorage.removeItem(prefixedKey);
 		} else {
-				window.localStorage.setItem(prefixedKey, value.toString());
+				safeSetItem(prefixedKey, value.toString());
 		}
 	};
 	const getStringParam = (key, default_value) => {
@@ -379,7 +391,7 @@ export default function webrtc() {
 		if (value === null || value === undefined) {
 				window.localStorage.removeItem(prefixedKey);
 		} else {
-				window.localStorage.setItem(prefixedKey, value.toString());
+				safeSetItem(prefixedKey, value.toString());
 		}
 	};
 

--- a/addons/selkies-web-core/selkies-ws-core.js
+++ b/addons/selkies-web-core/selkies-ws-core.js
@@ -159,9 +159,42 @@ window.onload = () => {
   'use strict';
 };
 
-// Set storage key based on URL
-const urlForKey = window.location.href.split('#')[0];
+// Storage key namespace. Must NOT include the query string: the portal hands out a
+// fresh ?token=... every session, so keying on the full URL leaked a whole new set of
+// localStorage entries on each connect and eventually exhausted the origin quota
+// (QuotaExceededError during init -> blank/grey iframe). Use origin + pathname so the
+// namespace is stable across sessions (and settings actually persist now).
+const urlForKey = window.location.origin + window.location.pathname;
 const storageAppName = urlForKey.replace(/[^a-zA-Z0-9.-_]/g, '_');
+
+// Guarded write: a full or unavailable store degrades to a warning instead of
+// throwing QuotaExceededError into the caller.
+const safeSetItem = (key, value) => {
+  try {
+    window.localStorage.setItem(key, value);
+  } catch (e) {
+    console.warn(`Selkies: could not persist '${key}' to localStorage:`, e);
+  }
+};
+
+// One-time cleanup of keys written by the old token-scoped scheme. Those keys were
+// prefixed by the full URL, so they start with this stable base followed by the query
+// string ('?...'); current keys use '<base>_<setting>'. Removing items never hits the
+// quota, so this also recovers browsers whose store is already full.
+try {
+  const legacyPrefix = storageAppName + '?';
+  const staleKeys = [];
+  for (let i = 0; i < window.localStorage.length; i++) {
+    const k = window.localStorage.key(i);
+    if (k && k.startsWith(legacyPrefix)) staleKeys.push(k);
+  }
+  staleKeys.forEach((k) => window.localStorage.removeItem(k));
+  if (staleKeys.length) {
+    console.log(`Selkies: removed ${staleKeys.length} stale token-scoped localStorage keys.`);
+  }
+} catch (e) {
+  console.warn('Selkies: localStorage cleanup failed:', e);
+}
 
 // Set page title
 document.title = 'Selkies';
@@ -242,7 +275,7 @@ const setIntParam = (key, value) => {
   if (value === null || value === undefined) {
     window.localStorage.removeItem(finalKey);
   } else {
-    window.localStorage.setItem(finalKey, value.toString());
+    safeSetItem(finalKey, value.toString());
   }
 };
 const getBoolParam = (key, default_value) => {
@@ -266,7 +299,7 @@ const setBoolParam = (key, value) => {
   if (value === null || value === undefined) {
     window.localStorage.removeItem(finalKey);
   } else {
-    window.localStorage.setItem(finalKey, value.toString());
+    safeSetItem(finalKey, value.toString());
   }
 };
 const getStringParam = (key, default_value) => {
@@ -287,7 +320,7 @@ const setStringParam = (key, value) => {
   if (value === null || value === undefined) {
     window.localStorage.removeItem(finalKey);
   } else {
-    window.localStorage.setItem(finalKey, value.toString());
+    safeSetItem(finalKey, value.toString());
   }
 };
 function sanitizeAndStoreSettings(serverSettings) {
@@ -4512,10 +4545,10 @@ function initiateFallback(error, context) {
         const crashKey = `${storageAppName}_crash_count`;
         let crashCount = parseInt(window.localStorage.getItem(crashKey) || '0');
         crashCount++;
-        window.localStorage.setItem(crashKey, crashCount.toString());
+        safeSetItem(crashKey, crashCount.toString());
         if (crashCount >= 3) {
             setStringParam('encoder', 'jpeg');
-            window.localStorage.setItem(crashKey, '0');
+            safeSetItem(crashKey, '0');
         } else {
             setStringParam('encoder', 'x264enc');
         }


### PR DESCRIPTION

## Problem

All four frontend modules (`selkies-ws-core.js`, `selkies-core.js`,
`selkies-wr-core.js`, dashboard `Sidebar.jsx`) derive their localStorage
namespace from `window.location.href.split('#')[0]` — which includes the query
string. Deployments that hand out per-session URLs (e.g. `?token=...`) therefore
leak a fresh namespace of ~20 keys every session. Once the ~5 MB origin quota
fills, `localStorage.setItem` throws `QuotaExceededError` during startup —
`selkies-core.js` writes `stream_mode` on load, so the client aborts before
initialising and the user gets a blank iframe. Settings also never persisted
across sessions, since each session read from a namespace nothing had written.

## Fix

- Derive the namespace from `location.origin + location.pathname` in all four
  modules (they must agree — comment added to each).
- On startup, prune keys written by the old token-scoped scheme (they share the
  stable base followed by `?`), which also recovers browsers whose store is
  already full: `removeItem` never hits the quota.
- Route the remaining raw `setItem` calls (`setIntParam`/`setBoolParam`/
  `setStringParam`, `stream_mode`, the crash counter in `initiateFallback`)
  through guarded writes so a full or unavailable store degrades to a console
  warning instead of aborting startup.

A side benefit on `main`: `determineStreamingMode()`'s last-session-mode
precedence now actually works across sessions in tokenised deployments.

## Testing

Running in our production deployment (lsio-based): quota exhaustion and the
resulting blank-iframe startup failures are gone, stale namespaces are reclaimed
on first load, and settings persist across sessions. The port needed a small hand-resolve in `selkies-core.js`
(restructured on `main`) — the result keeps `main`'s `determineStreamingMode()`
/ deferred-init structure intact. Build-verified on `main` (web-core and
dashboard vite builds), not yet runtime-tested against `main` itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
