### PR TITLE
fix(tests): Bound the waits that let a suite hang or read a frame rate too early

### DIFF
--- a/tests/core_lib.py
+++ b/tests/core_lib.py
@@ -3,7 +3,9 @@
 import json
 import os
 import platform
+import signal
 import sys
+import threading
 import time
 from typing import Any, Optional
 
@@ -104,6 +106,44 @@ def launch_browser(pw: Any, engine: str = "chromium") -> Any:
     if engine == "webkit":
         return pw.webkit.launch(headless=True)
     return chromium_launch(pw)
+
+
+def close_browser(closer: Any, timeout: float = 30) -> bool:
+    """Close a browser or persistent context, abandoning one that will not go.
+
+    An engine that wedges while tearing a session down blocks the close with no
+    deadline of its own, and the suite then reaches its own timeout and is
+    killed, which throws away every result it had already printed. The wait is
+    bounded here instead: the checks are done by the time anything closes, so a
+    browser that will not answer is reported and left to the driver to reap.
+
+    Args:
+        closer: The browser or persistent context to close.
+        timeout: Seconds to wait before giving up on it.
+
+    Returns:
+        Whether the close returned on its own.
+    """
+    def expired(signum: int, frame: Any) -> None:
+        raise TimeoutError(f"the browser did not close within {timeout:.0f}s")
+
+    if threading.current_thread() is not threading.main_thread():
+        # Only the main thread can take a signal; a caller off it closes plainly.
+        closer.close()
+        return True
+    previous = signal.signal(signal.SIGALRM, expired)
+    signal.setitimer(signal.ITIMER_REAL, timeout)
+    try:
+        closer.close()
+        return True
+    except TimeoutError as e:
+        print(f"note: {e}; abandoning it", flush=True)
+        return False
+    except Exception:
+        return True
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, previous)
 
 
 # Persistent Firefox profile: Firefox grants clipboard access only to a profile

--- a/tests/e2e/test_clipboard_reads.py
+++ b/tests/e2e/test_clipboard_reads.py
@@ -133,7 +133,7 @@ def drive(res: "H.Results", mode: str, engine: str, clipboard_in: bool) -> None:
                 res.check(f"{tag} a paste event still reaches the session", sent > 0,
                           f"sent={sent} policy/active={policy}")
         finally:
-            closer.close()
+            C.close_browser(closer)
 
 
 def main() -> "H.Results":

--- a/tests/e2e/test_encoders.py
+++ b/tests/e2e/test_encoders.py
@@ -185,8 +185,14 @@ def wait_video(page: Any, mode: str) -> Optional[dict]:
     return C.wait_ws_video(page, timeout=30) if mode == "websockets" else C.wait_wr_video(page)
 
 
-def wait_divert(page: Any, want: bool, timeout: float = 15) -> dict:
-    """Poll the divert state the core publishes until it matches, or time out."""
+def wait_divert(page: Any, want: bool, timeout: float = 15, presented: bool = False) -> dict:
+    """Poll the divert state the core publishes until it matches, or time out.
+
+    ``presented`` also waits for a frame to have been presented. The row layout
+    is published as the first stripes are decoded, while the frame rate is
+    counted over a window that closes later, so a caller asserting one has to
+    wait for it rather than for the rows that arrive before it.
+    """
     deadline = time.time() + timeout
     state = {}
     while time.time() < deadline:
@@ -195,7 +201,8 @@ def wait_divert(page: Any, want: bool, timeout: float = 15) -> dict:
           rows: Object.keys(window.videoStripeRows || {}).length,
           fps: window.fps || 0,
         })""")
-        if state["on"] == want and (not want or state["rows"] > 0):
+        settled = state["rows"] > 0 and (not presented or state["fps"] > 0)
+        if state["on"] == want and (not want or settled):
             return state
         time.sleep(0.5)
     return state
@@ -279,7 +286,7 @@ def block_striped(mode: str, wayland: bool, res: "H.Results") -> None:
                     res.check("striped: several H.264 stripes per frame on the wire",
                               video and is_striped(seen, video["h"]), seen)
                     res.check("striped: encoded in software", cpu_encoder(line), encoder_field(line))
-                    divert = wait_divert(page, True)
+                    divert = wait_divert(page, True, presented=True)
                     res.check("striped: the video worker decodes and presents it",
                               divert["on"] and divert["rows"] > 1 and divert["fps"] > 0, divert)
                     page.evaluate("window.__stripes = {}")

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -133,22 +133,34 @@ def pulse_setup() -> None:
     """Create the 'output' null sink the audio capture reads through its monitor
     source, matching the deployed layout. Module ids must not collide across
     restarts, so an existing sink is left alone. Without pactl the sink has to
