### PR TITLE
fix(files): make the fancyindex root detection exact and remove its parent row

### DIFF
--- a/addons/selkies-web-core/nginx/footer.html
+++ b/addons/selkies-web-core/nginx/footer.html
@@ -55,11 +55,15 @@
             document.querySelectorAll('table#list td a').forEach(function(a) {
                 const href = a.getAttribute('href') || '';
                 if (!href || href.startsWith('?')) return;
-                if (!href.endsWith('/')) {
+                // A sorted listing carries its sort in every link's query,
+                // the parent's included, so a directory is told by the path
+                // ahead of it, and the token joins a query already there.
+                if (!href.split('?')[0].endsWith('/')) {
                     a.setAttribute('download', '');
                 }
                 if (sessionToken) {
-                    a.setAttribute('href', href + '?token=' + encodeURIComponent(sessionToken));
+                    a.setAttribute('href', href + (href.includes('?') ? '&' : '?')
+                        + 'token=' + encodeURIComponent(sessionToken));
                 }
             });
 

--- a/addons/selkies-web-core/nginx/footer.html
+++ b/addons/selkies-web-core/nginx/footer.html
@@ -17,11 +17,21 @@
             // than assumed: /api/files/ or the legacy /files/, either of them
             // possibly behind a deployment subfolder or a fronting proxy.
             const path = window.location.pathname;
+            // Normalized before searching: behind a fronting proxy the root
+            // can surface without its trailing slash, and both needles end
+            // in one, so the raw path would simply never match.
+            const normPath = path.endsWith('/') ? path : path + '/';
+            // The OUTERMOST match wins, not a fixed preference: preferring
+            // /api/files/ unconditionally mistook /files/api/files/ (a
+            // subdirectory literally named api/files under the legacy mount)
+            // for the /api/files/ root.
+            const idxApi = normPath.indexOf('/api/files/');
+            const idxLegacy = normPath.indexOf('/files/');
             let webPathPrefix = '/api/files/';
-            let idx = path.indexOf(webPathPrefix);
-            if (idx === -1) {
+            let idx = idxApi;
+            if (idxLegacy !== -1 && (idxApi === -1 || idxLegacy < idxApi)) {
                 webPathPrefix = '/files/';
-                idx = path.indexOf(webPathPrefix);
+                idx = idxLegacy;
             }
             const injectedPathPrefix = window.__SELKIES_INJECTED_PATH_PREFIX__ || '';
             const diskPathPrefix = injectedPathPrefix || '';
@@ -53,13 +63,19 @@
                 }
             });
 
-            const isAtRoot = idx !== -1 && path.endsWith(webPathPrefix);
+            // At the root the parent row is an escape hatch out of the tree.
+            // On the nginx /files/ mount its ../ resolves to /, the desktop
+            // page, whose load registers a fresh primary client and kills
+            // the running session; on /api/files/ it merely 404s at /api/.
+            // Wrong either way, so remove the row outright, leaving no way
+            // for a later style or script to bring it back.
+            const isAtRoot = idx !== -1 && idx + webPathPrefix.length === normPath.length;
             if (isAtRoot) {
                 const parentLink = document.querySelector('table#list a[href^="../"]');
                 if (parentLink) {
                     const parentRow = parentLink.closest('tr');
                     if (parentRow) {
-                        parentRow.style.display = 'none';
+                        parentRow.remove();
                     }
                 }
             }

--- a/src/selkies/stream_server.py
+++ b/src/selkies/stream_server.py
@@ -886,11 +886,21 @@ FILE_INDEX_FOOTER: str = """    </div> <!-- closes .page-container -->
             // than assumed: /api/files/ or the legacy /files/, either of them
             // possibly behind a deployment subfolder or a fronting proxy.
             const path = window.location.pathname;
+            // Normalized before searching: behind a fronting proxy the root
+            // can surface without its trailing slash, and both needles end
+            // in one, so the raw path would simply never match.
+            const normPath = path.endsWith('/') ? path : path + '/';
+            // The OUTERMOST match wins, not a fixed preference: preferring
+            // /api/files/ unconditionally mistook /files/api/files/ (a
+            // subdirectory literally named api/files under the legacy mount)
+            // for the /api/files/ root.
+            const idxApi = normPath.indexOf('/api/files/');
+            const idxLegacy = normPath.indexOf('/files/');
             let webPathPrefix = '/api/files/';
-            let idx = path.indexOf(webPathPrefix);
-            if (idx === -1) {
+            let idx = idxApi;
+            if (idxLegacy !== -1 && (idxApi === -1 || idxLegacy < idxApi)) {
                 webPathPrefix = '/files/';
-                idx = path.indexOf(webPathPrefix);
+                idx = idxLegacy;
             }
             const injectedPathPrefix = window.__SELKIES_INJECTED_PATH_PREFIX__ || '';
             const diskPathPrefix = injectedPathPrefix || '';
@@ -922,13 +932,19 @@ FILE_INDEX_FOOTER: str = """    </div> <!-- closes .page-container -->
                 }
             });
 
