### PR TITLE
fix: Restart the window manager on WebRTC's first extend too, and hold the layout until the replacement manages

### DIFF
--- a/src/selkies/display_utils.py
+++ b/src/selkies/display_utils.py
@@ -1212,7 +1212,8 @@ class MultiMonitorWindowManager:
                 f"Multi-monitor setup: {running or 'no window manager'} keeps its "
                 "monitor set current; no restart.")
             return
-        command = wm_command(await current_wm_pid()) or [needing]
+        replacing = await current_wm_pid()
+        command = wm_command(replacing) or [needing]
         if "--replace" not in command:
             command.append("--replace")
         logger_app_resize.info(
@@ -1229,7 +1230,7 @@ class MultiMonitorWindowManager:
             return
         # Before the layout applies: a WM snapshotting the monitor set mid-swap
         # re-tiles maximized windows across the whole framebuffer.
-        if not await wait_for_wm(needing):
+        if not await wait_for_wm(needing, replacing):
             logger_app_resize.warning(
                 f"{needing} restart not confirmed; applying layout anyway.")
 
@@ -1273,20 +1274,24 @@ def wm_name_matches(command_name: str, wm_name: str) -> bool:
     return bool(want) and bool(have) and (want.startswith(have) or have.startswith(want))
 
 
-async def wait_for_wm(name_substring: str, timeout: float = 3.0) -> bool:
-    """Wait until the EWMH WM name is the window manager ``name_substring``
-    starts (`wm_name_matches`).
+async def wait_for_wm(name_substring: str, replacing: int = 0,
+                      timeout: float = 3.0) -> bool:
+    """Wait until the window manager ``name_substring`` starts is the one
+    running (`wm_name_matches`) and, given the process id of the one it
+    replaces, no longer that one.
 
     Used after a WM --replace so layout changes are not applied while two
-    window managers hand over the selection (the incoming WM snapshots the
-    monitor set it starts against).
+    window managers hand over the selection: the incoming WM snapshots the
+    monitor set it starts against, and the outgoing one answers to the same
+    name until it is gone.
 
     Returns:
-        True when the name matched within ``timeout`` seconds.
+        True when the manager matched within ``timeout`` seconds.
     """
     deadline = asyncio.get_running_loop().time() + timeout
     while True:
-        if wm_name_matches(name_substring, await current_wm_name()):
+        if wm_name_matches(name_substring, await current_wm_name()) and (
+                not replacing or await current_wm_pid() not in (0, replacing)):
             return True
         if asyncio.get_running_loop().time() >= deadline:
             return False

--- a/src/selkies/webrtc_mode.py
+++ b/src/selkies/webrtc_mode.py
@@ -1800,7 +1800,8 @@ class WebRTCService(BaseStreamingService):
                 self._broadcast_display_config()
                 return
             did, info = secondary
-            await self._wm_swap.ensure_for(len(self.display_clients), IS_WAYLAND)
+            # display_clients holds the secondaries; the primary counts too.
+            await self._wm_swap.ensure_for(len({"primary", *self.display_clients}), IS_WAYLAND)
             if self._primary_dims is None:
                 p_w, p_h = self.media_pipeline.width, self.media_pipeline.height
                 if IS_WAYLAND:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -825,15 +825,16 @@ def wl_clear(socket_name: str, timeout: float = 12) -> None:
 
 
 class WlObs:
-    """Drive the pywayland observer client (tests/tools/wlobs.py) against the
-    compositor and collect its JSONL event lines from a reader thread."""
+    """Drive a pywayland client from tests/tools against the compositor and
+    collect its JSONL event lines from a reader thread. `tool` names the client,
+    and any keyword arguments are added to its environment."""
 
-    def __init__(self, socket_name: str) -> None:
+    def __init__(self, socket_name: str, tool: str = "wlobs.py", **env: str) -> None:
         self.proc = spawn(
-            [PYTHON, os.path.join(TOOLS, "wlobs.py"), socket_name],
+            [PYTHON, os.path.join(TOOLS, tool), socket_name],
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
             env={**os.environ, "XDG_RUNTIME_DIR": RUNTIME_DIR,
-                 "WLOBS_DURATION": "60"})
+                 "WLOBS_DURATION": "60", **env})
         self.lines: list = []
         self._start_reader()
 

--- a/tests/integration/test_relative_injection.py
+++ b/tests/integration/test_relative_injection.py
@@ -13,6 +13,10 @@ The seam back to absolute mode is pinned too: a drag held against the screen
 edge stops at the edge and unwinds from there rather than from where the deltas
 would have carried it, and the absolute move after it lands where it says,
 whatever the tracked position made of the drag.
+A game asks for more than the deltas: it locks the pointer, and a lock the
+compositor confirms but does not honour leaves the pointer moving under the
+holder, which reads every move a second time off the absolute motion it is
+still sent. The Wayland lock block pins both halves of that.
 """
 import asyncio
 import json
@@ -141,10 +145,43 @@ def wayland_block(res) -> None:
         H.server_stop()
 
 
+def lock_block(res) -> None:
+    """What a client holding a pointer lock is told: every delta, and no move."""
+    H.server_start(mode="websockets", wayland=True)
+    probe = H.WlObs(WL_SOCKET, "wl_lock_probe.py", WL_LOCK_DURATION="60")
+    try:
+        if not probe.ready(20):
+            res.skip("wayland: a client's pointer lock is confirmed",
+                     f"the lock probe never mapped: {probe.lines[-3:]}")
+            return
+        # A lock holds only a surface the pointer is already inside.
+        asyncio.run(send_all([f"m,{START[0]},{START[1]},0,0"]))
+        locked = probe.wait_for("locked", 8)
+        res.check("wayland: a client's pointer lock is confirmed",
+                  locked is not None, f"{probe.lines[-4:]}")
+        if locked is None:
+            return
+        mark = len(probe.lines)
+        deltas = [(7, 3), (-4, 11), (60, -25)]
+        asyncio.run(send_all([f"m2,{dx},{dy},0,0" for dx, dy in deltas]))
+        after = probe.lines[mark:]
+        carried = [(int(line["dx"]), int(line["dy"])) for line in after
+                   if line.get("kind") == "relative"]
+        res.check("wayland: the lock's holder is given every delta, once",
+                  carried == deltas, f"{carried}")
+        moved = [line for line in after if line.get("kind") == "motion"]
+        res.check("wayland: and is not moved as well, so it reads no delta twice",
+                  moved == [], f"{moved[:4]}")
+    finally:
+        probe.stop()
+        H.server_stop()
+
+
 def run() -> "H.Results":
     res = H.Results("relative-injection")
     x11_block(res)
     wayland_block(res)
+    lock_block(res)
     res.summary()
     return res
 

--- a/tests/tools/wl_lock_probe.py
+++ b/tests/tools/wl_lock_probe.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Wayland pointer-lock client, for asserting what a game holding a lock is told.
+
+Maps a fullscreen surface, takes a `zwp_locked_pointer_v1` on it once the
+pointer is inside, and prints JSONL for the lock's confirmation, every
+relative-pointer delta and every absolute pointer motion. A compositor that
+honours the lock sends the deltas alone; one that moves the pointer as well
+sends absolute motion too, which a toolkit turns into a second delta.
+"""
+import json
+import mmap
+import os
+import signal
+import struct
+import sys
+import tempfile
+import time
+
+from pywayland.client import Display
+from pywayland.protocol.wayland import WlCompositor, WlOutput, WlSeat, WlShm
+from pywayland.protocol.pointer_constraints_unstable_v1 import ZwpPointerConstraintsV1
+from pywayland.protocol.relative_pointer_unstable_v1 import ZwpRelativePointerManagerV1
+from pywayland.protocol.xdg_shell import XdgWmBase
+
+SOCKET = sys.argv[1] if len(sys.argv) > 1 else "wayland-1"
+DURATION = float(os.environ.get("WL_LOCK_DURATION", "40"))
+
+signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+
+
+def emit(kind: str, **kv) -> None:
+    print(json.dumps({"kind": kind, **kv}), flush=True)
+
+
+display = Display(SOCKET)
+display.connect()
+registry = display.get_registry()
+handles = {}
+WANTED = {
+    "wl_compositor": ("comp", WlCompositor, 4),
+    "wl_shm": ("shm", WlShm, 1),
+    "xdg_wm_base": ("xdg", XdgWmBase, 1),
+    "wl_seat": ("seat", WlSeat, 5),
+    "wl_output": ("output", WlOutput, 1),
+    "zwp_pointer_constraints_v1": ("constraints", ZwpPointerConstraintsV1, 1),
+    "zwp_relative_pointer_manager_v1": ("relative", ZwpRelativePointerManagerV1, 1),
+}
+
+
+def on_global(reg, name, iface, version):
+    if iface in WANTED:
+        key, cls, cap = WANTED[iface]
+        handles[key] = reg.bind(name, cls, min(version, cap))
+
+
+registry.dispatcher["global"] = on_global
+registry.dispatcher["global_remove"] = lambda *a: None
+display.dispatch(block=True)
+display.roundtrip()
+
+missing = [k for k in ("comp", "shm", "xdg", "seat", "constraints", "relative") if k not in handles]
+if missing:
+    emit("unavailable", missing=missing)
+    sys.exit(0)
+
+surf = handles["comp"].create_surface()
+xdg_surf = handles["xdg"].get_xdg_surface(surf)
+toplevel = xdg_surf.get_toplevel()
+toplevel.set_title("selkies-wl-lock-probe")
+configured, asked = [], [0, 0]
+xdg_surf.dispatcher["configure"] = lambda xs, serial: (xs.ack_configure(serial), configured.append(serial))
+toplevel.dispatcher["configure"] = lambda _tl, w, h, _s: asked.__setitem__(slice(0, 2), [w, h]) if w and h else None
+toplevel.set_fullscreen(handles.get("output"))
+surf.commit()
+for _ in range(30):
+    if display.dispatch(block=False, queue=None) < 0:
+        break
+    display.roundtrip()
+    if configured:
+        break
+    time.sleep(0.05)
+
+W, H = (asked[0], asked[1]) if asked[0] else (1280, 720)
+stride, size = W * 4, W * 4 * H
+_tmp = tempfile.TemporaryFile(prefix="wl-lock-buf")
+os.ftruncate(_tmp.fileno(), size)
+with mmap.mmap(_tmp.fileno(), size) as m:
+    m.write(struct.pack("<I", 0xFF101010) * (W * H))
+pool = handles["shm"].create_pool(_tmp.fileno(), size)
+buf = pool.create_buffer(0, W, H, stride, 0)
+pool.destroy()
+surf.attach(buf, 0, 0)
+surf.commit()
+display.roundtrip()
+
+ptr = handles["seat"].get_pointer()
+rel = handles["relative"].get_relative_pointer(ptr)
+lock = {"obj": None}
+
+
+def take_lock() -> None:
+    """One lock for the life of the probe, held whenever the pointer is inside."""
+    if lock["obj"] is not None:
+        return
+    obj = handles["constraints"].lock_pointer(
+        surf, ptr, None, ZwpPointerConstraintsV1.lifetime.persistent)
+    obj.dispatcher["locked"] = lambda _o: emit("locked")
+    obj.dispatcher["unlocked"] = lambda _o: emit("unlocked")
+    lock["obj"] = obj
+    surf.commit()
+
+
+ptr.dispatcher["enter"] = lambda _p, serial, s, sx, sy: (emit("enter", x=float(sx), y=float(sy)), take_lock())
+ptr.dispatcher["leave"] = lambda _p, serial, s: emit("leave")
+ptr.dispatcher["motion"] = lambda _p, t, sx, sy: emit("motion", x=float(sx), y=float(sy))
+ptr.dispatcher["button"] = lambda _p, serial, t, b, st: emit("button", button=b, down=bool(st))
+ptr.dispatcher["axis"] = lambda *a: None
+rel.dispatcher["relative_motion"] = (
+    lambda _r, uhi, ulo, dx, dy, udx, udy: emit("relative", dx=float(dx), dy=float(dy)))
+display.roundtrip()
+emit("mapped", w=W, h=H)
+
+end = time.time() + DURATION
+while time.time() < end:
+    if display.dispatch(block=True) < 0:
+        break
+emit("done")

--- a/tests/unit/test_wm_swap.py
+++ b/tests/unit/test_wm_swap.py
@@ -53,7 +53,7 @@ def restart_attempt(running_wm: str = "Openbox", cmdline=("openbox", "--config-f
     def fake_wm_command(pid: int) -> list:
         return list(cmdline) if pid == 4242 else []
 
-    async def fake_wait(_name: str) -> bool:
+    async def fake_wait(_name: str, _replacing: int = 0) -> bool:
         return True
 
     saved = (DU.asyncio.create_subprocess_exec, DU.current_wm_name, DU.current_wm_pid,
@@ -173,6 +173,9 @@ def live_openbox_check() -> None:
             asyncio.run(DU.MultiMonitorWindowManager().ensure_for(2, False))
         finally:
             DU.logger_app_resize.removeHandler(handler)
+        on_return = DU._sync_wm_pid()
+        res.check("ensure_for returns only once the replacement manages",
+                  on_return not in (0, proc.pid), (on_return, proc.pid, said))
         deadline = time.time() + 10
         while time.time() < deadline and (proc.poll() is None
                                           or DU._sync_wm_pid() in (0, proc.pid)):


### PR DESCRIPTION
Stacked on #337 (its swap-suite guard is what lets the new unit check run reliably); retargets to main once that merges. Two small fixes to the same mechanism: restarting the window manager when a session extends onto a second display, so it reads the new monitor set rather than tiling maximized windows across the whole framebuffer.

**1. WebRTC never asked.** `webrtc_mode.reconfigure_displays` passed `len(self.display_clients)` to `ensure_for`, but on WebRTC that dictionary holds the secondaries only, so the first extend asked for one display and the restart's own gate said no. The two-display e2e suite's "the first extend restarts the window manager" check fails on WebRTC X11 every run here (`said=False`, the Openbox it started still managing), on main's code as much as on the wait fix below. It had passed on the runner because the runner had no Openbox until #337's predecessor installed one, so the check was skipping. The count now includes the primary, the way the same file already lists displays elsewhere.

**2. The wait after the restart returned at once.** `ensure_for` waits for the named manager before the layout pass goes on, so the incoming manager is not still reading the monitor set while xrandr changes it. The outgoing manager answers to the same name until it is gone, so the wait was satisfied immediately: measured with the real Openbox, `ensure_for` returned with the old process still managing every time. `wait_for_wm` now also takes the process id being replaced and is satisfied only once the manager's check window belongs to a different process; `ensure_for` passes the id it already read for the command line. Where the id cannot be read (no X-Resource, a manager that sets no pid) the wait behaves as before.

**Tested.** `tests/unit/test_wm_swap.py` gains "ensure_for returns only once the replacement manages", read from the display the instant the call returns: it fails on main's wait (`(2777277, 2777277, ...)`) and passes with the change, 16/16 on Python 3.14 (3 runs) and 3.12 (2 runs), and under a 3 s stall of the first Openbox at its check window. The stand-in driver in the same suite accepts the added argument. `tests/e2e/test_two_displays.py` passes all four selectors with both fixes, the WebRTC X11 restart check now reading `said=True`, the Openbox it started exited and a fresh one managing (two further runs of that selector alike, and the server log carries the restart line it never had); WebSockets X11 keeps passing the same check, and the Wayland selectors are unchanged since Wayland never restarts. `tests/e2e/test_cross_display_drag.py x11`, which also runs under Openbox, passes 61/61 with the wait change.

**Side effects.** The layout pass now waits for the handover, up to the same 3 s it already allowed, in the one case it restarts a manager, and WebRTC sessions restart Openbox on the first extend as WebSockets sessions already did; every other path is unchanged.


**Third commit, the pointer-lock assertions.** A game that locks the pointer was reading every mouse move twice on the Wayland path, which is what CI's `pointer_lock` ws-wl, `pointer_lock` wr-wl and `gaming_mode` wl failures were. The cause is in pixelflux, which advertises `zwp_pointer_constraints_v1` and accepts a lock but never activates it, so the holder is sent absolute motion as well as the delta and synthesizes a second one. `tests/tools/wl_lock_probe.py` is a pywayland client that takes a real `zwp_locked_pointer_v1` and reports the confirmation, every delta and every absolute motion, and `integration/test_relative_injection.py` gains three checks over it: the lock is confirmed, the holder is given every delta once, and it is not moved as well. `WlObs` now takes the name of the client it drives, so both probes share one reader.

These three checks need the pixelflux fix, so **merge selkies-project/pixelflux#14 first**: against a wheel from pixelflux main today the first of them fails by design, and against the fixed wheel the suite passes 13/13.
