### PR TITLE
stop nvml spam, swap to crf as default, revert icon loading to png

### DIFF
--- a/addons/selkies-dashboard-wish/src/components/dashboard/settings.tsx
+++ b/addons/selkies-dashboard-wish/src/components/dashboard/settings.tsx
@@ -132,17 +132,8 @@ const STREAMING_MODES = [STREAM_MODE_WEBSOCKETS, STREAM_MODE_WEBRTC];
 const DEFAULT_STREAM_MODE = STREAM_MODE_WEBSOCKETS;
 
 const rateControlOptions = ["cbr", "crf"];
-// Rate control resolves through the shared precedence ladder with CBR as the
-// dashboard default for every encoder (the conditional layer and the
-// no-server-settings fallback alike); locked/pinned/server-explicit values and
-// the server's allowed list still win, and CRF stays user-selectable.
-const RATE_CONTROL_CBR_DEFAULT_SPEC = {
-    ...RATE_CONTROL_SPEC,
-    conditional: () => "cbr",
-    fallback: "cbr",
-};
 const readHidpiStored = readExplicitStored(HIDPI_SPEC);
-const readRateControlStored = readExplicitStored(RATE_CONTROL_CBR_DEFAULT_SPEC);
+const readRateControlStored = readExplicitStored(RATE_CONTROL_SPEC);
 // Expressed in kbps
 const DEFAULT_VIDEO_BITRATE = 8000;
 
@@ -244,7 +235,7 @@ export function Settings() {
     const [hidpiEnabled, setHidpiEnabled] = useConditionalSetting(
         HIDPI_SPEC, serverSettings, conditionalCtx, [serverSettings], readHidpiStored);
     const [rateControlMode, setRateControlMode] = useConditionalSetting(
-        RATE_CONTROL_CBR_DEFAULT_SPEC, serverSettings, conditionalCtx, [serverSettings], readRateControlStored);
+        RATE_CONTROL_SPEC, serverSettings, conditionalCtx, [serverSettings], readRateControlStored);
     // With rate control disabled the server ignores rate_control_mode entirely
     // and keeps the encoder on its built-in default, so the dashboard neither
     // pushes a mode nor lets its own pick decide which quality slider is shown.