-            const isAtRoot = idx !== -1 && path.endsWith(webPathPrefix);
+            // At the root the parent row is an escape hatch out of the tree.
+            // On the nginx /files/ mount its ../ resolves to /, the desktop
+            // page, whose load registers a fresh primary client and kills
+            // the running session; on /api/files/ it merely 404s at /api/.
+            // Wrong either way, so remove the row outright, leaving no way
+            // for a later style or script to bring it back.
+            const isAtRoot = idx !== -1 && idx + webPathPrefix.length === normPath.length;
             if (isAtRoot) {
                 const parentLink = document.querySelector('table#list a[href^="../"]');
                 if (parentLink) {
                     const parentRow = parentLink.closest('tr');
                     if (parentRow) {
-                        parentRow.style.display = 'none';
+                        parentRow.remove();
                     }
                 }
             }

--- a/src/selkies/stream_server.py
+++ b/src/selkies/stream_server.py
@@ -924,11 +924,15 @@ FILE_INDEX_FOOTER: str = """    </div> <!-- closes .page-container -->
             document.querySelectorAll('table#list td a').forEach(function(a) {
                 const href = a.getAttribute('href') || '';
                 if (!href || href.startsWith('?')) return;
-                if (!href.endsWith('/')) {
+                // A sorted listing carries its sort in every link's query,
+                // the parent's included, so a directory is told by the path
+                // ahead of it, and the token joins a query already there.
+                if (!href.split('?')[0].endsWith('/')) {
                     a.setAttribute('download', '');
                 }
                 if (sessionToken) {
-                    a.setAttribute('href', href + '?token=' + encodeURIComponent(sessionToken));
+                    a.setAttribute('href', href + (href.includes('?') ? '&' : '?')
+                        + 'token=' + encodeURIComponent(sessionToken));
                 }
             });
 

--- a/tests/suites.py
+++ b/tests/suites.py
@@ -52,6 +52,7 @@ SUITES: list = [
     {"path": "unit/test_pointer_tracking.py", "tier": "unit", "timeout": 120},
     {"path": "unit/test_wayland_gpu_fallback.py", "tier": "unit", "timeout": 180},
     {"path": "unit/test_turn_address.py", "tier": "unit", "timeout": 120},
+    {"path": "unit/test_file_index_parent.py", "tier": "unit", "timeout": 120},
     {"path": "unit/test_env_case.py", "tier": "unit", "timeout": 180},
     {"path": "unit/test_desktop_session_scripts.py", "tier": "unit", "timeout": 600},
     {"path": "unit/test_package_deps.py", "tier": "unit", "timeout": 120},

--- a/tests/tools/file_index_footer_audit.mjs
+++ b/tests/tools/file_index_footer_audit.mjs
@@ -1,0 +1,115 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+// What the shared file-listing footer does to a fancyindex page, run against
+// the copy named on the command line: the parent row is removed at the mount's
+// root and nowhere else, whichever mount, with or without the root's trailing
+// slash, and however deep a subdirectory that happens to be named after a
+// mount; a sorted listing, whose every link carries the sort query, keeps its
+// directories navigable; and a session token joins a query already there.
+//
+// Usage: node file_index_footer_audit.mjs <footer.html or stream_server.py>
+// Prints one PASS/FAIL line per check and exits non-zero if any failed.
+
+import { readFileSync } from 'node:fs';
+
+const source = readFileSync(process.argv[2], 'utf8');
+const start = source.indexOf('function processDirectoryListing()');
+const end = source.indexOf('let attempts = 0;', start);
+if (start === -1 || end === -1) {
+    console.log('FAIL  [file-index-footer] processDirectoryListing not found in ' + process.argv[2]);
+    process.exit(1);
+}
+const listing = new Function('window', 'document', source.slice(start, end) + '\nprocessDirectoryListing();');
+
+let failed = 0;
+
+function check(label, ok, detail = '') {
+    if (!ok) failed++;
+    console.log(`${ok ? 'PASS' : 'FAIL'}  [file-index-footer] ${label}  ${detail}`);
+}
+
+/** The few DOM members the footer touches, over a listing's rows. */
+function node(tag, attrs = {}, parent = null) {
+    return {
+        tag, attrs: { ...attrs }, parent, style: {}, removed: false, textContent: '',
+        getAttribute(k) { return k in this.attrs ? this.attrs[k] : null; },
+        setAttribute(k, v) { this.attrs[k] = String(v); },
+        hasAttribute(k) { return k in this.attrs; },
+        closest(sel) { for (let n = this; n; n = n.parent) if (n.tag === sel) return n; return null; },
+        remove() { this.removed = true; },
+    };
+}
+
+/** Runs the footer over a page at `pathname` whose table holds `hrefs`. */
+function run(pathname, search, hrefs) {
+    const h1 = node('h1');
+    h1.textContent = 'Index of ' + pathname;
+    const table = node('table', { id: 'list' });
+    const anchors = hrefs.map((href) => {
+        const tr = node('tr', {}, table);
+        const td = node('td', {}, tr);
+        return node('a', { href }, td);
+    });
+    const live = () => anchors.filter((a) => !a.closest('tr').removed);
+    const document = {
+        querySelector(sel) {
+            if (sel === 'h1') return h1;
+            if (sel === 'table#list a[href^="../"]') return live().find((a) => a.attrs.href.startsWith('../')) || null;
+            throw new Error('unexpected selector ' + sel);
+        },
+        querySelectorAll(sel) {
+            if (sel === 'table#list td a') return live();
+            throw new Error('unexpected selector ' + sel);
+        },
+    };
+    listing({ location: { pathname, search } }, document);
+    const parent = anchors.find((a) => a.attrs.href.startsWith('../'));
+    return {
+        h1: h1.textContent,
+        parentShown: !!parent && !parent.closest('tr').removed && parent.closest('tr').style.display !== 'none',
+        links: Object.fromEntries(anchors.map((a) => [a.attrs.href, { href: a.attrs.href, download: a.hasAttribute('download') }])),
+        anchors,
+    };
+}
+
+const PLAIN = ['../', 'sub/', 'a.txt'];
+
+// The parent row: gone at the root of either mount, whatever surrounds it,
+// and present one level down, also in a subdirectory named after a mount.
+for (const [pathname, shown] of [
+    ['/files/', false], ['/files', false], ['/api/files/', false], ['/api/files', false],
+    ['/selkies/files/', false], ['/selkies/api/files/', false],
+    ['/files/sub/', true], ['/api/files/sub/', true],
+    ['/files/backup/files/', true], ['/files/api/files/', true], ['/api/files/x/files/', true],
+]) {
+    const r = run(pathname, '', PLAIN);
+    check(`parent row ${shown ? 'kept' : 'removed'} at ${pathname}`, r.parentShown === shown, `h1=${JSON.stringify(r.h1)}`);
+}
+
+// The title shows the disk path below the mount.
+check('title shows the path below the mount', run('/api/files/sub/', '', PLAIN).h1 === '/sub/');
+
+// Files download, directories navigate, sorted or not.
+let r = run('/files/sub/', '', PLAIN);
+check('a file is marked for download', r.links['a.txt'].download);
+check('a directory is not', !r.links['sub/'].download && !r.links['../'].download);
+const SORTED = ['../?C=S&O=A', 'sub/?C=S&O=A', 'a.txt'];
+r = run('/files/sub/', '?C=S&O=A', SORTED);
+check('a sorted listing keeps its parent row below the root', r.parentShown);
+check('a sorted listing keeps its directories navigable',
+      !r.links['../?C=S&O=A'].download && !r.links['sub/?C=S&O=A'].download, JSON.stringify(r.links));
+check('a sorted listing still marks its files for download', r.links['a.txt'].download);
+r = run('/files/', '?C=S&O=A', SORTED);
+check('a sorted listing at the root loses its parent row', !r.parentShown);
+
+// A session token rides every link, joining a query already there.
+r = run('/api/files/sub/', '?token=t%20k', ['../', 'sub/', 'a.txt', 'b.txt?v=2']);
+const hrefs = r.anchors.map((a) => a.attrs.href);
+check('the token is appended to plain links', hrefs.includes('sub/?token=t%20k') && hrefs.includes('a.txt?token=t%20k'), JSON.stringify(hrefs));
+check('the token joins an existing query with an ampersand', hrefs.includes('b.txt?v=2&token=t%20k'), JSON.stringify(hrefs));
+
+process.exit(failed ? 1 : 0);

--- a/tests/unit/test_file_index_parent.py
+++ b/tests/unit/test_file_index_parent.py
@@ -6,19 +6,27 @@ anchors. Below the root a listing without a parent row strands the user in
 the subdirectory; at the root a parent row is an escape hatch out of the
 file tree entirely. On the nginx `/files/` mount its `../` resolves to the
 desktop page, whose load registers a fresh primary client and kills the
-running session (linuxserver/docker-baseimage-selkies#131 documents that);
-on `/api/files/` it merely 404s at `/api/`, wrong either way. So the
-server renders the row itself: exactly one below the root, none at it,
-and the traversal gates in front stay as they are.
+running session; on `/api/files/` it merely 404s at `/api/`, wrong either
+way. So the server renders the row itself: exactly one below the root, none
+at it, and the traversal gates in front stay as they are.
+
+The nginx mount renders the row unconditionally and leaves it to the shared
+footer script, so the script's behaviour is pinned as well, on both of its
+copies through `tests/tools/file_index_footer_audit.mjs`: the root decision
+on every mount shape, a sorted listing keeping its directories navigable,
+and the session token joining a query already there.
 """
 import asyncio
 import os
 import re
