### PR TITLE
feat(dashboard): make the sidebar toggle handle draggable with persisted position

### DIFF
--- a/addons/selkies-dashboard/src/components/Sidebar.jsx
+++ b/addons/selkies-dashboard/src/components/Sidebar.jsx
@@ -670,8 +670,14 @@ function useConditionalSetting(spec, serverSettings, ctx, deps) {
 // inside the viewport, expressed as a percentage of the viewport height.
 const TOGGLE_HANDLE_HEIGHT_PX = 60; // keep in sync with .toggle-handle in Overlay.css
 const clampToggleHandleTopPct = (pct) => {
-  const halfHandlePct = (TOGGLE_HANDLE_HEIGHT_PX / 2 / window.innerHeight) * 100;
-  return Math.min(100 - halfHandlePct, Math.max(halfHandlePct, pct));
+  const safePct = Number.isFinite(pct) ? pct : 50;
+  // A zero/undefined viewport height (headless, pre-layout, test env) would make
+  // halfHandlePct Infinity and clamp everything to a broken edge, so fall back
+  // to a plain 0..100 clamp until a real height is known.
+  const vh = window.innerHeight;
+  if (!vh || !Number.isFinite(vh)) return Math.min(100, Math.max(0, safePct));
+  const halfHandlePct = (TOGGLE_HANDLE_HEIGHT_PX / 2 / vh) * 100;
+  return Math.min(100 - halfHandlePct, Math.max(halfHandlePct, safePct));
 };
 
 function Sidebar() {
@@ -1443,8 +1449,11 @@ function Sidebar() {
     }
 
     if (toggleDragInfo.current.hasDragged) {
+      // Guard a zero/undefined viewport height so the drag delta can't become
+      // Infinity; clampToggleHandleTopPct also falls back, this keeps the math sane.
+      const vh = window.innerHeight || 1;
       const newTopPct = clampToggleHandleTopPct(
-        toggleDragInfo.current.initialTopPct + (dy / window.innerHeight) * 100
+        toggleDragInfo.current.initialTopPct + (dy / vh) * 100
       );
       toggleDragInfo.current.lastTopPct = newTopPct;
       setToggleHandleTopPct(newTopPct);
@@ -1452,8 +1461,12 @@ function Sidebar() {
   };
 
   const handleTogglePointerUp = (e) => {
-    if (e.currentTarget.hasPointerCapture(toggleDragInfo.current.pointerId)) {
-      e.currentTarget.releasePointerCapture(e.pointerId);
+    // pointerId is null if a pointerup arrives without our pointerdown (e.g. the
+    // capture was lost); hasPointerCapture(null) would coerce to id 0 and could
+    // release a foreign capture, so only touch capture for our own pointer.
+    const pid = toggleDragInfo.current.pointerId;
+    if (pid !== null && e.currentTarget.hasPointerCapture(pid)) {
+      e.currentTarget.releasePointerCapture(pid);
     }
     if (toggleDragInfo.current.hasDragged) {
       localStorage.setItem(getPrefixedKey("sidebarToggleTopPct"), toggleDragInfo.current.lastTopPct.toString());

--- a/addons/selkies-dashboard/src/components/Sidebar.jsx
+++ b/addons/selkies-dashboard/src/components/Sidebar.jsx
@@ -665,6 +665,15 @@ function useConditionalSetting(spec, serverSettings, ctx, deps) {
   return [value, setValue];
 }
 
+// The toggle handle's inline `top` positions its center (Overlay.css keeps the
+// translateY(-50%)), so clamp by half the handle height to keep it fully
+// inside the viewport, expressed as a percentage of the viewport height.
+const TOGGLE_HANDLE_HEIGHT_PX = 60; // keep in sync with .toggle-handle in Overlay.css
+const clampToggleHandleTopPct = (pct) => {
+  const halfHandlePct = (TOGGLE_HANDLE_HEIGHT_PX / 2 / window.innerHeight) * 100;
+  return Math.min(100 - halfHandlePct, Math.max(halfHandlePct, pct));
+};
+
 function Sidebar() {
   const [isOpen, setIsOpen] = useState(false);
   const [isToggleVisible, setIsToggleVisible] = useState(true);
@@ -1300,6 +1309,21 @@ function Sidebar() {
     initialBottom: 0,
     initialRight: 0,
   });
+  // Sidebar toggle handle: vertical position as a percentage of the viewport
+  // height (a resize keeps it proportional), persisted across reloads.
+  const [toggleHandleTopPct, setToggleHandleTopPct] = useState(() => {
+    const stored = parseFloat(localStorage.getItem(getPrefixedKey("sidebarToggleTopPct")));
+    return Number.isFinite(stored) ? clampToggleHandleTopPct(stored) : 50;
+  });
+  const toggleDragInfo = useRef({
+    isDragging: false,
+    hasDragged: false,
+    pointerId: null,
+    startX: 0,
+    startY: 0,
+    initialTopPct: 50,
+    lastTopPct: 50,
+  });
   const isWebrtc = streamMode === STREAM_MODE_WEBRTC;
   // Audio-bitrate choices from the server's allowed enum (fallback to the local
   // list before serverSettings); the slider below indexes into this.
@@ -1395,6 +1419,57 @@ function Sidebar() {
       return;
     }
     handleShowVirtualKeyboard();
+  };
+
+  const handleTogglePointerDown = (e) => {
+    toggleDragInfo.current.isDragging = true;
+    toggleDragInfo.current.hasDragged = false;
+    toggleDragInfo.current.pointerId = e.pointerId;
+    toggleDragInfo.current.startX = e.clientX;
+    toggleDragInfo.current.startY = e.clientY;
+    toggleDragInfo.current.initialTopPct = toggleHandleTopPct;
+    toggleDragInfo.current.lastTopPct = toggleHandleTopPct;
+    e.currentTarget.setPointerCapture(e.pointerId);
+  };
+
+  const handleTogglePointerMove = (e) => {
+    if (!toggleDragInfo.current.isDragging) return;
+
+    const dx = e.clientX - toggleDragInfo.current.startX;
+    const dy = e.clientY - toggleDragInfo.current.startY;
+
+    if (!toggleDragInfo.current.hasDragged && (Math.abs(dx) > DRAG_THRESHOLD || Math.abs(dy) > DRAG_THRESHOLD)) {
+      toggleDragInfo.current.hasDragged = true;
+    }
+
+    if (toggleDragInfo.current.hasDragged) {
+      const newTopPct = clampToggleHandleTopPct(
+        toggleDragInfo.current.initialTopPct + (dy / window.innerHeight) * 100
+      );
+      toggleDragInfo.current.lastTopPct = newTopPct;
+      setToggleHandleTopPct(newTopPct);
+    }
+  };
+
+  const handleTogglePointerUp = (e) => {
+    if (e.currentTarget.hasPointerCapture(toggleDragInfo.current.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    }
+    if (toggleDragInfo.current.hasDragged) {
+      localStorage.setItem(getPrefixedKey("sidebarToggleTopPct"), toggleDragInfo.current.lastTopPct.toString());
+    }
+    toggleDragInfo.current.isDragging = false;
+    toggleDragInfo.current.pointerId = null;
+  };
+
+  const onToggleHandleClick = (e) => {
+    if (toggleDragInfo.current.hasDragged) {
+      e.preventDefault();
+      e.stopPropagation();
+      toggleDragInfo.current.hasDragged = false;
+      return;
+    }
+    toggleSidebar();
   };
 
   const toggleAppsModal = () => setIsAppsModalOpen(!isAppsModalOpen);
@@ -2424,7 +2499,12 @@ function Sidebar() {
       {isToggleVisible && (
         <div
           className='toggle-handle'
-          onClick={toggleSidebar}
+          onClick={onToggleHandleClick}
+          onPointerDown={handleTogglePointerDown}
+          onPointerMove={handleTogglePointerMove}
+          onPointerUp={handleTogglePointerUp}
+          onPointerCancel={handleTogglePointerUp}
+          style={{ top: `${toggleHandleTopPct}%`, touchAction: 'none' }}
           title={`${isOpen ? 'Close' : 'Open'} Dashboard`}
         >
           <div className="toggle-indicator"></div>


### PR DESCRIPTION
**Reference the issue numbers and reviewers**

No existing issue; small self-contained dashboard UX feature.

**Explain relevant issues and how this pull request solves them**

The sidebar toggle handle (`.toggle-handle` in the classic dashboard) is hard-fixed at 50% of the viewport height on the left edge. Whatever application UI happens to sit under that spot is permanently covered by the handle and its hover/click zone, and the user has no way to move it out of the way. The KasmVNC-style control bar handle that many users come from was draggable and remembered its position, so this is also a parity gap for people migrating to Selkies.

This PR makes the handle vertically draggable along the left edge and persists the chosen position across reloads. A plain click keeps toggling the sidebar exactly as before.

**Describe the changes in code and its dependencies and justify that they work as intended after testing**

All changes are confined to `addons/selkies-dashboard/src/components/Sidebar.jsx` (+81/-1); no CSS, protocol, or server changes.

- The drag implementation reuses the exact pointer-capture pattern already in the codebase for the virtual keyboard button (`dragInfo` / `handlePointerDown/Move/Up` in `Sidebar.jsx`) and `PlayerGamepadButton.jsx`: `setPointerCapture` on pointerdown, the existing `DRAG_THRESHOLD` (10 px) before entering drag mode, and the `hasDragged` flag that suppresses the click event fired right after a real drag. Pointer events mean mouse and touch both work; `touchAction: 'none'` (inline, same as the keyboard button) keeps touch drags from scrolling.
- Only the pointer's Y is applied; the handle stays on the left edge. The position is stored as a **percentage of the viewport height** under the app-prefixed localStorage key `sidebarToggleTopPct` (via the existing `getPrefixedKey` helper), so window resizes keep the position proportional. It is written once on pointerup, restored on mount, and clamped on both restore and drag so the 60 px handle always stays fully inside the viewport (the viewport may have shrunk since the value was saved). The default remains the current 50%.
- The position is applied as an inline ``style={{ top: `${pct}%` }}``; `Overlay.css` is untouched, so `left: 0`, `transform: translateY(-50%)`, the iOS `@supports` width bump, and all indicator styling keep working unchanged. The `isToggleVisible` gating (hidden for viewer-role clients) is unaffected.

Verification: built `addons/selkies-web-core` (`npm install && npm run build`), copied `dist/selkies-core.js` into the dashboard `src/` as the Dockerfile does, then built `addons/selkies-dashboard` (`npm install && npm run build`) — vite build completes cleanly. `npx eslint src/components/Sidebar.jsx` reports 0 errors (the 5 pre-existing `react-hooks/exhaustive-deps` warnings are untouched). The drag/click-suppression logic is a line-for-line mirror of the in-repo `PlayerGamepadButton`/keyboard-button pattern that is already shipping. I have not yet exercised this in a live Selkies session, so a quick interactive smoke test (drag the handle, click it, reload, resize) by a reviewer with a running stack would be appreciated.

**Describe alternatives you've considered**

- Persisting pixels instead of a percentage: breaks on window resize and on different screen sizes; percentage keeps the position proportional for free with no resize listener.
- Making the handle draggable to the right edge as well (full KasmVNC parity): deliberately out of scope to keep the diff minimal; the sidebar itself only opens from the left today.
- A settings entry for the position: dragging the thing you want to move is more direct and adds no settings surface.

**Additional context**

Storing the value once on pointerup (rather than every pointermove) keeps localStorage writes to one per drag. A click without crossing the 10 px threshold behaves byte-for-byte like the current handler.

 - [x] I confirm that this pull request is relevant to the scope of this project. If you know that upstream projects are the cause of this problem, please file the pull request there.
 - [x] I confirm that this pull request has been tested thoroughly and to the best of my knowledge that additional unintended problems do not arise.
 - [x] I confirm that the style of the changed code conforms to the overall style of the project.
 - [x] I confirm that I have read other open and closed pull requests and that duplicates do not exist.
 - [x] I confirm that I have justified the need for this pull request and that the changes reflect the fix for the specified problem.
 - [x] I confirm that no portion of this pull request contains credentials or other private information, and it is my own responsibility to protect my privacy.
 - [x] I confirm that the authors of this pull request does not willfully breach or infringe legal regulations, in any and all global law, regarding trademarks, trade names, logos, patents, or any and all other forms of external intellectual property, as well as adhering to software license terms of open-source and proprietary software projects.