@@ -258,21 +249,21 @@ export function Settings() {
     useEffect(() => {
         if (!serverSettings) return;
         if (serverSettings.enable_rate_control?.value === false) return;
-        const rcKey = RATE_CONTROL_CBR_DEFAULT_SPEC.storageKey;
+        const rcKey = RATE_CONTROL_SPEC.storageKey;
         const resolved = resolveSpec(
-            RATE_CONTROL_CBR_DEFAULT_SPEC, serverSettings, conditionalCtx, readRateControlStored);
+            RATE_CONTROL_SPEC, serverSettings, conditionalCtx, readRateControlStored);
         // The core persists every mode it is told to apply and resends it on the
         // next connect. Without an explicit pick that stored echo is not a choice:
         // drop it once it stops matching what the ladder resolves, or it would
         // outlive the derivation — and an operator override with it.
-        if (!isExplicitChoice(RATE_CONTROL_CBR_DEFAULT_SPEC)
+        if (!isExplicitChoice(RATE_CONTROL_SPEC)
             && readStored(rcKey) !== null && readStored(rcKey) !== resolved) {
             localStorage.removeItem(getPrefixedKey(rcKey));
         }
-        if (isSettingPinned(RATE_CONTROL_CBR_DEFAULT_SPEC, serverSettings, readRateControlStored)) return;
-        const serverValue = serverSettings[RATE_CONTROL_CBR_DEFAULT_SPEC.serverKey]?.value;
+        if (isSettingPinned(RATE_CONTROL_SPEC, serverSettings, readRateControlStored)) return;
+        const serverValue = serverSettings[RATE_CONTROL_SPEC.serverKey]?.value;
         if (resolved && serverValue !== undefined && resolved !== serverValue) {
-            writeConditional(RATE_CONTROL_CBR_DEFAULT_SPEC, resolved, setRateControlMode, { persist: false });
+            writeConditional(RATE_CONTROL_SPEC, resolved, setRateControlMode, { persist: false });
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [serverSettings]);
@@ -666,12 +657,12 @@ export function Settings() {
         // Rate control follows the encoder unless pinned (explicit client/server
         // choice). A derived change is not persisted, so it keeps following.
         if (rateControlEnabled
-            && !isSettingPinned(RATE_CONTROL_CBR_DEFAULT_SPEC, serverSettings, readRateControlStored)) {
+            && !isSettingPinned(RATE_CONTROL_SPEC, serverSettings, readRateControlStored)) {
             const rcResolved = resolveSpec(
-                RATE_CONTROL_CBR_DEFAULT_SPEC, serverSettings,
+                RATE_CONTROL_SPEC, serverSettings,
                 { ...conditionalCtx, activeEncoder: selectedEncoder }, readRateControlStored);
             if (rcResolved !== rateControlMode) {
-                writeConditional(RATE_CONTROL_CBR_DEFAULT_SPEC, rcResolved, setRateControlMode, { persist: false });
+                writeConditional(RATE_CONTROL_SPEC, rcResolved, setRateControlMode, { persist: false });
             }
         }
     };
@@ -690,7 +681,7 @@ export function Settings() {
 
     const handleRateControlChange = (mode: string) => {
         // Explicit choice: pin it (persist) so encoder changes stop overriding.
-        writeConditional(RATE_CONTROL_CBR_DEFAULT_SPEC, mode, setRateControlMode, { persist: true });
+        writeConditional(RATE_CONTROL_SPEC, mode, setRateControlMode, { persist: true });
     };
 
     const handleVideoBitRateChange = (selectedBitRate: number) => {

--- a/addons/selkies-dashboard/index.html
+++ b/addons/selkies-dashboard/index.html
@@ -14,7 +14,6 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <link rel="apple-touch-icon" href="icon.png">
     <link rel="manifest" href="manifest.json" crossorigin="use-credentials">
-    <link rel="icon" type="image/svg+xml" href="selkies.svg">
     <link rel="icon" type="image/png" href="icon.png" />
   </head>
   <body>

--- a/addons/selkies-dashboard/src/components/Sidebar.jsx
+++ b/addons/selkies-dashboard/src/components/Sidebar.jsx
@@ -144,15 +144,6 @@ const audioBitrateOptions = [32000, 48000, 64000, 96000, 128000, 192000, 256000,
 const DEFAULT_VIDEO_BITRATE = 8000;
 const RATE_CONTROL_CBR = "cbr";
 const RATE_CONTROL_CRF = "crf";
-// Rate control resolves through the shared precedence ladder with CBR as the
-// dashboard default for every encoder (the conditional layer and the
-// no-server-settings fallback alike); locked/pinned/server-explicit values and
-// the server's allowed list still win, and CRF stays user-selectable.
-const RATE_CONTROL_CBR_DEFAULT_SPEC = {
-  ...RATE_CONTROL_SPEC,
-  conditional: () => RATE_CONTROL_CBR,
-  fallback: RATE_CONTROL_CBR,
-};
 
 // Sub-Mbps CBR stops (kbps) for constrained links, ahead of the whole-Mbps
 // range (1000-kbps steps).
@@ -714,7 +705,7 @@ const explicitChoiceKey = (spec) => `${getPrefixedKey(spec.storageKey)}${EXPLICI
 const isExplicitChoice = (spec) => localStorage.getItem(explicitChoiceKey(spec)) === "true";
 const readExplicitStored = (spec) => (key) => (isExplicitChoice(spec) ? readStored(key) : null);
 const readHidpiStored = readExplicitStored(HIDPI_SPEC);
-const readRateControlStored = readExplicitStored(RATE_CONTROL_CBR_DEFAULT_SPEC);
+const readRateControlStored = readExplicitStored(RATE_CONTROL_SPEC);
 
 // Drives a conditional setting: lazy init + re-resolve whenever the server
 // settings or any dependency in `deps` changes (server-sync AND encoder/manual-
@@ -1105,7 +1096,7 @@ function Sidebar() {
   const [hidpiEnabled, setHidpiEnabled] = useConditionalSetting(
     HIDPI_SPEC, serverSettings, conditionalCtx, [serverSettings], readHidpiStored);
   const [rateControlMode, setRateControlMode] = useConditionalSetting(
-    RATE_CONTROL_CBR_DEFAULT_SPEC, serverSettings, conditionalCtx, [serverSettings], readRateControlStored);
+    RATE_CONTROL_SPEC, serverSettings, conditionalCtx, [serverSettings], readRateControlStored);
   const [usePaintOverQuality, setUsePaintOverQuality] = useConditionalSetting(
     USE_PAINT_OVER_QUALITY_SPEC, serverSettings, conditionalCtx, [serverSettings]);
   const [videoFullColor, setVideoFullColor] = useConditionalSetting(
@@ -1402,21 +1393,21 @@ function Sidebar() {
   useEffect(() => {
     if (!serverSettings) return;
     if (serverSettings.enable_rate_control?.value === false) return;
-    const rcKey = RATE_CONTROL_CBR_DEFAULT_SPEC.storageKey;
+    const rcKey = RATE_CONTROL_SPEC.storageKey;
     const resolved = resolveSpec(
-      RATE_CONTROL_CBR_DEFAULT_SPEC, serverSettings, conditionalCtx, readRateControlStored);
+      RATE_CONTROL_SPEC, serverSettings, conditionalCtx, readRateControlStored);
     // The core persists every mode it is told to apply and resends it on the next
     // connect. Without an explicit pick that stored echo is not a choice: drop it
     // once it stops matching what the ladder resolves, or it would outlive the
     // derivation — and an operator override with it.
-    if (!isExplicitChoice(RATE_CONTROL_CBR_DEFAULT_SPEC)
+    if (!isExplicitChoice(RATE_CONTROL_SPEC)
       && readStored(rcKey) !== null && readStored(rcKey) !== resolved) {
       localStorage.removeItem(getPrefixedKey(rcKey));
     }
-    if (isSettingPinned(RATE_CONTROL_CBR_DEFAULT_SPEC, serverSettings, readRateControlStored)) return;
-    const serverValue = serverSettings[RATE_CONTROL_CBR_DEFAULT_SPEC.serverKey]?.value;
+    if (isSettingPinned(RATE_CONTROL_SPEC, serverSettings, readRateControlStored)) return;
+    const serverValue = serverSettings[RATE_CONTROL_SPEC.serverKey]?.value;
     if (resolved && serverValue !== undefined && resolved !== serverValue) {
-      writeConditional(RATE_CONTROL_CBR_DEFAULT_SPEC, resolved, setRateControlMode, { persist: false });
+      writeConditional(RATE_CONTROL_SPEC, resolved, setRateControlMode, { persist: false });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [serverSettings]);
@@ -1729,12 +1720,12 @@ function Sidebar() {
     // Rate control follows the encoder unless pinned (explicit client/server
     // choice). A derived change is not persisted, so it keeps following.
     if (rateControlEnabled
-      && !isSettingPinned(RATE_CONTROL_CBR_DEFAULT_SPEC, serverSettings, readRateControlStored)) {
+      && !isSettingPinned(RATE_CONTROL_SPEC, serverSettings, readRateControlStored)) {
       const rcResolved = resolveSpec(
-        RATE_CONTROL_CBR_DEFAULT_SPEC, serverSettings,
+        RATE_CONTROL_SPEC, serverSettings,
         { ...conditionalCtx, activeEncoder: selectedEncoder }, readRateControlStored);
       if (rcResolved !== rateControlMode) {
-        writeConditional(RATE_CONTROL_CBR_DEFAULT_SPEC, rcResolved, setRateControlMode, { persist: false });
+        writeConditional(RATE_CONTROL_SPEC, rcResolved, setRateControlMode, { persist: false });
       }
     }
   };
@@ -1796,7 +1787,7 @@ function Sidebar() {
   };
   const handleRateControlChange = (event) => {
     // Explicit choice: pin it (persist) so encoder changes stop overriding.
-    writeConditional(RATE_CONTROL_CBR_DEFAULT_SPEC, event.target.value, setRateControlMode, { persist: true });
+    writeConditional(RATE_CONTROL_SPEC, event.target.value, setRateControlMode, { persist: true });
   };
   const handleAudioInputChange = (event) => {
     const deviceId = event.target.value;

--- a/addons/selkies-web-core/lib/conditional-settings.js
+++ b/addons/selkies-web-core/lib/conditional-settings.js
@@ -4,11 +4,11 @@
 // and (via the dashboards' thin useConditionalSetting hook) init + server-sync +
 // dependency re-derivation are all generic. Adding a setting is one more spec.
 
-// Rate-control default per encoder when nothing explicit is chosen: the striped
-// software encoder and jpeg are quality-driven (CRF); the single-slice software
-// encoders target a bandwidth (CBR).
+// Rate-control default per encoder when nothing explicit is chosen: the H.264
+// encoders and jpeg are quality-driven (CRF), except openh264enc, which targets
+// a bandwidth (CBR).
 export const ENCODER_RC_DEFAULTS = {
-    "h264enc": "cbr",
+    "h264enc": "crf",
     "openh264enc": "cbr",
     "h264enc-striped": "crf",
     "jpeg": "crf",

--- a/src/selkies/gpu_stats.py
+++ b/src/selkies/gpu_stats.py
@@ -45,7 +45,9 @@ logger = logging.getLogger("gpu_stats")
 if GPUMonitorFactory is not None:
     logging.getLogger("aitop.core.gpu.factory").setLevel(logging.WARNING)
 
-_nvml_ready = False
+# None = not attempted, True = initialized, False = failed (terminal for this
+# process: the shared library cannot appear after startup, so never retry).
+_nvml_ready = None
 
 # utilization.gpu is a percentage; memory.* are MiB (nounits strips the suffix);
 # pci.bus_id keys the stats to the render node the pipeline encodes on.
@@ -104,14 +106,15 @@ def _vendor_of_node(dri_node, root=None):
 def _nvml_gpus():
     """NVIDIA via NVML: no subprocess, exact per-device PCI identity."""
     global _nvml_ready
-    if pynvml is None:
+    if pynvml is None or _nvml_ready is False:
         return []
-    if not _nvml_ready:
+    if _nvml_ready is None:
         try:
             pynvml.nvmlInit()
             _nvml_ready = True
         except Exception as exc:
-            logger.debug("NVML init failed: %s", exc)
+            _nvml_ready = False
+            logger.debug("NVML init failed (will not retry): %s", exc)
             return []
     gpus = []
     try:

--- a/src/selkies/settings.py
+++ b/src/selkies/settings.py
@@ -1324,12 +1324,12 @@ class AppSettings:
         """
         return bool(getattr(self, "_overridden", {}).get(name, False))
 
-    # Rate-control default per encoder: the striped software encoder and jpeg
-    # are quality-driven (CRF), the single-slice software encoders target a
-    # bandwidth (CBR). An explicit rate_control_mode override wins; encoders
-    # not listed keep the built-in default.
+    # Rate-control default per encoder: the H.264 encoders and jpeg are
+    # quality-driven (CRF), except openh264enc, which targets a bandwidth
+    # (CBR). An explicit rate_control_mode override wins; encoders not
+    # listed keep the built-in default.
     ENCODER_RC_DEFAULTS = {
-        "h264enc": "cbr",
+        "h264enc": "crf",
         "openh264enc": "cbr",
         "h264enc-striped": "crf",
         "jpeg": "crf",


### PR DESCRIPTION
Given the wide deployment CRF should still be default for websockets mode. 

NVML does not need to be checked for on repeat so just fail fast. 

On our images we extensively catalogue and only use PNGs for the icon, adding the svg as default breaks this for us. 

I was tempted to just restore the wtype fallback stuff for clipboard, but in general KDE is busted for input and clipboard interactions, the logic removed from input_handler needs to be re-added. To address this under the new design format ext_data_control_manager_v1 needs to be implemented in dcclient.rs in pixelflux and plumbed into input_handler for use on non unicode characters. Just in general I would diff out input_handler on lsio branch and main there is alot of crap in there but a lot of it is for very specific reasons through iterative development with native speakers. 