### PR TITLE
test: Give the suites a runtime directory of their own, end a desktop manager's whole process group, and say why a swap failed

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -44,7 +44,7 @@ every interpreter the package supports.
 | --- | --- | --- |
 | `E2E_DISPLAY` | none; required | X display the server streams from. Deliberately not defaulted and never inherited from `DISPLAY`: the suites inject input and resize the root window, so pointing them at a real session damages it. Provision a throwaway server (`Xvfb :N -screen 0 8192x4096x24 -noreset`) and name it here. |
 | `E2E_PORT` | a free port | Server port; everything the server exposes, `/api/metrics` included, is on it. Left unset each suite process takes its own, so runs do not have to be serialised. Set it when something in front of the server needs a fixed one. |
-| `E2E_WORKDIR` | `$TMPDIR/selkies-tests` | Server log, shim recordings and other scratch. Run through `pytest`, each suite's logs are also copied into `suite-logs/<suite>/` under it, which CI uploads. |
+| `E2E_WORKDIR` | `$TMPDIR/selkies-tests` | Server log, shim recordings and other scratch. Run through `pytest`, each suite's logs are also copied into `suite-logs/<suite>/` under it, which CI uploads. Its `run/` is the `XDG_RUNTIME_DIR` every compositor, observer and client the suites start is given, so their sockets never land in a desktop session's own. |
 | `SELKIES_TEST_PYTHON` | the interpreter running the tests | Interpreter the server under test runs on. |
 | `E2E_CHROME` | unset | System Chrome/Chromium binary. Unset uses Playwright's bundled Chromium. |
 | `E2E_FIREFOX_PROFILE` | `$E2E_WORKDIR/firefox-profile` | Persistent Firefox profile; clipboard permission does not survive a fresh one, and `tests/tools/fetch-openh264.sh` seeds the OpenH264 plugin into it. Firefox negotiates no H.264 without that plugin, and the WebRTC block skips. |

--- a/tests/e2e/test_clipboard_image.py
+++ b/tests/e2e/test_clipboard_image.py
@@ -45,7 +45,7 @@ def png(seed: int) -> bytes:
 
 def _wl_env() -> dict:
     return {**os.environ, "WAYLAND_DISPLAY": WL_SOCKET,
-            "XDG_RUNTIME_DIR": os.environ.get("XDG_RUNTIME_DIR", H.WORKDIR)}
+            "XDG_RUNTIME_DIR": H.RUNTIME_DIR}
 
 
 def session_image(wayland: bool) -> tuple:

--- a/tests/e2e/test_clipboard_pacing.py
+++ b/tests/e2e/test_clipboard_pacing.py
@@ -127,7 +127,7 @@ def push_clipboard(wayland: bool, payload: bytes) -> dict:
     """Put `payload` on the session clipboard as text, as an application would."""
     if wayland:
         env = {**os.environ, "WAYLAND_DISPLAY": "wayland-1",
-               "XDG_RUNTIME_DIR": os.environ.get("XDG_RUNTIME_DIR", H.WORKDIR)}
+               "XDG_RUNTIME_DIR": H.RUNTIME_DIR}
         proc = subprocess.Popen(["wl-copy", "-t", "text/plain"],
                                 stdin=subprocess.PIPE, env=env)
         proc.stdin.write(payload)

--- a/tests/e2e/test_pointer_lock.py
+++ b/tests/e2e/test_pointer_lock.py
@@ -42,6 +42,7 @@ locked movement deltas do not add up), on both transports and backends.
 import json
 import os
 import shutil
+import signal
 import subprocess
 import sys
 import threading
@@ -115,7 +116,7 @@ def at(pos: Optional[tuple], expected: tuple) -> bool:
 
 
 def runtime_dir() -> str:
-    return os.environ.get("XDG_RUNTIME_DIR", H.WORKDIR)
+    return H.RUNTIME_DIR
 
 
 class Desktop:
@@ -146,7 +147,7 @@ class Desktop:
             env = {**os.environ, "DISPLAY": display}
             cmd = ["openbox", "--replace"] if self.name == "openbox" else \
                 ["dbus-run-session", "--", "kwin_x11", "--replace"]
-            self.proc = H.spawn(cmd, env=env, stdout=log, stderr=subprocess.STDOUT)
+            self.proc = H.spawn(cmd, env=env, stdout=log, stderr=subprocess.STDOUT, start_new_session=True)
             return self._wait(lambda: self._x11_managed(display), f"{binary} never took the display")
         if not capture:
             self.why = "the capture compositor announced no socket"
