### PR TITLE
fix(webrtc): Measure transport-cc loss and goodput over the control interval

### DIFF
--- a/src/selkies/rtc.py
+++ b/src/selkies/rtc.py
@@ -273,9 +273,16 @@ class PipelineBridge:
                 a dropped ENCODED frame breaks the wire reference chain with no
                 RTP gap, so the browser never requests a PLI and the smear
                 would persist under infinite GOP.
+
+        Attributes:
+            dropped: Items dropped since construction. A drop here spends no
+                sequence number, so it appears in no loss statistic on either
+                side; this counter is the only place it is visible, and it is
+                what separates it from a pacer drop.
         """
         self._queue: asyncio.Queue = asyncio.Queue(maxsize=maxsize)
         self._on_drop = on_drop
+        self.dropped = 0
 
     def set_data(self, data: Any) -> None:
         """Enqueue an item, dropping the oldest one when the queue is full.
@@ -287,6 +294,7 @@ class PipelineBridge:
         """
         if self._queue.full():
             self._queue.get_nowait()
+            self.dropped += 1
             if self._on_drop is not None:
                 self._on_drop()
         self._queue.put_nowait(data)
@@ -1074,6 +1082,18 @@ class RTCApp:
                         bridge.set_data(packet)
                 except Exception as e:
                     logger.error(f"error processing audio sample: {e}")
+
+    def bridge_drops(self) -> Dict[str, int]:
+        """Frames each display's video bridge has dropped, by display id.
+
+        A drop happens before the sender packetizes, so no sequence number is
+        spent and neither `packetsLost` nor the pacer's counters move, while
+        the pictures that do go out reference one the client never got. Rising
+        here with those flat is a lagging consumer, not a lossy link.
+        """
+        return {did: graph["video_bridge"].dropped
+                for did, graph in self.displays.items()
+                if graph.get("video_bridge") is not None}
 
     def update_rtc_config(self, stun_servers: List[str], turn_servers: List[str]) -> None:
         """Update the STUN/TURN servers used for every NEW peer connection.

--- a/src/selkies/webrtc/rtcdtlstransport.py
+++ b/src/selkies/webrtc/rtcdtlstransport.py
@@ -424,6 +424,7 @@ class RTCDtlsTransport(AsyncIOEventEmitter):
         self._twcc_seq = 0
         self._twcc_history: dict[int, tuple[int, float]] = {}
         self.twcc_estimate: Optional[dict] = None
+        self._twcc_window = self._twcc_window_zero()
         # Receive side of transport-wide congestion control: a sender that
         # negotiates transport-cc runs its bandwidth estimation on this
         # feedback alone and starves at its floor bitrate without it.
@@ -959,6 +960,11 @@ class RTCDtlsTransport(AsyncIOEventEmitter):
             "recv_span_s": span_s,
             "goodput_bps": int(bytes_acked * 8 / span_s) if received else 0,
         }
+        window = self._twcc_window
+        window["received"] += received
+        window["lost"] += lost
+        window["bytes_acked"] += bytes_acked
+        window["span_s"] += span_s
         if self._pacer is not None and bytes_acked >= MIN_GOODPUT_SAMPLE_BYTES:
             # Windows carrying almost no data (pure keepalive / control)
             # carry no rate signal; feeding them to the pacer slams the pace.
@@ -969,6 +975,39 @@ class RTCDtlsTransport(AsyncIOEventEmitter):
             lost,
             self.twcc_estimate["goodput_bps"],
         )
