### PR TITLE
fix(input): request unadjusted movement for pointer lock (#294)

### DIFF
--- a/addons/selkies-web-core/lib/input.js
+++ b/addons/selkies-web-core/lib/input.js
@@ -2132,9 +2132,21 @@ export class Input {
             // requestPointerLock() returns undefined (not a Promise) on older
             // engines (Safari, Firefox < 122); failures there surface via the
             // pointerlockerror event instead.
-            const lockPromise = targetElement.requestPointerLock();
+            // Request unadjustedMovement first so relative-move deltas bypass
+            // the OS pointer-acceleration curve; engines that don't support
+            // the option reject with NotSupportedError, so retry without it.
+            const lockPromise = targetElement.requestPointerLock({ unadjustedMovement: true });
             if (lockPromise && typeof lockPromise.catch === 'function') {
-                lockPromise.catch(err => console.error("Pointer lock failed:", err));
+                lockPromise.catch(err => {
+                    if (err && err.name === 'NotSupportedError') {
+                        const fallback = targetElement.requestPointerLock();
+                        if (fallback && typeof fallback.catch === 'function') {
+                            fallback.catch(err2 => console.error("Pointer lock failed:", err2));
+                        }
+                        return;
+                    }
+                    console.error("Pointer lock failed:", err);
+                });
             }
             this.cursorDiv.style.visibility = 'hidden';
             event.preventDefault();
@@ -3168,14 +3180,27 @@ export class Input {
         // requestPointerLock() returns undefined (not a Promise) on older engines
         // (Safari, Firefox < 122); there the transition-race retry cannot run and
         // failures surface via the pointerlockerror event instead.
-        const lockPromise = this.element.requestPointerLock();
+        const onLockFailure = (err) => {
+            if (attempt < 5) {
+                setTimeout(() => this._armPointerLock(attempt + 1), 60);
+            } else {
+                console.warn("Pointer lock failed on fullscreen:", err);
+            }
+        };
+        // Request unadjustedMovement first (bypasses OS pointer-acceleration);
+        // engines that don't support it reject with NotSupportedError, so
+        // retry without it there rather than treating it as a real failure.
+        const lockPromise = this.element.requestPointerLock({ unadjustedMovement: true });
         if (lockPromise && typeof lockPromise.catch === 'function') {
             lockPromise.catch((err) => {
-                if (attempt < 5) {
-                    setTimeout(() => this._armPointerLock(attempt + 1), 60);
-                } else {
-                    console.warn("Pointer lock failed on fullscreen:", err);
+                if (err && err.name === 'NotSupportedError') {
+                    const fallback = this.element.requestPointerLock();
+                    if (fallback && typeof fallback.catch === 'function') {
+                        fallback.catch(onLockFailure);
+                    }
+                    return;
                 }
+                onLockFailure(err);
             });
         }
     }


### PR DESCRIPTION
Relates to #294.

## Problem
Pointer-lock relative mouse movement can feel inconsistent across browsers/OSes. The issue's own suggestion was a manual sensitivity multiplier, but @ehfd's comment on the issue points at the better fix: resolve the browser's relative-movement behavior properly rather than add a user-facing "handle" for people to fight the platform with.

## Fix
`requestPointerLock()` accepts an `{ unadjustedMovement: true }` option (Pointer Lock API v2) that bypasses the OS-level mouse-acceleration curve some platforms apply to `movementX`/`movementY`, giving raw hardware deltas instead. This PR requests it first at both call sites (`Input.js` manual Ctrl+Shift+click lock and `_armPointerLock`'s fullscreen auto-lock), and falls back to a plain `requestPointerLock()` specifically on `NotSupportedError` (the spec-defined rejection when the option isn't available), so engines without support behave exactly as before.

Chromium has supported this since M88; Firefox shipped it in Firefox 152. Older engines that return `undefined` instead of a Promise from `requestPointerLock()` (Safari, Firefox < 122) are unaffected by the extra option and keep working through the existing undefined-vs-Promise duck-typing check already in this code.

## Scope
This is deliberately the low-risk half of the fix. The other, harder half — normalizing Firefox's coalesced/throttled `movementX`/`movementY` event delivery under pointer lock via `PointerEvent.getCoalescedEvents()` — touches a hot input path and needs real cross-browser and real-hardware testing this environment can't provide, so it's left for a separate follow-up rather than bundled in here.

## Verification
`node --check addons/selkies-web-core/lib/input.js` passes. No test harness exists for this addon; this is a source-level review, not a runtime test — happy to adjust based on real browser testing feedback.