@@ -161,7 +162,7 @@ class Desktop:
                 os.unlink(marker)
             env.update({"WLR_BACKENDS": "wayland", "WLR_WL_OUTPUTS": "1"})
             cmd = ["labwc", "-s", f"sh -c 'echo \"$WAYLAND_DISPLAY\" > {marker}'"]
-            self.proc = H.spawn(cmd, env=env, stdout=log, stderr=subprocess.STDOUT)
+            self.proc = H.spawn(cmd, env=env, stdout=log, stderr=subprocess.STDOUT, start_new_session=True)
             if not self._wait(lambda: os.path.exists(marker) and os.path.getsize(marker) > 0,
                               "labwc never published its socket"):
                 return False
@@ -175,7 +176,7 @@ class Desktop:
             cmd = ["dbus-run-session", "--", "kwin_wayland", "--wayland-display", capture,
                    "--socket", self.socket, "--width", str(WINDOW[0]), "--height", str(WINDOW[1]),
                    "--no-lockscreen", "--no-global-shortcuts", "--no-kactivities"]
-            self.proc = H.spawn(cmd, env=env, stdout=log, stderr=subprocess.STDOUT)
+            self.proc = H.spawn(cmd, env=env, stdout=log, stderr=subprocess.STDOUT, start_new_session=True)
             path = os.path.join(runtime_dir(), self.socket)
             if not self._wait(lambda: os.path.exists(path), "kwin_wayland never opened its socket"):
                 return False
@@ -212,16 +213,21 @@ class Desktop:
         return "window id" in out
 
     def stop(self) -> None:
+        """Ends the manager and everything it started: a KWin runs under
+        dbus-run-session, and ending only that would leave it holding the display
+        and its socket for the suites that follow."""
         if self.proc is None:
             return
-        try:
-            self.proc.terminate()
-            self.proc.wait(5)
-        except Exception:
+        for sig in (signal.SIGTERM, signal.SIGKILL):
             try:
-                self.proc.kill()
-            except Exception:
-                pass
+                os.killpg(os.getpgid(self.proc.pid), sig)
+            except (ProcessLookupError, PermissionError):
+                return
+            try:
+                self.proc.wait(5)
+                return
+            except subprocess.TimeoutExpired:
+                continue
 
 
 class GameProbe:

--- a/tests/e2e/test_wayland_layout_churn.py
+++ b/tests/e2e/test_wayland_layout_churn.py
@@ -49,7 +49,7 @@ def spawn_labwc(socket: str):
     if not shutil.which("labwc"):
         return None
     env = dict(os.environ, WAYLAND_DISPLAY=socket, WLR_BACKENDS="wayland",
-               XDG_RUNTIME_DIR=os.environ.get("XDG_RUNTIME_DIR", H.WORKDIR), WLR_WL_OUTPUTS="1")
+               XDG_RUNTIME_DIR=H.RUNTIME_DIR, WLR_WL_OUTPUTS="1")
     env.pop("DISPLAY", None)
     log = open(os.path.join(H.WORKDIR, "labwc.log"), "w")
     proc = H.spawn(["labwc"], env=env, stdout=log, stderr=subprocess.STDOUT)

--- a/tests/e2e/test_ws_unix_socket.py
+++ b/tests/e2e/test_ws_unix_socket.py
@@ -83,7 +83,7 @@ def spawn_server(log: str) -> subprocess.Popen:
     """A server bound to SOCK, logging to `log`; not waited for."""
     env = {"PATH": os.environ.get("PATH", ""), "HOME": os.path.expanduser("~"),
            "DISPLAY": H.require_display(),
-           "XDG_RUNTIME_DIR": os.environ.get("XDG_RUNTIME_DIR", H.WORKDIR),
+           "XDG_RUNTIME_DIR": H.RUNTIME_DIR,
            "SELKIES_MODE": "websockets", "SELKIES_ENABLE_BASIC_AUTH": "false",
            "SELKIES_ENABLE_HTTPS": "false", "SELKIES_WEB_ROOT": H.CORE_DIST,
            "SELKIES_PORT": str(H.PORT), "SELKIES_UNIX_SOCKET": SOCK}

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -63,6 +63,11 @@ WISH_DIST = os.path.join(REPO, "addons/selkies-dashboard-wish/dist")
 
 WORKDIR = os.environ.get("E2E_WORKDIR", os.path.join(tempfile.gettempdir(), "selkies-tests"))
 os.makedirs(WORKDIR, exist_ok=True)
