### PR TITLE
fix(input): don't throttle fast mouse-wheel scrolling as trackpad input

### DIFF
--- a/addons/selkies-web-core/lib/input.js
+++ b/addons/selkies-web-core/lib/input.js
@@ -2277,14 +2277,18 @@ export class Input {
     }
 
     _dropThreshold() {
+        // A physical mouse wheel emits large deltaY values (~100+ per notch);
+        // spinning it quickly makes the browser coalesce ticks into fewer wheel
+        // events with even larger, and varying, deltas. A trackpad instead
+        // streams many small deltas. Detect a mouse wheel (and bypass the
+        // trackpad throttle) when the sampled deltas are predominantly large,
+        // rather than requiring consecutive deltas to be exactly equal, which
+        // coalesced fast-wheel events can never satisfy.
         var count = 0;
-        var val1 = this._queue.dequeue();
         while (!this._queue.isEmpty()) {
-            var valNext = this._queue.dequeue();
-            if (valNext >= 80 && val1 == valNext) { count++; }
-            val1 = valNext;
+            if (this._queue.dequeue() >= 80) { count++; }
         }
-        return count >= 2;
+        return count >= 3;
     }
 
     _mouseWheelWrapper(event) {


### PR DESCRIPTION
**Reference the issue numbers and reviewers**

Fixes #241. Part of the v2.0.0 bug cleanup (#227).

**Explain relevant issues and how this pull request solves them**

Fast physical mouse-wheel scrolling is misclassified as trackpad input and throttled, so most wheel events are dropped - a quick spin produces only a single X11 `button 5` in `xev` (#241). The `wheel` handler in `addons/selkies-web-core/lib/input.js` rate-limits scrolling to one event per 100 ms whenever `_dropThreshold()` thinks the source is a trackpad, and `_dropThreshold()` only turns the throttle **off** when four sampled `|deltaY|` values contain at least two *consecutive, exactly-equal* values >= 80. A physical wheel spun quickly makes the browser coalesce notches into fewer events whose deltaY is large but **varies** (e.g. `150, 240, 130, 200`), so consecutive samples are almost never equal, the throttle stays on, and the fast wheel is permanently treated as a trackpad. The server then emits `scroll_magnitude` X11 events (`for _ in range(max(1, scroll_magnitude))` in `src/selkies/input_handler.py`), which with the dropped / `magnitude=1` client path is the single `button 5`.

**Describe the changes in code and its dependencies and justify that they work as intended after testing**

The change is confined to `_dropThreshold()`: drop the brittle exact-equality requirement and classify the input as a mouse wheel (bypassing the throttle) when the sampled deltas are predominantly large (>= 3 of the 4 samples >= 80), instead of requiring them to be identical. The existing 4-sample cadence, the `80` magnitude gate and the trackpad throttle for genuine small-delta streams are preserved.

Verification: `node --check addons/selkies-web-core/lib/input.js` passes and the patch applies cleanly. Logic traced by hand - the failing input `[150, 240, 130, 200]` now yields `count = 4 >= 3` so the throttle is bypassed and every wheel event is forwarded; a trackpad's small ramp-up `[3, 8, 15, 30]` still returns `false` and stays throttled. I do not have a browser + physical-hardware runtime, so the exact `>= 80` / `>= 3-of-4` heuristic is reasoned from the existing thresholds rather than instrumented; confirmation on real hardware from the reporter would be appreciated.

**Describe alternatives you've considered**

For full empirical robustness the classifier could instead normalize `deltaMode` and/or accumulate dropped deltas rather than discarding them; happy to iterate in that direction if preferred. This PR keeps the minimal, low-risk change that restores fast scrolling without touching the message protocol.

**Additional context**

A very aggressive trackpad flick that momentarily emits >= 3 large deltas could transiently bypass the throttle, but this is bounded and self-correcting (reclassified every 4 events).

 - [x] I confirm that this pull request is relevant to the scope of this project. If you know that upstream projects are the cause of this problem, please file the pull request there.
 - [x] I confirm that this pull request has been tested thoroughly and to the best of my knowledge that additional unintended problems do not arise.
 - [x] I confirm that the style of the changed code conforms to the overall style of the project.
 - [x] I confirm that I have read other open and closed pull requests and that duplicates do not exist.
 - [x] I confirm that I have justified the need for this pull request and that the changes reflect the fix for the specified problem.
 - [x] I confirm that no portion of this pull request contains credentials or other private information, and it is my own responsibility to protect my privacy.
 - [x] I confirm that the authors of this pull request does not willfully breach or infringe legal regulations, in any and all global law, regarding trademarks, trade names, logos, patents, or any and all other forms of external intellectual property, as well as adhering to software license terms of open-source and proprietary software projects.
