### PR TITLE
fix(input): send the character's own keysym for pasted/typed uppercase (lsio)

### DIFF
--- a/addons/selkies-web-core/lib/input.js
+++ b/addons/selkies-web-core/lib/input.js
@@ -1598,24 +1598,17 @@ export class Input {
         if (!text) {
             return;
         }
+        // Send each character's OWN keysym directly; the server resolves the shift
+        // level for it. The previous per-character Shift_L-wrap-around-lowercase-keysym
+        // approach (still used nowhere else in this file) depended on the X keymap
+        // correctly binding Shift as a real modifier -- when it doesn't, the Shift_L
+        // press/release around the lowercase keysym is silently swallowed and every
+        // uppercase character arrives lowercase.
         for (let i = 0; i < text.length; i++) {
-            const char = text[i];
-            const isUpperCase = char >= 'A' && char <= 'Z';
-            if (isUpperCase) {
-                this.send("kd," + KeyTable.XK_Shift_L);
-                const lowerChar = char.toLowerCase();
-                const letterKeysym = Keysyms.lookup(lowerChar.charCodeAt(0));
-                if (letterKeysym) {
-                    this.send("kd," + letterKeysym);
-                    this.send("ku," + letterKeysym);
-                }
-                this.send("ku," + KeyTable.XK_Shift_L);
-            } else {
-                const keysym = Keysyms.lookup(char.charCodeAt(0));
-                if (keysym) {
-                    this.send("kd," + keysym);
-                    this.send("ku," + keysym);
-                }
+            const keysym = Keysyms.lookup(text.charCodeAt(i));
+            if (keysym) {
+                this.send("kd," + keysym);
+                this.send("ku," + keysym);
             }
         }
         event.target.value = '';


### PR DESCRIPTION
**Reference the issue numbers and reviewers**

@ehfd @thelamer — re-applies my own #296 (issue #295) to the `lsio` branch, which has neither #296 nor its later `main`-branch form (`4edd73a`). Downstream report this is blocking: [junkerderprovinz/krusader#27](https://github.com/junkerderprovinz/krusader/issues/27).

**Explain relevant issues and how this pull request solves them**

`_handleMobileInput` in `addons/selkies-web-core/lib/input.js` wraps uppercase letters in explicit `Shift_L` down/up around a LOWERCASE keysym instead of sending the uppercase character's own keysym. On `lsio`'s server side this doesn't work: `input_handler.py` routes alpha keysyms through `pynput`, while `Shift_L` goes through a separate `xdotool` path with no shared modifier state, so the held Shift is silently dropped and every pasted/typed uppercase character arrives lowercase. This is exactly what #295/#296 originally fixed on `main`, and what `4edd73a` later folded into a bigger commit — neither has reached `lsio`.

**Describe the changes in code and its dependencies and justify that they work as intended after testing**

`_handleMobileInput` now looks up and sends each character's own keysym directly — exactly what its own (unmodified) non-uppercase branch, and this file's other two text-injection paths (`_handleTextInput`, `_updateCompositionText`), already do on `lsio`. Also removes a stuck-Shift hazard: the old raw `Shift_L` send bypassed `_keyDownList` bookkeeping, so a lost release left Shift held with nothing tracking it.

**Not live-tested end-to-end in a running browser session** — I don't have a build/runtime environment for this repo set up. What I did verify:
- Direct comparison to this file's two other (unmodified, already-correct) text-injection paths.
- A full trace through `lsio`'s actual `input_handler.py` confirming the mechanism above.
- A brute-force equivalence check (all non-`A-Z` UTF-16 code units) that the new unconditional loop body is behaviorally identical to the untouched half of the old branch.
- `node --check` on the resulting file.

Happy to do a real browser test if there's a quick way to spin up a dev build — just didn't want to hold the PR on that.

**Describe alternatives you've considered**

Porting `main`'s `4edd73a` wholesale. Rejected: it also carries the chord-modifier double-type guard (`_chordModifierHeld`/`_noteMomentaryChordMods`/`_keysymHeld`), plus unrelated GPU-probe/container-entrypoint/TURN changes — none of that exists on `lsio`, and pulling it in is well out of scope for this fix. I checked that the chord-modifier guard predates `4edd73a` (already present at `4edd73a^`), so it isn't a companion fix for this specific change and leaving it out doesn't leave a regression behind.

**Additional context**

- `docker-baseimage-selkies` hard-pins a specific commit (`git checkout -f 348bc4f...` in its Dockerfile), not the `lsio` branch HEAD, so merging this alone doesn't reach downstream images (Krusader/HandBrake and other Selkies-based Unraid containers) until that pin is separately bumped afterward. I'll follow up there once/if this lands.
- I know `lsio` isn't the usual target for outside PRs — happy to close this and take a different route (an issue instead, or waiting for a pin bump past a `main` sync) if that's preferred. Figured a concrete diff was more useful than just asking.
- `main` also switched to codepoint iteration (`for...of` + `codePointAt`) for astral characters in this same area; `lsio` uses UTF-16 code units throughout this file (matching `_handleTextInput`'s existing style here), so I left that alone to keep this change minimal. Can add it if you'd rather have it.

 - [x] I confirm that this pull request is relevant to the scope of this project. If you know that upstream projects are the cause of this problem, please file the pull request there.
 - [x] I confirm that this pull request has been tested thoroughly and to the best of my knowledge that additional unintended problems do not arise. *(see testing note above — static verification, not a live browser session)*
 - [x] I confirm that the style of the changed code conforms to the overall style of the project.
 - [x] I confirm that I have read other open and closed pull requests and that duplicates do not exist.
 - [x] I confirm that I have justified the need for this pull request and that the changes reflect the fix for the specified problem.
 - [x] I confirm that no portion of this pull request contains credentials or other private information, and it is my own responsibility to protect my privacy.
 - [x] I confirm that the authors of this pull request does not willfully breach or infringe legal regulations, in any and all global law, regarding trademarks, trade names, logos, patents, or any and all other forms of external intellectual property, as well as adhering to software license terms of open-source and proprietary software projects.
