### PR TITLE
perf(input): reduce per-mouse-move overhead (X11 flush, client rAF coalescing)

### DIFF
--- a/addons/selkies-web-core/lib/input.js
+++ b/addons/selkies-web-core/lib/input.js
@@ -1727,8 +1727,58 @@ export class Input {
                 this.buttonMask &= ~mask;
             }
         }
-        var toks = [ mtype, this.x, this.y, this.buttonMask, 0 ];
-        this.send(toks.join(","));
+        if (event.type === 'mousemove' || event.type === 'pointermove') {
+            // Coalesce high-frequency motion. A 1000 Hz mouse would otherwise emit
+            // ~1000 tiny WS messages/sec, congesting the uplink (felt as input lag
+            // over the internet) and starving the server's single-threaded
+            // input/video loop. Batch to at most one send per animation frame.
+            this._queueCoalescedMouseMove(mtype, this.x, this.y, this.buttonMask);
+        } else {
+            // Button / non-move event: flush any pending motion first so ordering
+            // (move-then-click, and accumulated relative deltas) is preserved, then
+            // send this event immediately.
+            this._flushCoalescedMouseMove();
+            this.send([ mtype, this.x, this.y, this.buttonMask, 0 ].join(","));
+        }
+    }
+
+    _queueCoalescedMouseMove(mtype, x, y, buttonMask) {
+        if (mtype === "m2") {
+            // Relative mode: deltas must be summed, never dropped.
+            if (this._pendingMove && this._pendingMove.mtype === "m2") {
+                this._pendingMove.x += x;
+                this._pendingMove.y += y;
+                this._pendingMove.buttonMask = buttonMask;
+            } else {
+                this._flushCoalescedMouseMove();
+                this._pendingMove = { mtype: "m2", x: x, y: y, buttonMask: buttonMask };
+            }
+        } else {
+            // Absolute mode: only the latest position matters.
+            if (this._pendingMove && this._pendingMove.mtype !== "m") {
+                this._flushCoalescedMouseMove();
+            }
+            this._pendingMove = { mtype: "m", x: x, y: y, buttonMask: buttonMask };
+        }
+        if (!this._moveFlushScheduled) {
+            this._moveFlushScheduled = true;
+            const raf = window.requestAnimationFrame
+                ? window.requestAnimationFrame.bind(window)
+                : (cb) => setTimeout(cb, 16);
+            raf(() => {
+                this._moveFlushScheduled = false;
+                this._flushCoalescedMouseMove();
+            });
+        }
+    }
+
+    _flushCoalescedMouseMove() {
+        const m = this._pendingMove;
+        if (!m) return;
+        this._pendingMove = null;
+        // An accumulated relative move of (0,0) carries no information.
+        if (m.mtype === "m2" && m.x === 0 && m.y === 0) return;
+        this.send([ m.mtype, m.x, m.y, m.buttonMask, 0 ].join(","));
     }
 
     _handlePointerDown(event) {

--- a/src/selkies/input_handler.py
+++ b/src/selkies/input_handler.py
@@ -1228,7 +1228,9 @@ class WebRTCInput:
                 self.__mouse_emit(UINPUT_REL_Y, y)
             elif self.xdisplay:
                 xtest.fake_input(self.xdisplay, Xlib.X.MotionNotify, detail=True, root=Xlib.X.NONE, x=x, y=y)
-                self.xdisplay.sync()
+                # flush() sends the queued event without the blocking round-trip
+                # that sync() would wait for; input is delivered in order regardless.
+                self.xdisplay.flush()
         elif action == MOUSE_SCROLL_UP:
             if self.uinput_mouse_socket_path: self.__mouse_emit(UINPUT_REL_WHEEL, 1)
             elif self.mouse: self.mouse.scroll(0, -1)
@@ -1703,7 +1705,9 @@ class WebRTCInput:
             self.button_mask = button_mask
 
         if not relative and self.xdisplay:
-            self.xdisplay.sync()
+            # flush() (not sync()) avoids a blocking X round-trip per absolute
+            # move; on the pynput path self.xdisplay usually has nothing pending.
+            self.xdisplay.flush()
     async def update_binary_clipboard_setting(self, enabled: bool):
         """Asynchronously updates the binary clipboard setting and restarts the monitor if it's running."""
         new_setting_str = "true" if enabled else "false"


### PR DESCRIPTION
## Problem

Two independent sources of per-mouse-move overhead on the input path:

1. **Server**: `send_x11_mouse()` and `send_mouse()` call `self.xdisplay.sync()`
   after injecting motion, which blocks on a full X server round-trip per
   event. On the absolute (non-relative) path this sync runs even though
   pynput drives the motion on its own display connection, so it round-trips
   a connection with nothing pending. This blocking happens on the event loop
   the video sender shares.
2. **Client**: every `mousemove` DOM event produced a websocket send. At high
   polling rates (gaming mice easily exceed 500 events/s) this floods the
   socket with intermediate positions the server will immediately overwrite.

## Fix

1. Use `flush()` instead of `sync()` — it delivers queued input in order
   without waiting for a reply, removing the per-move event-loop stall.
   (`comprehensive-fixes` makes the same change; this extracts it so it can
   land independently.)
2. Coalesce mouse-move sends to one per animation frame: intermediate
   positions within a frame are collapsed to the latest, non-move input is
   unaffected, and the final position is always flushed so no endpoint is
   lost.

## Testing

Running in our production deployment (lsio-based images) for two weeks;
measurably smoother pointer under load with no observed input loss or
reordering. Both hunks apply to `main` unchanged (cherry-picks; the
surrounding code is identical between the branches). Not yet runtime-tested
against `main` itself — a main-based test build on production NVIDIA hardware
is in progress, results to follow on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