+# The XDG runtime directory every compositor, observer and client the suites
+# start is given: the session's own would collect their sockets beside the
+# desktop's, and a stale socket there can be mistaken for a live compositor.
+RUNTIME_DIR = os.path.join(WORKDIR, "run")
+os.makedirs(RUNTIME_DIR, mode=0o700, exist_ok=True)
 LOG = os.path.join(WORKDIR, "selkies-server.log")
 PIDFILE = os.path.join(WORKDIR, "selkies-server.pid")
 
@@ -170,6 +175,28 @@ def pulse_setup() -> None:
     ask("set-default-sink", "output")
 
 
+def pulse_server() -> Optional[str]:
+    """The sound server's address as libpulse takes it in `PULSE_SERVER`, read
+    back from `pactl info`. The suites run their children under a runtime
+    directory of their own (`RUNTIME_DIR`), where libpulse would look for a
+    sound server that is not there; the one the suites set up listens under
+    the session's, so its address has to travel explicitly. An address the
+    environment already names wins."""
+    if os.environ.get("PULSE_SERVER"):
+        return os.environ["PULSE_SERVER"]
+    pactl = shutil.which("pactl")
+    if not pactl:
+        return None
+    try:
+        out = subprocess.run([pactl, "info"], capture_output=True, text=True, timeout=10).stdout
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    for line in out.splitlines():
+        if line.startswith("Server String:"):
+            return line.split(":", 1)[1].strip()
+    return None
+
+
 def pulse_null_sink(name: str, **opts: Any) -> Optional[str]:
     """Load a null sink named `name`, returning the module id to unload later.
 
@@ -251,7 +278,7 @@ def server_start(mode: str = "websockets", wayland: bool = False,
     env = {
         "PATH": os.environ.get("PATH", ""),
         "HOME": os.path.expanduser("~"),
-        "XDG_RUNTIME_DIR": os.environ.get("XDG_RUNTIME_DIR", WORKDIR),
+        "XDG_RUNTIME_DIR": RUNTIME_DIR,
         "SELKIES_PORT": str(port),
         "SELKIES_ENABLE_BASIC_AUTH": "false",
         "SELKIES_MODE": mode,
@@ -269,6 +296,9 @@ def server_start(mode: str = "websockets", wayland: bool = False,
         env["PYTHONWARNINGS"] = os.environ["PYTHONWARNINGS"]
     if not wayland:
         env["DISPLAY"] = require_display()
+    pulse = pulse_server()
+    if pulse:
+        env["PULSE_SERVER"] = pulse
     if extra_env:
         env.update(extra_env)
     with open(log, "w") as lf:
@@ -759,7 +789,7 @@ def _wl_env(socket_name: str) -> dict:
     the missing dependency it is.
     """
     return {**os.environ, "WAYLAND_DISPLAY": socket_name,
-            "XDG_RUNTIME_DIR": os.environ.get("XDG_RUNTIME_DIR", WORKDIR)}
+            "XDG_RUNTIME_DIR": RUNTIME_DIR}
 
 
 def wl_paste(socket_name: str, timeout: float = 6) -> str:
@@ -791,7 +821,7 @@ def wl_clear(socket_name: str, timeout: float = 12) -> None:
     subprocess.run(
         ["env", "WAYLAND_DISPLAY=" + socket_name, "wl-copy", "-c"],
         capture_output=True, timeout=timeout,
-        env={**os.environ, "XDG_RUNTIME_DIR": os.environ.get("XDG_RUNTIME_DIR", WORKDIR)})
+        env={**os.environ, "XDG_RUNTIME_DIR": RUNTIME_DIR})
 
 
 class WlObs:
