### PR TITLE
docs(faq): document missing video output while the screen is locked

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -72,6 +72,16 @@ In order to use the web interface when this is not possible (or when you are usi
 
 </details>
 
+## There is no video output when the screen is locked on an existing desktop.
+
+<details markdown>
+  <summary>Open Answer</summary>
+
+When the screen locks, the display manager switches to a lock screen greeter running on a separate display or virtual terminal (with LightDM, for instance, a second X server such as `:1` is spawned for the greeter). Selkies keeps capturing the original `DISPLAY`, which no longer produces any output, so the video stream stays black until the screen is unlocked, after which capture resumes normally.
+
+To avoid this, disable screen locking in your desktop environment and disable any autostarted screen locker (`light-locker`, `xscreensaver`, `gnome-screensaver`), then turn off the screensaver and DPMS with `xset s off -dpms`. With NVIDIA GPUs, DPMS blanking may additionally require setting `Option "HardDPMS" "False"` under the `Device` or `Screen` section in `/etc/X11/xorg.conf`. Alternatively, use a container or session without a display manager, where no lock screen exists.
+
+</details>
 ## My touchpad does not move while pressing a key with the keyboard.
 
 <details markdown>


### PR DESCRIPTION
**Reference the issue numbers and reviewers**

#174 @ehfd

**Explain relevant issues and how this pull request solves them**

This pull request documents the known limitation discussed in #174: when the screen is locked on an existing desktop, Selkies produces no video output. As established in that thread, the display manager's lock switches to a greeter on a separate display or virtual terminal (observed with LightDM spawning a second X server on `:1`), so Selkies capturing the original `DISPLAY` loses output until the screen is unlocked. Since documentation was explicitly requested in that issue, this adds a FAQ entry covering the cause and the workarounds. Documents #174; feel free to close that issue if this satisfies the documentation requirement.

**Describe the changes in code and its dependencies and justify that they work as intended after testing**

Adds one new entry to `docs/faq.md`, matching the existing entry pattern (`##` heading, `<details markdown>` block with an `Open Answer` summary). It explains why the video output stops on screen lock and lists the workarounds in order: disable screen locking and any autostarted locker (`light-locker`, `xscreensaver`, `gnome-screensaver`), run `xset s off -dpms`, add `Option "HardDPMS" "False"` in `/etc/X11/xorg.conf` for NVIDIA DPMS blanking, or use a container/session without a display manager. Verified that the Markdown renders correctly with the `md_in_html` extension used for the existing entries: all eight `<details>`/`</details>` pairs and summaries are balanced. Documentation-only change; no code or dependencies are affected.

**Describe alternatives you've considered**

Handling the lock screen transition in code was ruled out in #174 ("There is not much that can be reliably done here"), since the greeter runs on a different display that Selkies cannot follow, so documenting the limitation and workarounds is the agreed approach.

**Additional context**

The new entry is placed directly after the existing display-manager-related entry ("The web interface refuses to start up in the terminal after rebooting...") to keep session/display-manager topics grouped together.

 - [x] I confirm that this pull request is relevant to the scope of this project. If you know that upstream projects are the cause of this problem, please file the pull request there.
 - [x] I confirm that this pull request has been tested thoroughly and to the best of my knowledge that additional unintended problems do not arise.
 - [x] I confirm that the style of the changed code conforms to the overall style of the project.
 - [x] I confirm that I have read other open and closed pull requests and that duplicates do not exist.
 - [x] I confirm that I have justified the need for this pull request and that the changes reflect the fix for the specified problem.
 - [x] I confirm that no portion of this pull request contains credentials or other private information, and it is my own responsibility to protect my privacy.
 - [x] I confirm that the authors of this pull request does not willfully breach or infringe legal regulations, in any and all global law, regarding trademarks, trade names, logos, patents, or any and all other forms of external intellectual property, as well as adhering to software license terms of open-source and proprietary software projects.