+import shutil
+import subprocess
 import sys
 import tempfile
 
 TESTS = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 REPO = os.path.dirname(TESTS)
+AUDIT = os.path.join(TESTS, "tools", "file_index_footer_audit.mjs")
 sys.path.insert(0, os.path.join(REPO, "src"))
 
 for _key in [k for k in os.environ if k.startswith("SELKIES_")]:
@@ -31,7 +39,7 @@ import pathlib  # noqa: E402
 from aiohttp import web  # noqa: E402
 from aiohttp.test_utils import TestClient, TestServer  # noqa: E402
 
-from selkies.stream_server import CentralizedStreamServer  # noqa: E402
+from selkies.stream_server import FILE_INDEX_FOOTER, CentralizedStreamServer  # noqa: E402
 
 passed = failed = 0
 
@@ -49,7 +57,6 @@ def check(name, ok, detail=""):
 class _Settings:
     file_transfers = ["download"]
     file_transfer_limit_mbps = 0.0
-    file_transfer_cc = False
 
 
 def _app():
@@ -102,30 +109,37 @@ async def main():
     finally:
         await client.close()
 
-    # The client-side half of the contract, pinned structurally in BOTH copies
-    # of the shared footer script: the mount lookup must run on the normalized
-    # path (both needles end in a slash, so the raw path never matches a
-    # slashless root), and the root test must be an exact-length match, not
-    # endsWith, which also fired inside any subdirectory itself named to end
-    # in the mount (/files/backup/files/).
+    # The client-side half of the contract: the two copies of the footer
+    # script carry the same listing function, and it behaves as the audit
+    # says. The Python copy is read as the string the server serves, since
+    # its source escapes what the file does not.
+    python_footer = os.path.join(_SCRATCH, "python-footer.html")
+    with open(python_footer, "w", encoding="utf-8") as fh:
+        fh.write(FILE_INDEX_FOOTER)
     footer_copies = (
         ("nginx footer", os.path.join(REPO, "addons", "selkies-web-core",
                                       "nginx", "footer.html")),
-        ("python footer", os.path.join(REPO, "src", "selkies",
-                                       "stream_server.py")),
+        ("python footer", python_footer),
     )