+
+    @staticmethod
+    def _twcc_window_zero() -> dict:
+        return {"received": 0, "lost": 0, "bytes_acked": 0, "span_s": 0.0}
+
+    def take_twcc_window(self) -> Optional[dict]:
+        """Drain the transport-cc feedback accumulated since the last call.
+
+        One feedback packet covers a few tens of RTP packets over a few tens of
+        milliseconds, which is too little to measure either quantity: five lost
+        out of twenty-two reads as 22.7% loss, and a 17 ms receive span turns a
+        static screen's trickle into tens of Mbps. A control interval's worth of
+        feedback is the measurement. Draining also means an interval that
+        carried no feedback yields nothing to steer from, rather than the last
+        window to apply again.
+
+        Returns:
+            Loss and goodput over the drained interval, or None when no feedback
+            arrived in it.
+        """
+        window = self._twcc_window
+        packets = window["received"] + window["lost"]
+        if not packets:
+            return None
+        self._twcc_window = self._twcc_window_zero()
+        span_s = max(window["span_s"], 1e-4)
+        return {
+            "received": window["received"],
+            "lost": window["lost"],
+            "loss_fraction": window["lost"] / packets,
+            "bytes_acked": window["bytes_acked"],
+            "goodput_bps": int(window["bytes_acked"] * 8 / span_s) if window["received"] else 0,
+        }
 
     def _set_role(self, role: str) -> None:
         self._role = role

--- a/src/selkies/webrtc_mode.py
+++ b/src/selkies/webrtc_mode.py
@@ -2480,6 +2480,8 @@ class WebRTCService(BaseStreamingService):
                 if window["goodput_bps"]:
                     bucket["goodputs"].append(window["goodput_bps"])
                 bucket["worst_loss"] = max(bucket["worst_loss"], window["loss_fraction"])
+            if self.metrics is not None:
+                self.metrics.set_bridge_drops(rtc_app.bridge_drops())
             for did, bucket in per_display.items():
                 if not self.args.congestion_control:
                     continue

--- a/src/selkies/webrtc_mode.py
+++ b/src/selkies/webrtc_mode.py
@@ -2429,6 +2429,12 @@ class WebRTCService(BaseStreamingService):
         encoder within the allowed video_bitrate range — one display's congested
         link never steers another's stream. Only CBR mode has a target to steer.
 
+        Each peer's feedback is drained per tick, so a decision is taken over a
+        tick's worth of it rather than whichever window landed last: a single
+        window is a few tens of packets, too few for its loss fraction to mean
+        anything, and a display that sends little (a still second screen) is
+        made of such windows. A tick that drains nothing steers nothing.
+
         The user-selected bitrate is the ceiling: control only backs off below
         it and recovers up to it. Clamping to the allowed range instead let a
         fast local segment ramp an 8000 kbps session to 80000+ kbps, saturating
@@ -2465,15 +2471,15 @@ class WebRTCService(BaseStreamingService):
                             self.metrics.set_pacer_snapshot(did, dtls.pacer_snapshot())
                     except Exception:
                         logger.exception("_ensure_pacer failed (display %s)", did)
-                sctp = getattr(pc, "sctp", None)
-                estimate = getattr(getattr(sctp, "transport", None), "twcc_estimate", None)
-                if not estimate:
+                transport = getattr(getattr(pc, "sctp", None), "transport", None)
+                window = transport.take_twcc_window() if transport is not None else None
+                if window is None:
                     continue
                 bucket = per_display.setdefault(
                     did, {"goodputs": [], "worst_loss": 0.0})
-                if estimate.get("goodput_bps"):
-                    bucket["goodputs"].append(estimate["goodput_bps"])
-                bucket["worst_loss"] = max(bucket["worst_loss"], estimate.get("loss_fraction", 0.0))
+                if window["goodput_bps"]:
+                    bucket["goodputs"].append(window["goodput_bps"])
+                bucket["worst_loss"] = max(bucket["worst_loss"], window["loss_fraction"])
             for did, bucket in per_display.items():
                 if not self.args.congestion_control:
                     continue

--- a/src/selkies/webrtc_utils.py
+++ b/src/selkies/webrtc_utils.py
@@ -1112,6 +1112,9 @@ class Metrics:
         webrtc_pacer_pace_bps: Pacer gauges are per display and exist only
             while a pacer is attached; the event counters are cumulative
             since transport start.