-    exist already; only the audio checks depend on it."""
+    exist already; only the audio checks depend on it.
+
+    Every call is bounded, because a sound server that accepts a connection and
+    then stops answering would otherwise hold the suite that asked until its own
+    timeout killed it, with nothing said about where it stopped.
+    """
     pactl = shutil.which("pactl")
     if not pactl:
         print("note: pactl not found, leaving the audio sink as it is", flush=True)
         return
-    r = subprocess.run([pactl, "list", "short", "sources"],
-                       capture_output=True, text=True)
-    if "output.monitor" not in r.stdout:
-        subprocess.run(
-            [pactl, "load-module", "module-null-sink",
-             "sink_name=output", "rate=48000", "channels=2"],
-            capture_output=True, timeout=10)
+
+    def ask(*args: str) -> Optional[subprocess.CompletedProcess]:
+        try:
+            return subprocess.run([pactl, *args], capture_output=True, text=True, timeout=10)
+        except subprocess.TimeoutExpired:
+            print(f"note: pactl {args[0]} did not answer in 10s; "
+                  "leaving the audio sink as it is", flush=True)
+            return None
+
+    sources = ask("list", "short", "sources")
+    if sources is None:
+        return
+    if "output.monitor" not in sources.stdout:
+        ask("load-module", "module-null-sink",
+            "sink_name=output", "rate=48000", "channels=2")
     # Reset on every setup: a suite that pointed the default elsewhere and died
     # would otherwise leave every later audio check reading silence.
-    subprocess.run([pactl, "set-default-sink", "output"],
-                   capture_output=True, timeout=10)
+    ask("set-default-sink", "output")
 
 
 def pulse_null_sink(name: str, **opts: Any) -> Optional[str]:


### PR DESCRIPTION
The nightly run failed two suites. Both are waits that are shorter or looser than the thing they are waiting for, and neither is caused by what it tested.

## A frame rate read before it is counted

`test_encoders-ws-x11` reported `striped: the video worker decodes and presents it {'on': True, 'rows': 4, 'fps': 0}`. `wait_divert` returns as soon as the divert is on and the row layout is published, but the caller also asserts a frame rate, which the page counts over a window that closes later. So the poll can return with the rate still zero. The same suite proves it is a race rather than a fault: the identical state reads `fps: 41` and `fps: 52` at the two later checks, and the second of those passed in the same run.

The wait now takes the frame rate into account where a caller asserts it. Verified against a stub page whose rows appear at once and whose rate arrives two seconds later: the old call returns `fps: 0` immediately, the new one waits and returns `fps: 41`, and a worker that never presents still fails at the timeout rather than waiting forever.

## Two calls with no deadline at all

`test_clipboard_reads-webkit` was killed at its 900 second timeout with nothing printed after the sixth check, which throws away the results it had already produced. Every call in that stretch is bounded except two, so the suite could only have been in one of them:

- `pulse_setup` runs three `pactl` commands and gives a timeout to two of them. The first, `pactl list short sources`, has none, so a sound server that accepts a connection and then stops answering blocks the suite forever. This is reproducible: against a `pactl` that never returns, the old code was still blocked when killed at 25 seconds, and the fixed code returns in 10 with a note naming what did not answer. All three calls are bounded now.
- `closer.close()` waits on the browser with no deadline. An engine wedged while tearing a session down, which is what WebKit does after WebRTC, holds the suite until it is killed. `core_lib.close_browser` bounds that wait and reports a browser it had to abandon, leaving the suite free to finish and print. Verified both ways: a browser that closes returns immediately, one that will not is abandoned on time, and the alarm does not leak into what runs next.

For the record, that suite passes in 73 seconds on a quiet machine, so the failure was a hang and not slowness. The checks themselves are untouched.