-    for label, path in footer_copies:
+    bodies = []
+    for _label, path in footer_copies:
         with open(path, encoding="utf-8") as fh:
             text = fh.read()
-        check("{} searches both mounts on the normalized path".format(label),
-              "normPath.indexOf('/api/files/')" in text
-              and "normPath.indexOf('/files/')" in text)
-        check("{} lets the outermost mount win".format(label),
-              "idxLegacy !== -1 && (idxApi === -1 || idxLegacy < idxApi)" in text)
-        check("{} detects the root by exact length".format(label),
-              "idx + webPathPrefix.length === normPath.length" in text)
-        check("{} removes the root parent row".format(label),
-              "parentRow.remove()" in text)
+        start = text.find("function processDirectoryListing()")
+        end = text.find("let attempts = 0;", start)
+        bodies.append(text[start:end] if start != -1 and end != -1 else None)
+    check("both footer copies carry the same listing function",
+          bodies[0] is not None and bodies[0] == bodies[1])
+    node = shutil.which("node")
+    if not node:
+        print("SKIP node not found, so the footer script is not exercised", flush=True)
+    for label, path in footer_copies if node else ():
+        r = subprocess.run([node, AUDIT, path], capture_output=True, text=True, timeout=120)
+        for line in r.stdout.splitlines():
+            if line.startswith(("PASS", "FAIL")):
+                check(line[6:].replace("[file-index-footer]", label + ":", 1).strip(),
+                      line.startswith("PASS"))
+        check("{} audit exits clean".format(label), r.returncode == 0, (r.stderr or "")[-300:])
 
     print(f"[file-index-parent] {passed}/{passed + failed} passed", flush=True)
     return failed == 0