+        webrtc_bridge_dropped_frames: Per display, cumulative since the graph
+            was built; unlike the pacer counters it is published whether or not
+            a pacer is attached.
         prev_stats_video_header_names: Header names of the video CSV (and
             `prev_stats_audio_header_names` for audio), tracked alongside the
             lengths so a same-count field swap still triggers a remap.
@@ -1145,6 +1148,9 @@ class Metrics:
             'webrtc_pacer_idr_floor_bytes', 'IDR floor of the pacer video queue budget in bytes', ['display'])
         self.webrtc_pacer_events = Gauge(
             'webrtc_pacer_events', 'Cumulative pacer event counter', ['display', 'event'])
+        self.webrtc_bridge_dropped_frames = Gauge(
+            'webrtc_bridge_dropped_frames',
+            'Encoded frames dropped before packetization, per display', ['display'])
         self.stats_video_file_path: Optional[str] = None
         self.stats_audio_file_path: Optional[str] = None
         self.prev_stats_video_header_len: Optional[int]  = None
@@ -1175,6 +1181,11 @@ class Metrics:
                       "idr_resurrects", "timeout_resurrects", "stale_resets"):
             self.webrtc_pacer_events.labels(display, event).set(snap.get(event, 0))
 
+    def set_bridge_drops(self, drops: Dict[str, int]) -> None:
+        """Publish each display's bridge drop count (see `RTCApp.bridge_drops`)."""
+        for display, dropped in drops.items():
+            self.webrtc_bridge_dropped_frames.labels(display or "primary").set(dropped)
+
     def set_gpu_utilization(self, utilization: float) -> None:
         self.gpu_utilization.set(utilization)
 
@@ -1200,7 +1211,8 @@ class Metrics:
         for collector in (self.fps, self.fps_hist, self.gpu_utilization,
                           self.latency, self.webrtc_statistics,
                           self.webrtc_pacer_pace_bps, self.webrtc_pacer_queue_bytes,
-                          self.webrtc_pacer_idr_floor_bytes, self.webrtc_pacer_events):
+                          self.webrtc_pacer_idr_floor_bytes, self.webrtc_pacer_events,
+                          self.webrtc_bridge_dropped_frames):
             try:
                 REGISTRY.unregister(collector)
             except KeyError:

