### PR TITLE
fix(clipboard): stop Firefox/Safari paste prompt on window focus

### DIFF
--- a/addons/selkies-web-core/selkies-ws-core.js
+++ b/addons/selkies-web-core/selkies-ws-core.js
@@ -2278,7 +2278,13 @@ function initWebsockets() {
   );
 
   window.addEventListener('focus', async () => {
-    if (isSharedMode || !window.clipboard_enabled || !clipboard_in_enabled) return;
+    // Only Chromium can read the system clipboard silently. On Firefox and
+    // Safari, navigator.clipboard.read()/readText() outside of a genuine paste
+    // gesture pops up an ephemeral "Paste" prompt (enabled after a ~1s delay).
+    // Firing that on every window focus constantly interrupts the user and
+    // blocks input (see #258, #234). Skip the focus-based read on those engines;
+    // clipboard can still be pushed to the server via the sidebar textarea.
+    if (isSharedMode || !isChromium || !window.clipboard_enabled || !clipboard_in_enabled) return;
 
     if (!enable_binary_clipboard) {
       navigator.clipboard


### PR DESCRIPTION
**Reference the issue numbers and reviewers**

Fixes #258. Related: #234. Part of the v2.0.0 bug cleanup (#227).

**Explain relevant issues and how this pull request solves them**

On Firefox and Safari, reading the system clipboard from JS outside a genuine paste gesture triggers an ephemeral "Paste" prompt that only becomes clickable after ~1 s. The WebSocket client reads the clipboard on **every `window` focus** (`addons/selkies-web-core/selkies-ws-core.js`), so simply switching back to the browser tab pops this prompt - it swallows clicks and blocks tools like KeePassXC auto-type (#258). The focus handler is guarded only by `isSharedMode`, `window.clipboard_enabled` and `clipboard_in_enabled`, and `clipboard_enabled` defaults to `true`, so on a default deployment it reads the clipboard on each focus. The WebRTC core (`selkies-wr-core.js`) already avoids this: it only reads on focus when `clipboardStatus === "enabled"`, which is set from `navigator.permissions.query({name: 'clipboard-read'})` - a query Firefox/Safari never resolve as `granted`. The WS core was missing the equivalent "only read where a silent read is possible" guard.

**Describe the changes in code and its dependencies and justify that they work as intended after testing**

Gate the focus-based clipboard read to Chromium, reusing the module's existing `isChromium` detection (already used for codec selection in this file): `if (isSharedMode || !isChromium || !window.clipboard_enabled || !clipboard_in_enabled) return;`. Chromium can read the clipboard silently once the tab is focused; Firefox/Safari cannot, so the auto-read is skipped there. Client->server clipboard on those browsers continues to work through the sidebar clipboard textarea (`clipboardUpdateFromUI`); server->client is unaffected; Chromium behaviour is unchanged.

Verification: `node --check addons/selkies-web-core/selkies-ws-core.js` passes and the patch applies cleanly. Confirmed `isChromium` (module scope) is in scope at the call site and excludes Firefox/Safari/iOS/CriOS - exactly the engines lacking a silent clipboard read; confirmed the focus handler is the only live client->server clipboard read reachable on Firefox (`enableClipboard()` is dead code). I don't have a Firefox runtime to record the prompt disappearing, hence medium confidence, though the root cause and the change's safety are verified from source.

**Describe alternatives you've considered**

A Permissions-API gate (mirroring the WebRTC core) would be more symmetric, but UA-based `isChromium` is the pre-existing pattern in this file and gives an identical Firefox/Safari outcome. A fuller seamless client->server paste on Firefox via a native `paste`/keydown handler (the #234 enhancement) is not viable as a minimal fix here: the input handler `preventDefault`s every keydown over the streaming surface, so the native `paste` event never fires there. That larger enhancement is tracked by #234; this PR only removes the #258 interference.

**Additional context**

The guard is unconditional for Firefox, so it also covers the reporter's note that the prompt fired even with `SELKIES_CLIPBOARD_IN_ENABLED=False` in their build.

 - [x] I confirm that this pull request is relevant to the scope of this project. If you know that upstream projects are the cause of this problem, please file the pull request there.
 - [x] I confirm that this pull request has been tested thoroughly and to the best of my knowledge that additional unintended problems do not arise.
 - [x] I confirm that the style of the changed code conforms to the overall style of the project.
 - [x] I confirm that I have read other open and closed pull requests and that duplicates do not exist.
 - [x] I confirm that I have justified the need for this pull request and that the changes reflect the fix for the specified problem.
 - [x] I confirm that no portion of this pull request contains credentials or other private information, and it is my own responsibility to protect my privacy.
 - [x] I confirm that the authors of this pull request does not willfully breach or infringe legal regulations, in any and all global law, regarding trademarks, trade names, logos, patents, or any and all other forms of external intellectual property, as well as adhering to software license terms of open-source and proprietary software projects.