@@ -802,7 +832,7 @@ class WlObs:
         self.proc = spawn(
             [PYTHON, os.path.join(TOOLS, "wlobs.py"), socket_name],
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
-            env={**os.environ, "XDG_RUNTIME_DIR": os.environ.get("XDG_RUNTIME_DIR", WORKDIR),
+            env={**os.environ, "XDG_RUNTIME_DIR": RUNTIME_DIR,
                  "WLOBS_DURATION": "60"})
         self.lines: list = []
         self._start_reader()

--- a/tests/integration/test_webrtc_unix_socket.py
+++ b/tests/integration/test_webrtc_unix_socket.py
@@ -27,7 +27,7 @@ os.path.exists(SOCK) and os.unlink(SOCK)
 
 env = {"PATH": os.environ.get("PATH", ""),
        "HOME": os.path.expanduser("~"), "DISPLAY": H.require_display(),
-       "XDG_RUNTIME_DIR": os.environ.get("XDG_RUNTIME_DIR", H.WORKDIR),
+       "XDG_RUNTIME_DIR": H.RUNTIME_DIR,
        "SELKIES_MODE": "webrtc", "SELKIES_ENABLE_BASIC_AUTH": "false",
        "SELKIES_WEB_ROOT": H.CORE_DIST,
        "SELKIES_TURN_REST_URI": ""}

--- a/tests/unit/test_wm_swap.py
+++ b/tests/unit/test_wm_swap.py
@@ -13,6 +13,7 @@ The decision is driven against stand-ins; the readers are then checked against
 a real Openbox on the test display, restarted for real.
 """
 import asyncio
+import logging
 import os
 import subprocess
 import sys
@@ -123,16 +124,26 @@ def live_openbox_check() -> None:
                   DU.wm_name_matches("openbox", name) and pid == proc.pid, (name, pid, proc.pid))
         res.check("and its command line is read back from /proc",
                   DU.wm_command(pid) == ["openbox", "--replace"], DU.wm_command(pid))
-        asyncio.run(DU.MultiMonitorWindowManager().ensure_for(2, False))
+        # What the restart said and which openbox processes are left are the
+        # record of a swap that did not happen, so a failure names its cause.
+        said: list = []
+        handler = logging.Handler()
+        handler.emit = lambda record: said.append(record.getMessage())
+        DU.logger_app_resize.addHandler(handler)
+        try:
+            asyncio.run(DU.MultiMonitorWindowManager().ensure_for(2, False))
+        finally:
+            DU.logger_app_resize.removeHandler(handler)
         deadline = time.time() + 10
         while time.time() < deadline and (proc.poll() is None
                                           or DU._sync_wm_pid() in (0, proc.pid)):
             time.sleep(0.2)
         new_pid = DU._sync_wm_pid()
+        procs = subprocess.run(["pgrep", "-a", "openbox"], capture_output=True, text=True).stdout.split("\n")
         res.check("the first extend restarts it: the old process exits and a new one manages",
                   proc.poll() is not None and new_pid not in (0, proc.pid)
                   and DU.wm_name_matches("openbox", DU._sync_wm_name()),
-                  (proc.poll(), new_pid, proc.pid))
+                  (proc.poll(), new_pid, proc.pid, said, [x for x in procs if x]))
         if new_pid not in (0, proc.pid):
             os.kill(new_pid, 15)
     finally:

--- a/tests/unit/test_wm_swap.py
+++ b/tests/unit/test_wm_swap.py
@@ -27,6 +27,7 @@ sys.path.insert(0, os.path.join(REPO, "src"))
 import helpers as H  # noqa: E402
 
 from selkies import display_utils as DU  # noqa: E402
+from selkies.Xlib import X, display as xdisplay  # noqa: E402
 
 res = H.Results("wm-swap")
 
@@ -96,6 +97,41 @@ res.check("the desktop image names no window manager",
           "MULTI_MONITOR_WM" not in open(DESKTOP_IMAGE, encoding="utf-8").read())
 
 
+def wm_manages_a_window(display: str, timeout: float = 15.0) -> float:
+    """Seconds until the manager lists a window mapped now, or -1.
+
+    Openbox publishes its check window well before its event loop runs, and a
+    map request or a replacement claimed in between is never acted on, so the
+    swap has to wait for a manager that answers. Each attempt maps a fresh
+    window and gives up on it after half a second.
+    """
+    d = xdisplay.Display(display)
+    try:
+        root = d.screen().root
+        listed = d.intern_atom("_NET_CLIENT_LIST")
+        started = time.monotonic()
+        while time.monotonic() - started < timeout:
+            w = root.create_window(0, 0, 1, 1, 0, d.screen().root_depth,
+                                   X.InputOutput, X.CopyFromParent)
+            w.set_wm_name("wm-probe")
+            w.map()
+            d.flush()
+            attempt = time.monotonic()
+            managed = False
+            while not managed and time.monotonic() - attempt < 0.5:
+                prop = root.get_full_property(listed, X.AnyPropertyType)
+                managed = bool(prop) and w.id in list(prop.value)
+                if not managed:
+                    time.sleep(0.02)
+            w.destroy()
+            d.flush()
+            if managed:
+                return time.monotonic() - started
+        return -1
+    finally:
+        d.close()
+
+
 def live_openbox_check() -> None:
     """The readers against a real Openbox, and a real restart of it."""
     if H.shutil.which("openbox") is None:
@@ -124,6 +160,9 @@ def live_openbox_check() -> None:
                   DU.wm_name_matches("openbox", name) and pid == proc.pid, (name, pid, proc.pid))
         res.check("and its command line is read back from /proc",
                   DU.wm_command(pid) == ["openbox", "--replace"], DU.wm_command(pid))
+        answered = wm_manages_a_window(display)
+        res.check("and it manages a window mapped now, so its startup is over",
+                  answered >= 0, answered)
         # What the restart said and which openbox processes are left are the
         # record of a swap that did not happen, so a failure names its cause.
         said: list = []


### PR DESCRIPTION
Three test-harness changes, no product code.

**Why.** With `openbox` now installed on the runner (added with the desktop selectors), `tests/unit/test_wm_swap.py` drives a real Openbox and its first-extend restart on CI, and the unit tier of the last main push failed that check with `(None, 10905, 10905)`: the old Openbox never exited and stayed the manager. The same check passes here (14/14), and the failure carries no reason because the restart reports through the `resize` logger, which the check did not capture.

**What changes.**
- `test_wm_swap.py`: the swap check captures what the restart logged and lists the Openbox processes left, so a runner failure names its cause (here it reads `restarting openbox to read the monitor set` and one new process).
- `helpers.py` and every suite that starts a compositor or connects to one: the suites now use a runtime directory of their own, `$E2E_WORKDIR/run`, as `XDG_RUNTIME_DIR` instead of the environment's. Run from a desktop session, the harness had been placing the capture compositor's socket, the observers' and the nested compositors' beside the session's own, where a stale one could pass for a live compositor. libpulse looks for the sound server under the same variable, so the server is also handed `PULSE_SERVER`, read back from `pactl info`, or the audio capture finds nothing (the clipboard-pacing suite's audio check caught exactly that on the first run of this change).
- `test_pointer_lock.py`: the desktop selectors start each manager in its own process group and end the whole group. A KWin runs under `dbus-run-session`; ending only that can leave the KWin itself running on the test display for the suites that follow, and it left the nested KWins' `wayland-kwin-*` sockets behind in the runtime directory.

**Confirmed.** Every suite that starts or connects to a compositor, run here on the new runtime directory with the desktop session's `/tmp/runtime-ubuntu` watched before and after (entry count unchanged, 2 to 2): pointer-lock ws-wl 25/25, wr-wl 25/25, ws-wl-labwc 26/26, ws-x11 23/23, ws-x11-kwin 24/24, ws-wl-kwin 25/25 (plus the recorded skip for the nested KWin delta check); layout churn websockets 5/5; clipboard image wayland 3/3 and websockets 3/3; clipboard pacing wayland 3/3 (the suite that had lost audio, now with 2 capture starts and no open failures in the server log); microphone audio websockets 7/7; ws unix socket 15/15; webrtc unix socket 4/4. After the runs the suite runtime directory held only the capture compositor's `wayland-1`, its lock and the `pulse` directory libpulse creates; no nested `wayland-kwin-*` socket and no manager process survived.

**The runner failure, found and fixed (second commit).** Openbox publishes its EWMH check window at the start of its own startup, well before its event loop runs, and a replacement claimed in between is never acted on: the running instance never logs the request and keeps managing, the incoming one waits 15 s for it and gives up. The suite asked for the swap the instant the check window appeared, which a slow runner turns into exactly that window. Reproduced here deterministically by stopping the first Openbox at its check window for 3 s: the committed suite fails with the runner's tuple, now with the detail `(None, <pid>, <pid>, ['Multi-monitor setup: restarting openbox to read the monitor set.'], [both openbox processes])`, on Python 3.12.14 and 3.14 alike. The guard maps a window and waits until the manager lists it, retrying with a fresh window every half second because map requests sent during that startup are dropped too. With it the suite passes 15/15 plain (3 runs on 3.14, 2 on 3.12) and under 3 s and 8 s freezes, the guard reporting how long it waited. Real sessions are not affected: the restart there replaces a manager that has been running for a long time. The product's `wait_for_wm` returning at once because the outgoing manager still matches by name is a separate matter for its own PR.

**Previously confirmed.** `test_wm_swap` 14/14 locally with the new detail; the `ws-x11-kwin` and `ws-wl-kwin` selectors pass with the group kill and leave no manager or socket behind (checked with `pgrep` and the runtime directory after the run).

**Side effects.** None on product code. The first CI run of this PR is what answers the runner-side question; if the restart still fails there, the detail now says whether the restart was attempted, what it logged and what survived.
