### PR TITLE
feat(example): opt-in flag to keep capture alive when the screen is locked

### DIFF
--- a/addons/example/entrypoint.sh
+++ b/addons/example/entrypoint.sh
@@ -51,6 +51,21 @@ echo 'Waiting for X Socket' && until [ -S "/tmp/.X11-unix/X${DISPLAY#*:}" ]; do 
 # Preset the resolution
 selkies-resize 1920x1080
 
+# Opt-in: disable screen blanking, DPMS, and screen lockers so a locked/blanked
+# session does not stop framebuffer capture (default off, current behavior unchanged).
+# See https://github.com/selkies-project/selkies/issues/174
+if [ "${SELKIES_DISABLE_SCREEN_BLANKING:-false}" = "1" ] || [ "$(echo "${SELKIES_DISABLE_SCREEN_BLANKING:-false}" | tr '[:upper:]' '[:lower:]')" = "true" ]; then
+  # Turn off the built-in X screen saver, screen blanking, and DPMS power management
+  xset s off || true
+  xset s noblank || true
+  xset -dpms || true
+  # Prevent common desktop screen lockers from autostarting and blanking the framebuffer on lock
+  mkdir -p "${HOME}/.config/autostart"
+  for locker in light-locker xscreensaver xfce4-screensaver gnome-screensaver mate-screensaver xss-lock; do
+    printf '[Desktop Entry]\nType=Application\nName=%s\nHidden=true\nX-GNOME-Autostart-enabled=false\n' "${locker}" > "${HOME}/.config/autostart/${locker}.desktop"
+  done
+fi
+
 # Start Xfce4 Desktop session
 [ "${START_XFCE4:-true}" = "true" ] && rm -rf ~/.config/xfce4 && vglrun -d "${VGL_DISPLAY:-egl}" /usr/bin/dbus-launch --exit-with-session /usr/bin/xfce4-session &
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,9 @@ services:
       # Additional server-side settings.
       SELKIES_ENABLE_RESIZE: ${SELKIES_ENABLE_RESIZE}
 
+      # Opt-in: disable screen blanking, DPMS, and screen lockers (default off), see issue #174.
+      SELKIES_DISABLE_SCREEN_BLANKING: ${SELKIES_DISABLE_SCREEN_BLANKING:-false}
+
       # DEBUG remote cursors
       SELKIES_DEBUG_CURSORS: ${SELKIES_DEBUG_CURSORS:-false}
 


### PR DESCRIPTION
## Summary

Addresses #174.

When Selkies captures the X framebuffer and a screensaver, DPMS blanking, or a desktop screen locker blanks the display, the WebRTC stream goes black and the user cannot interact with the session to unlock it. This adds an opt-in flag to the reference example container so operators can keep capture alive across those events.

## What this changes

A new environment variable, `SELKIES_DISABLE_SCREEN_BLANKING`, wired into `addons/example/entrypoint.sh`:

- Defaults to `false`. When unset or false, behavior is exactly as before, so nothing changes for existing users.
- When set to `true` (or `1`), right after the X server is ready and before the Xfce4 session starts, it:
  - runs `xset s off`, `xset s noblank`, and `xset -dpms` to turn off the built-in X screen saver, screen blanking, and DPMS power management;
  - writes `Hidden=true` XDG autostart overrides for the common lockers (`light-locker`, `xscreensaver`, `xfce4-screensaver`, `gnome-screensaver`, `mate-screensaver`, `xss-lock`) so the desktop session does not autostart them and blank the framebuffer on lock.

The variable is also surfaced in `docker-compose.yml` alongside the other `SELKIES_*` settings for discoverability. Naming and the on/off check follow the existing convention in the same entrypoint (for example `SELKIES_NGINX_OVERRIDE` and the lowercased `true` comparisons used for `SELKIES_ENABLE_HTTPS`).

## Notes

- Opt-in only. Default behavior is unchanged.
- This complements the documentation in PR #281, which describes the same workaround for operators who prefer to configure it by hand.
- `xset` is already available in the example image via `x11-xserver-utils`, and `xfce4-goodies` can pull in `xfce4-screensaver`, so the locker masking is relevant to this image.

## Testing

- `bash -n addons/example/entrypoint.sh` passes.
- With the flag unset, the entrypoint is equivalent in behavior to before, since the guarded block is skipped.
