### PR TITLE
fix(input): send the character keysym directly for typed and pasted uppercase

### DIFF
--- a/addons/selkies-web-core/lib/input.js
+++ b/addons/selkies-web-core/lib/input.js
@@ -2073,22 +2073,15 @@ export class Input {
         // Iterated per codepoint so an astral character (emoji, rare CJK) is sent
         // as one keysym instead of two lone surrogates the server cannot type.
         for (const char of text) {
-            const isUpperCase = char >= 'A' && char <= 'Z';
-            if (isUpperCase) {
-                this.send("kd," + KeyTable.XK_Shift_L);
-                const lowerChar = char.toLowerCase();
-                const letterKeysym = Keysyms.lookup(lowerChar.codePointAt(0));
-                if (letterKeysym) {
-                    this.send("kd," + letterKeysym);
-                    this.send("ku," + letterKeysym);
-                }
-                this.send("ku," + KeyTable.XK_Shift_L);
-            } else {
-                const keysym = Keysyms.lookup(char.codePointAt(0));
-                if (keysym) {
-                    this.send("kd," + keysym);
-                    this.send("ku," + keysym);
-                }
+            // Send the character's own keysym and let the server resolve the shift
+            // level, the same way the physical-keyboard path does. The previous
+            // uppercase branch injected Shift_L + the lowercase keysym instead, which
+            // dropped the case on deployments whose X keymap does not bind Shift as a
+            // real modifier, so pasted or typed capitals arrived lowercase (#295).
+            const keysym = Keysyms.lookup(char.codePointAt(0));
+            if (keysym) {
+                this.send("kd," + keysym);
+                this.send("ku," + keysym);
             }
         }
         event.target.value = '';


### PR DESCRIPTION
Fixes #295.

`_handleMobileInput` (the on-screen keyboard / clipboard re-type path) capitalised by injecting `Shift_L` down, then the LOWERCASE letter keysym, then `Shift_L` up, relying on the X server's Shift modifier. On deployments whose X keymap does not bind Shift as a real modifier (for example Xvfb-based bases that ship without a keymap), that Shift never engages and every uppercase letter arrives lowercase, while the physical-keyboard path is fine because it sends the uppercase keysym directly and lets the server resolve the shift level.

This makes the re-type path do the same: send the character's own keysym (an uppercase `A` looks up `XK_A`) and let the server resolve the level, instead of the fragile Shift injection. Lowercase, digits and symbols are unaffected; capitals now keep their case regardless of the deployment keymap.