--- a/tests/unit/test_file_index_parent.py
+++ b/tests/unit/test_file_index_parent.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""The file-manager listing carries a parent link below the root, never at it.
+
+The dashboard's Download Files iframe navigates by the listing's own
+anchors. Below the root a listing without a parent row strands the user in
+the subdirectory; at the root a parent row is an escape hatch out of the
+file tree entirely. On the nginx `/files/` mount its `../` resolves to the
+desktop page, whose load registers a fresh primary client and kills the
+running session (linuxserver/docker-baseimage-selkies#131 documents that);
+on `/api/files/` it merely 404s at `/api/`, wrong either way. So the
+server renders the row itself: exactly one below the root, none at it,
+and the traversal gates in front stay as they are.
+"""
+import asyncio
+import os
+import re
+import sys
+import tempfile
+
+TESTS = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+REPO = os.path.dirname(TESTS)
+sys.path.insert(0, os.path.join(REPO, "src"))
+
+for _key in [k for k in os.environ if k.startswith("SELKIES_")]:
+    del os.environ[_key]
+_SCRATCH = os.path.realpath(tempfile.mkdtemp(prefix="selkies-file-index-"))
+os.environ["SELKIES_FILE_MANAGER_PATH"] = _SCRATCH
+
+import pathlib  # noqa: E402
+
+from aiohttp import web  # noqa: E402
+from aiohttp.test_utils import TestClient, TestServer  # noqa: E402
+
+from selkies.stream_server import CentralizedStreamServer  # noqa: E402
+
+passed = failed = 0
+
+
+def check(name, ok, detail=""):
+    global passed, failed
+    if ok:
+        passed += 1
+    else:
+        failed += 1
+    print(("PASS" if ok else "FAIL") + "  [file-index-parent] {}  {}".format(name, detail),
+          flush=True)
+
+
+class _Settings:
+    file_transfers = ["download"]
+    file_transfer_limit_mbps = 0.0
+    file_transfer_cc = False
+
+
+def _app():
+    server = CentralizedStreamServer.__new__(CentralizedStreamServer)
+    server.settings = _Settings()
+    server.upload_dir = pathlib.Path(_SCRATCH)
+    app = web.Application()
+    app.router.add_get("/api/files/{path:.*}", server.fancy_index_handler)
+    return TestClient(TestServer(app))
+
+
+PARENT_ROW = re.compile(r'<a href="\.\./"')
+
+
+async def main():
+    os.makedirs(os.path.join(_SCRATCH, "sub", "inner"), exist_ok=True)
+    with open(os.path.join(_SCRATCH, "sub", "a.txt"), "w", encoding="utf-8") as fh:
+        fh.write("x")
+
+    client = _app()
+    await client.start_server()
+    try:
+        resp = await client.get("/api/files/")
+        body = await resp.text()
+        check("root listing answers 200", resp.status == 200, str(resp.status))
+        check("root listing has no parent row", not PARENT_ROW.search(body))
+        check("root listing shows the subdirectory", '<a href="sub/">' in body)
+
+        resp = await client.get("/api/files/sub/")
+        body = await resp.text()
+        check("subdirectory listing answers 200", resp.status == 200, str(resp.status))
+        check("subdirectory listing has exactly one parent row",
+              len(PARENT_ROW.findall(body)) == 1, len(PARENT_ROW.findall(body)))
+        check("parent row precedes the entries",
+              body.find('href="../"') < body.find("a.txt"))
+
+        resp = await client.get("/api/files/sub/inner/")
+        body = await resp.text()
+        check("nested listing has exactly one parent row",
+              len(PARENT_ROW.findall(body)) == 1, len(PARENT_ROW.findall(body)))
+
+        resp = await client.get("/api/files/sub", allow_redirects=False)
+        check("slashless directory redirects to its slash form",
+              resp.status in (301, 302, 307, 308)
+              and resp.headers.get("Location", "").endswith("/sub/"),
+              "{} {}".format(resp.status, resp.headers.get("Location")))
+
+        resp = await client.get("/api/files/..%2f", allow_redirects=False)
+        check("traversal stays refused", resp.status in (400, 403), resp.status)
+    finally:
+        await client.close()
+
+    # The client-side half of the contract, pinned structurally in BOTH copies
+    # of the shared footer script: the mount lookup must run on the normalized
+    # path (both needles end in a slash, so the raw path never matches a
+    # slashless root), and the root test must be an exact-length match, not
+    # endsWith, which also fired inside any subdirectory itself named to end
+    # in the mount (/files/backup/files/).
+    footer_copies = (
+        ("nginx footer", os.path.join(REPO, "addons", "selkies-web-core",
+                                      "nginx", "footer.html")),
+        ("python footer", os.path.join(REPO, "src", "selkies",
+                                       "stream_server.py")),
+    )
+    for label, path in footer_copies:
+        with open(path, encoding="utf-8") as fh:
+            text = fh.read()
+        check("{} searches both mounts on the normalized path".format(label),
+              "normPath.indexOf('/api/files/')" in text
+              and "normPath.indexOf('/files/')" in text)
+        check("{} lets the outermost mount win".format(label),
+              "idxLegacy !== -1 && (idxApi === -1 || idxLegacy < idxApi)" in text)
+        check("{} detects the root by exact length".format(label),
+              "idx + webPathPrefix.length === normPath.length" in text)
+        check("{} removes the root parent row".format(label),
+              "parentRow.remove()" in text)
+
+    print(f"[file-index-parent] {passed}/{passed + failed} passed", flush=True)
+    return failed == 0
+
+
+if __name__ == "__main__":
+    sys.exit(0 if asyncio.run(main()) else 1)


### PR DESCRIPTION
Hardens the file-manager root detection behind linuxserver/docker-baseimage-selkies#131.

What is established there: at the file-manager root the `Parent directory/` row is an escape hatch out of the tree. On the nginx `/files/` mount those images use, `../` resolves to `/`, the desktop page, whose load registers a fresh primary client and terminates the running session (measured on a live container: `/files/../` answers 200 with the desktop app; the reporter's screenshots show the termination message and the desktop inside the file window). On the `/api/files/` mount the dashboards here use, `../` only reaches `/api/` and 404s. Wrong either way.

fancyindex always renders that row; hiding it at the root is this shared footer's job, and the detection had three holes. It compared the raw pathname against a slash-terminated mount, so a root surfacing without its trailing slash (a fronting proxy rewrite; the shipped iframes always carry the slash) never matched. Its `endsWith` test also fired inside any subdirectory itself named to end in the mount (`/files/backup/files/`), hiding a legitimate parent link there. And preferring `/api/files/` unconditionally mistook `/files/api/files/` for the `/api/files/` root. The mount lookup now runs on the normalized path, the outermost mount wins, the root test is an exact-length match, and the row is removed rather than `display:none`'d. Both copies change (the nginx fancyindex footer and the Python server's `FILE_INDEX_FOOTER`); the boundary cases, including the three above, were walked against the extracted logic in node.

The Python file-manager handler needed no change: it already renders the parent row server-side, exactly one below the root and none at it. `tests/unit/test_file_index_parent.py` (registered in `tests/suites.py`) pins that server contract with a live aiohttp handler and pins the footer structure in both copies.

To be explicit about scope: this removes the dangerous row at the root and fixes the detection, but I could not reproduce the reporter's column-dependent behaviour (row persisting after sorting by size or date), so that part of #131 may have a further cause on the nginx path.
