### PR TITLE
fix(base): bind-mount the wheel set instead of copying it (535.61 MB per published image)

### DIFF
--- a/addons/base/Dockerfile
+++ b/addons/base/Dockerfile
@@ -308,9 +308,12 @@ RUN install -d /var/log/apt
 # latest PyPI release when `wheels/` is empty. When fresh pixelflux/pcmflux
 # wheels (built from the main HEAD of selkies-project/pixelflux and
 # selkies-project/pcmflux) ride along, pip selects the ones matching this image's
-# Python and platform; everything else still resolves from PyPI
-COPY --chown=1000:1000 addons/base/wheels/ /tmp/wheels/
-RUN set -e; \
+# Python and platform; everything else still resolves from PyPI.
+# `wheels/` is bind-mounted rather than copied: it holds every interpreter and
+# platform variant while this image installs only the matching ones, so a copy
+# would commit the whole set to a layer no later removal can reclaim.
+RUN --mount=type=bind,source=addons/base/wheels,target=/tmp/wheels \
+    set -e; \
     SELKIES_WHL="$(ls /tmp/wheels/selkies-*.whl 2>/dev/null || true)"; \
     if [ -z "${SELKIES_WHL}" ]; then \
       PKGS="${PYPI_PACKAGE}"; \
@@ -322,7 +325,7 @@ RUN set -e; \
       fi; \
     fi; \
     PIP_BREAK_SYSTEM_PACKAGES=1 pip3 install --no-cache-dir --retries 5 --timeout 60 --force-reinstall ${PKGS}; \
-    rm -rf /tmp/wheels /tmp/picked
+    rm -rf /tmp/picked
 
 # The DRI3-capable server replaces the distribution's /usr/bin/Xvfb; chowned
 # to the session user like the rest of the image so fakeroot-sudo apt can


### PR DESCRIPTION
`addons/base/Dockerfile` copies the staged wheel set into `/tmp/wheels/` in its own layer and removes it in the next `RUN`. The removal is a whiteout in a later layer, so the bytes stay in the image.

```dockerfile
COPY --chown=1000:1000 addons/base/wheels/ /tmp/wheels/   # layer is sealed here
RUN set -e; \
    ...
    rm -rf /tmp/wheels /tmp/picked                        # cannot reclaim the layer above
```

### What it costs, measured on the published images

Read from the ghcr.io manifests rather than inferred — the layer whose `created_by` is `COPY --chown=1000:1000 addons/base/wheels/ /tmp/wheels/ # buildkit`:

| tag | arch | this layer | image total | share |
|---|---|---|---|---|
| `main-ubuntu26.04` | amd64 | 535.61 MB | 1572.42 MB | 34.1% |
| `main-ubuntu26.04` | arm64 | 535.61 MB | 1564.62 MB | 34.2% |
| `main-debiantrixie` | amd64 | 535.61 MB | 1089.30 MB | 49.2% |
| `main-debiantrixie` | arm64 | 535.61 MB | 1069.16 MB | 50.1% |

**2142.44 MB across the four published manifests, 40.5% of all published bytes.**

Unpacking that layer from the registry gives 57 entries: pixelflux and pcmflux each at 7 interpreter versions x {manylinux, musllinux} x {aarch64, x86_64}, plus the selkies wheel. `images.yaml` stages them all (`cp dist/*.whl addons/base/wheels/`), and the `pip3 download --find-links` step then selects the one pair matching the image. An amd64 CPython 3.12 image installs 22.05 MiB of the 537.68 MiB it carries — **95.9% of the copied bytes are wheels for interpreters and architectures that image cannot load.**

### The change

Bind-mount the directory for the one `RUN` that reads it. The selection logic, the `PYPI_PACKAGE` fallback and the installed result are byte-for-byte unchanged; the wheels simply never enter a layer.

`rm -rf` now names only `/tmp/picked`: `/tmp/wheels` is a mount point for the duration of the step, and under `set -e` trying to remove it would fail the build. `/tmp/picked` is still created inside the layer, so it still needs removing.

### Why this is safe here

- **BuildKit is guaranteed.** `.github/actions/build-push` uses `docker/build-push-action@v7`, and the published layer history is already annotated `# buildkit`. No new build-system requirement.
- **The mount can be read-only.** Everything in the block only reads `/tmp/wheels` — `ls`, `pip3 install <path>`, and `pip3 download --find-links` writing to `--dest /tmp/picked`. Nothing writes into the mounted directory.
- **The empty-`wheels/` path still works.** `.gitkeep` keeps the directory present, `ls ... 2>/dev/null || true` still yields an empty `SELKIES_WHL`, and the build still falls back to `${PYPI_PACKAGE}`.
- **`--chown=1000:1000` is not needed.** It existed so the copied files were readable by the `USER 1000` layer; the mounted context files are world-readable and only read. Nothing after this step refers to `/tmp/wheels` — it is the only reference in the repository outside this block.

### What I have not done

I have not built the image — no Docker on the machine I prepared this on — so this is not verified by a build, and CI is the real check. What I did verify without one: the patch applies to current `main` (`8911106`); `sh -n` is clean on the modified `RUN` body; `/tmp/wheels` appears nowhere else in the repo; and the byte figures above come from the live registry, not from an estimate.

Happy to split, reshape or drop this if you would rather handle it differently.