--- a/tests/suites.py
+++ b/tests/suites.py
@@ -71,6 +71,7 @@ SUITES: list = [
     {"path": "unit/test_rate_control_defaults.py", "tier": "unit", "timeout": 180},
     {"path": "unit/test_transfer_pacer.py", "tier": "unit", "timeout": 180},
     {"path": "unit/test_webrtc_pacer_brake.py", "tier": "unit", "timeout": 120},
+    {"path": "unit/test_twcc_window.py", "tier": "unit", "timeout": 120},
     {"path": "unit/test_nvml_failfast.py", "tier": "unit", "timeout": 120},
     {"path": "unit/test_per_display_settings.py", "tier": "unit", "timeout": 120},
     {"path": "unit/test_realized_layout.py", "tier": "unit", "timeout": 120},

--- a/tests/unit/test_twcc_window.py
+++ b/tests/unit/test_twcc_window.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""What a transport-cc decision is allowed to be measured over.
+
+One feedback packet covers a few tens of RTP packets over a few tens of
+milliseconds. Its loss fraction and its goodput are noise at that size: five
+lost out of twenty-two reads as 22.7% loss, and a 17 ms receive span turns a
+still second screen's trickle into tens of Mbps. The failure this pins down:
+the congestion loop read whichever single window happened to land before its
+tick and never aged it, so one such window backed a display off 30% every
+second with no further feedback at all -- 40000 to 9604 kbps in four ticks --
+and the CBR encoder starved to a quarter of its target macroblocked while it
+climbed back.
+
+A control interval's worth of feedback is the measurement, and an interval
+that carried none steers nothing. A link that really is losing packets must
+still be backed off exactly as before.
+"""
+import os
+import struct
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "src"))
+from selkies.webrtc.rtcdtlstransport import RTCDtlsTransport  # noqa: E402
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import helpers as H  # noqa: E402
+
+PACKET_BYTES = 1200
+
+
+def feedback(base_seq: int, received: int, lost: int, delta_us: int = 1000) -> bytes:
+    """One transport-cc FCI: `received` acked, then `lost` missing, as run chunks."""
+    fci = struct.pack("!HH", base_seq, received + lost)
+    fci += bytes(3) + bytes(1)                              # reference time, feedback count
+    if received:
+        fci += struct.pack("!H", (1 << 13) | received)      # run of "received, small delta"
+    if lost:
+        fci += struct.pack("!H", lost)                      # run of "not received"
+    return fci + bytes([delta_us // 250]) * received
+
+
+def transport() -> RTCDtlsTransport:
+    """A transport with only the send-side congestion state a feedback needs."""
+    tr = object.__new__(RTCDtlsTransport)
+    tr._twcc_seq = 0
+    tr._twcc_history = {}
+    tr.twcc_estimate = None
+    tr._pacer = None
+    tr._twcc_window = RTCDtlsTransport._twcc_window_zero()
+    return tr
+
+
+def deliver(tr: RTCDtlsTransport, base_seq: int, received: int, lost: int) -> None:
+    """Send `received + lost` packets, then feed back what the receiver saw."""
+    for i in range(received + lost):
+        tr._twcc_history[(base_seq + i) & 0xFFFF] = (PACKET_BYTES, 0.0)
+    tr._twcc_process_feedback(feedback(base_seq, received, lost))
+
+
+def main() -> int:
+    res = H.Results("twcc-window")
+
+    tr = transport()
+    deliver(tr, 100, 17, 5)
+    res.check("one window is too small to measure loss",
+              round(tr.twcc_estimate["loss_fraction"], 3) == 0.227,
+              tr.twcc_estimate["loss_fraction"])
+
+    window = tr.take_twcc_window()
+    res.check("the interval reports what the interval carried",
+              window["received"] == 17 and window["lost"] == 5,
+              window)
+    res.check("draining leaves nothing to apply again",
+              tr.take_twcc_window() is None)
+
+    # A second of a still screen's feedback: 20 windows, one of them the one
+    # above. Over the interval that is 5 packets in 440, not 5 in 22.
+    tr = transport()
+    for i in range(20):
+        base = 1000 + i * 22
+        deliver(tr, base, 17, 5) if i == 19 else deliver(tr, base, 22, 0)
+    window = tr.take_twcc_window()
+    res.check("a second of windows measures the second",
+              window["received"] + window["lost"] == 440 and window["lost"] == 5,
+              window)
+    res.check("and reads far below the backoff threshold",
+              window["loss_fraction"] < 0.02, window["loss_fraction"])
+    res.check("its goodput spans the interval, not one window",
+              window["goodput_bps"] > 0
+              and window["bytes_acked"] == window["received"] * PACKET_BYTES,
+              window)
+
+    tr = transport()
+    for i in range(20):
+        deliver(tr, 5000 + i * 22, 16, 6)
+    window = tr.take_twcc_window()
+    res.check("a link that really is lossy still reads lossy",
+              window["loss_fraction"] > 0.10, window["loss_fraction"])
+
+    tr = transport()
+    deliver(tr, 7000, 0, 22)
+    window = tr.take_twcc_window()
+    res.check("a fully lost interval reads as total loss with no goodput",
+              window["loss_fraction"] == 1.0 and window["goodput_bps"] == 0,
+              window)
+
+    return 0 if res.summary() else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fixes #329.

## What the report is

A congestion controller that backs a display off from one feedback window, and re-applies that window until fresh feedback replaces it.

`_twcc_process_feedback` publishes an estimate per transport-cc feedback packet. One such packet covers a few tens of RTP packets over a few tens of milliseconds. The loop read whichever one happened to land before its tick, and nothing aged it, so a tick with no new feedback applied the previous decision again.

Two consequences, both visible in the reported logs:

* **A window is too small to measure loss.** Five lost out of twenty-two reads as 22.7% — the figure in the report, from a sample that cannot resolve the 10% threshold it is compared against. A still second screen sends few packets, so its windows are the smallest and its loss fraction the noisiest.
* **Goodput is measured over one window's receive span.** A 17 ms span turns a static screen's trickle into tens of Mbps, which is why the reported goodputs swing between 1982 and 34903 kbps on a terminal that is not changing.

WebRTC resolves `rate_control_mode` to `cbr` (`resolve_rate_control_default`), so this steers every display, the primary included — not only the display the log names.

## Reproduction

Driving the shipped loop over the shipped parser, one 22-packet window with 5 lost and no further feedback at all:

```
40000 -> 28000 -> 19600 -> 13720 -> 9604 -> 6723 kbps
```

That is `40000 x 0.7^n`, and `9604` is the figure the follow-up comment reports the primary falling to. A CBR encoder held at a quarter of its target on high-motion content macroblocks, then climbs back at +15%/s and the cycle repeats — corruption that keeps returning while the panel still reads 30 fps.

## The change

A control interval's worth of feedback is the measurement. `take_twcc_window()` drains what accumulated since the last call; the loop drains once per peer per tick. An interval that carried no feedback yields nothing, so nothing is applied twice.

For the same still second screen this raises the sample from ~22 packets to the hundreds it actually sent in that second, which is what makes its loss fraction mean anything. A minimum-sample threshold was not added: the interval already is the sample, and a threshold would leave a genuinely lossy low-rate stream unregulated.

| | before | after |
| --- | --- | --- |
| one bad window, then silence | 40000 → 6723 | 40000 → 28000, applied once |
| a second carrying 5 lost in 440 (1.1%), ending on a bad window | 40000 → 6723 | 40000, no backoff |
| a link losing 27% every window | 40000 → 6723 | 40000 → 6723, unchanged |

The last row is the point: a link that really is congested is backed off exactly as before.

## Bridge drop counter

The second commit publishes `webrtc_bridge_dropped_frames{display}`, the encoded frames a display's `PipelineBridge` dropped.

A drop there happens before the sender packetizes, so no sequence number is spent: `packetsLost` stays flat, the pacer counters stay flat, and the pictures that do go out reference one the client never received. It was the one drop in the pipeline with no counter, which is why the report could only be chased through `chrome://webrtc-internals`. Rising here with the pacer's `video_dropped` flat is a lagging consumer; both rising together is the pacer.

It earned this immediately: a session whose video never reached the client showed 1550 bridge drops against zero pacer drops and zero packet loss.

## Testing

* `tests/unit/test_twcc_window.py`, new: what a decision may be measured over, that draining leaves nothing to re-apply, and that a genuinely lossy link still reads lossy.
* Unit tier: 82/82.
* Two displays over WebRTC on X11, 1920x936 primary under continuous motion plus a still 1512x748 secondary, both on NVENC H.264 CBR 40000 with `keyframe_interval=2`: both hold 30 fps with no PLI, no loss, no dropped frames, and `webrtc_bridge_dropped_frames` reads 0 per display throughout.
* `tests/e2e/test_two_displays.py webrtc-x11`: unchanged against this branch (the one failing check, the window-manager restart, fails identically without it on this host).

The reported cross-display coupling itself did not reproduce on an unconstrained loopback link: with the secondary up, the primary held 30 fps with zero loss and zero drops, and closing the secondary changed nothing but its own teardown resize. That path needs the constrained link the reporter has, which is where the statistics above are what drive the encoder.
