### PR TITLE
clipboard: sync local clipboard on Ctrl/Cmd+V for Firefox and Safari

### DIFF
--- a/addons/selkies-web-core/selkies-ws-core.js
+++ b/addons/selkies-web-core/selkies-ws-core.js
@@ -2246,7 +2246,10 @@ document.addEventListener('DOMContentLoaded', () => {
     window.location.pathname.lastIndexOf('/') + 1
   );
 
-  window.addEventListener('focus', async () => {
+  // Read the local clipboard and forward it to the remote session. Runs on window
+  // focus (all browsers) and, for non-Chromium engines, on a real Ctrl/Cmd+V
+  // keydown as well -- see the keydown listener below for why.
+  async function readLocalClipboardAndSend() {
     if (isSharedMode || !window.clipboard_enabled || !clipboard_in_enabled) return;
 
     if (!enable_binary_clipboard) {
@@ -2255,11 +2258,11 @@ document.addEventListener('DOMContentLoaded', () => {
         .then((text) => {
           if (!text) return;
           sendClipboardData(text);
-          console.log("Sent clipboard text on focus via sendClipboardData");
+          console.log("Sent clipboard text via sendClipboardData");
         })
         .catch((err) => {
           if (err.name !== 'NotFoundError' && !err.message.includes('not focused')) {
-             console.warn(`Could not read text clipboard on focus: ${err.name} - ${err.message}`);
+             console.warn(`Could not read text clipboard: ${err.name} - ${err.message}`);
           }
         });
     } else {
@@ -2275,21 +2278,42 @@ document.addEventListener('DOMContentLoaded', () => {
           const blob = await clipboardItem.getType(imageType);
           const arrayBuffer = await blob.arrayBuffer();
           sendClipboardData(arrayBuffer, imageType);
-          console.log(`Sent binary clipboard on focus via sendClipboardData: ${imageType}, size: ${blob.size} bytes`);
+          console.log(`Sent binary clipboard via sendClipboardData: ${imageType}, size: ${blob.size} bytes`);
         } else if (clipboardItem.types.includes('text/plain')) {
           const blob = await clipboardItem.getType('text/plain');
           const text = await blob.text();
           if (!text) return;
           sendClipboardData(text);
-          console.log("Sent clipboard text (from binary-enabled path) on focus via sendClipboardData");
+          console.log("Sent clipboard text (from binary-enabled path) via sendClipboardData");
         }
       } catch (err) {
         if (err.name !== 'NotFoundError' && !err.message.includes('not focused')) {
-          console.warn(`Could not read clipboard using advanced API on focus: ${err.name} - ${err.message}`);
+          console.warn(`Could not read clipboard using advanced API: ${err.name} - ${err.message}`);
         }
       }
     }
-  });
+  }
+
+  window.addEventListener('focus', () => { readLocalClipboardAndSend(); });
+
+  // Firefox and Safari require real transient user activation before
+  // navigator.clipboard.read()/readText() may run; the focus listener above has
+  // none, so on those engines it silently fails or pops an ephemeral "Paste"
+  // permission prompt on every window focus instead (upstream issues #258,
+  // #234). Chromium has no such restriction and keeps using the focus listener
+  // alone. Mirror the sync onto the actual Ctrl/Cmd+V keydown for the other
+  // engines, which does carry transient activation. Never preventDefault: the
+  // keystroke must still reach the remote session.
+  if (!isChromium) {
+    window.addEventListener('keydown', (event) => {
+      if (isSharedMode || !window.clipboard_enabled || !clipboard_in_enabled) return;
+      if (!(event.ctrlKey || event.metaKey) || event.altKey || event.repeat) return;
+      // event.code (physical key position), not event.key, so this still fires
+      // on non-QWERTY layouts (e.g. event.key is 'м' for V on a Cyrillic layout).
+      if (event.code !== 'KeyV') return;
+      readLocalClipboardAndSend();
+    }, true);
+  }
 
   document.addEventListener('visibilitychange', async () => {
     if (isSharedMode) {


### PR DESCRIPTION
On `lsio`, `window.addEventListener('focus', ...)` in `selkies-ws-core.js` is the only trigger for reading the local browser clipboard and pushing it into the remote streamed session. `navigator.clipboard.readText()`/`.read()` require real transient user activation to succeed without a permission prompt; a `focus` event carries none. Chromium grants the read anyway; Firefox and Safari do not, so on those engines the read silently fails or pops an ephemeral "Paste" prompt on every window focus. This is documented in this repo's own FAQ (added via PR #224) and referenced in issues #258 and #234.

This PR adds a second trigger for the same existing read-and-send logic: a real Ctrl/Cmd+V keydown on non-Chromium browsers, which does carry transient activation. The focus listener stays unchanged for Chromium.

### Prior context

I opened PR #276 for this exact idea against `main` in July. The maintainer noted it was already covered by PR #254's larger merge. That merge, and `main`'s newer modular clipboard handling (`addons/selkies-web-core/lib/clipboard-sync.js`), never landed on `lsio` — `lsio`'s clipboard code is still the older, monolithic `selkies-ws-core.js` layout this PR targets directly.

### Scope

`main` separately carries commit `00ce7394046eb0b89f2bd1892492a348a23db780` ("Performance optimizations"), which contains this same Ctrl+V mechanism plus a much larger, unrelated rework: a video-pipeline change and a new clipboard *write* direction for Ctrl+C needing a new client/server request-response protocol not present on `lsio`. That commit does not apply to `lsio` cleanly (conflicts across roughly a dozen files) and is out of scope here. This PR only carries the read/paste direction, and I traced `sendClipboardData` and `isChromium` to confirm it has no dependency on the unported protocol pieces.

Two small deliberate differences from the upstream mechanism this was adapted from: the key check uses `event.code === 'KeyV'` (physical key position) instead of `event.key`, so it still works on non-QWERTY layouts; and an `event.repeat` guard avoids re-reading the clipboard on every repeat while the keys are held.

### Testing

Verified by static analysis and code tracing: the diff applies cleanly to current `lsio` HEAD, `node --check` passes, and I confirmed no dependency on the unported protocol pieces. **Not tested live end-to-end in a browser.** One caveat inherited from the mechanism this is adapted from: the keystroke itself reaches the remote session synchronously while the clipboard read settles asynchronously, so in principle the very first Ctrl+V after a local copy could deliver the previous clipboard content before the new one lands — a pre-existing characteristic, not something this PR introduces.
