### PR TITLE
fix(ci): derive wheels_ready from the wheel build instead of asserting it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,9 +105,8 @@ jobs:
     # The wheels are a dependency, not just an ordering constraint: the suites
     # run against the same main-HEAD capture stack the artifacts ship
     needs: [python-compat, pixelflux-pcmflux]
-    # Stated rather than left to the default: the wheels are built on pushes
-    # only, and a skip carries down the whole chain from wherever it starts. On
-    # a pull request the suites resolve the capture stack from PyPI instead.
+    # Stated rather than left to the default: the wheel build above is gated on
+    # pushes, and a skip carries down the whole chain from wherever it starts
     if: >-
       ${{ !cancelled()
           && needs.python-compat.result == 'success'
@@ -119,7 +118,12 @@ jobs:
     uses: ./.github/workflows/tests.yaml
     with:
       tiers: unit or integration
-      wheels_ready: true
+      # Read from the job that actually builds them rather than asserted: the
+      # build is gated on pushes, so on a pull request it skips and this is
+      # false, which is what lets tests.yaml fall back to building the wheels
+      # itself. Claiming true there would leave the suites on the last PyPI
+      # release of the capture stack instead of main HEAD.
+      wheels_ready: ${{ needs['pixelflux-pcmflux'].result == 'success' }}
 
   wheel:
     name: Build wheel


### PR DESCRIPTION
## What is broken

Every pull request runs its integration suite against the last **PyPI release** of `pixelflux`/`pcmflux` rather than the main-HEAD capture stack the artifacts ship, and nothing in the run says so louder than one `echo`. Any suite that exercises a capability added to `pixelflux` since that release therefore fails on every pull request, regardless of what the pull request changes.

## Why

Three lines that disagree with each other:

1. [`ci.yaml` L131-L133](https://github.com/selkies-project/selkies/blob/6c45895cb5679c61ede248b6d4c057540dc84eae/.github/workflows/ci.yaml#L131-L133) gates the wheel build on pushes:

   ```yaml
   pixelflux-pcmflux:
     name: Build pixelflux and pcmflux wheels (main HEAD)
     if: github.event_name == 'push'
   ```

2. [`ci.yaml` L122](https://github.com/selkies-project/selkies/blob/6c45895cb5679c61ede248b6d4c057540dc84eae/.github/workflows/ci.yaml#L122) nevertheless asserts the wheels are ready, unconditionally:

   ```yaml
   wheels_ready: true
   ```

3. [`tests.yaml` L85-L88](https://github.com/selkies-project/selkies/blob/6c45895cb5679c61ede248b6d4c057540dc84eae/.github/workflows/tests.yaml#L85-L88) has a fallback that would have covered exactly this case, and the assertion in (2) suppresses it:

   ```yaml
   wheels:
     name: Capture stack (main HEAD)
     if: ${{ !inputs.wheels_ready }}
   ```

So on a pull request: the wheel build skips, the fallback skips too because `wheels_ready` claims otherwise, the `download-artifact` steps are `continue-on-error: true` and find nothing, and the suites quietly land on PyPI.

## Evidence

From CI run [31380451724](https://github.com/selkies-project/selkies/actions/runs/31380451724) (a pull request):

```
skipped   Build pixelflux and pcmflux wheels (main HEAD)
skipped   Test suites / Capture stack (main HEAD)     <- the fallback, suppressed
failure   Test suites / Suites (unit or integration)
```

and in the suites log:

```
No main-HEAD wheels in this run: the suites use the PyPI pixelflux and pcmflux
capture stack: /opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/site-packages/pixelflux.cpython-312-x86_64-linux-gnu.so
...
FAILED tests/test_suites.py::test_suite[integration:test_keymap_parity]
AttributeError: 'builtins.ScreenCapture' object has no attribute 'set_keymap_overlay'.
    Did you mean: 'set_keymap_string'?
```

`set_keymap_overlay` is what [`input_handler.py` L312](https://github.com/selkies-project/selkies/blob/6c45895cb5679c61ede248b6d4c057540dc84eae/src/selkies/input_handler.py#L312) splices onto and what `test_keymap_parity.py` asserts against. It exists on main-HEAD `pixelflux` and not on the PyPI build, so that suite is red on every pull request and green on every push. This is not specific to one branch, it is the pull-request path itself.

## The fix

One value, read from the job that actually produces the wheels rather than asserted:

```yaml
wheels_ready: ${{ needs['pixelflux-pcmflux'].result == 'success' }}
```

`needs['pixelflux-pcmflux']` is already the accessor used by this job's own `if:` two lines up, and `needs` is in scope for `jobs.<id>.with`. It reads `true` on pushes, where the wheels were built earlier in the same run, and `false` on pull requests, which is what lets `tests.yaml` build them itself. The stale comment above the `if:` is updated to match. Nothing else changes.

## Does the fallback actually hold

Yes, and it is not a new code path. The nightly standalone `tests.yaml` run already takes it, because there `wheels_ready` defaults to `false`. Run [31358653193](https://github.com/selkies-project/selkies/actions/runs/31358653193):

```
success   Capture stack (main HEAD) / pixelflux (x86_64, manylinux)
success   Capture stack (main HEAD) / pixelflux (x86_64, musllinux)
success   Capture stack (main HEAD) / pixelflux (aarch64, manylinux)
success   Capture stack (main HEAD) / pixelflux (aarch64, musllinux)
success   Capture stack (main HEAD) / pcmflux (x86_64, manylinux)
... (8/8)
success   Suites (integration or e2e)
```

All eight matrix legs green, artifact names match the `pixelflux-wheels-*` / `pcmflux-wheels-*` download patterns in the suites job, and the `suites` gate (`needs.wheels.result == 'success' || 'skipped'`) accepts both branches. `actionlint 1.7.12` (the pinned version) passes over the whole workflow directory.

## Tradeoff worth naming

Pull requests now pay for the capture-stack build, eight `cibuildwheel` legs across `cp39`-`cp314`, where before they paid nothing and got a wrong answer. If that cost is unwelcome on the pull-request path, the cheaper shape is to parameterise `build-pixelflux-pcmflux-wheels.yaml` so a pull request builds only what the suites import (`cp312`, `manylinux_x86_64`) while pushes keep the full matrix. That is a larger change than this one, so I have left it out. Happy to follow up with it if you prefer that direction.

## Scope

CI wiring only, one file, no test or source changes. Found while working on #297, whose failing `test_keymap_parity` had nothing to do with the pointer-lock change in it.
