### PR TITLE
fix: add loading spinner for file modal

### DIFF
--- a/addons/selkies-dashboard/src/components/Sidebar.jsx
+++ b/addons/selkies-dashboard/src/components/Sidebar.jsx
@@ -1135,6 +1135,7 @@ function Sidebar() {
   const [notifications, setNotifications] = useState([]);
   const notificationTimeouts = useRef({});
   const [isFilesModalOpen, setIsFilesModalOpen] = useState(false);
+  const [isFilesModalLoading, setIsFilesModalLoading] = useState(true);
   const [isAppsModalOpen, setIsAppsModalOpen] = useState(false);
   const [keyboardButtonPosition, setKeyboardButtonPosition] = useState({ bottom: 20, right: 20 });
   const dragInfo = useRef({
@@ -1222,7 +1223,12 @@ function Sidebar() {
   };
 
   const toggleAppsModal = () => setIsAppsModalOpen(!isAppsModalOpen);
-  const toggleFilesModal = () => setIsFilesModalOpen(!isFilesModalOpen);
+  const toggleFilesModal = () => {
+    setIsFilesModalOpen(!isFilesModalOpen);
+    if (!isFilesModalOpen) {
+      setIsFilesModalLoading(true);
+    }
+  };
   const handleShowVirtualKeyboard = useCallback(() => {
     console.log("Dashboard: Directly handling virtual keyboard pop.");
     const kbdAssistInput = document.getElementById('keyboard-input-assist');
@@ -3871,7 +3877,17 @@ function Sidebar() {
           >
             &times;
           </button>
-          <iframe src="./files/" title="Downloadable Files" />
+          {isFilesModalLoading && (
+            <div className="files-modal-loading">
+              <SpinnerIcon />
+            </div>
+          )}
+          <iframe 
+            src="./files/" 
+            title="Downloadable Files"
+            onLoad={() => setIsFilesModalLoading(false)}
+            style={{ opacity: isFilesModalLoading ? 0 : 1 }}
+          />
         </div>
       )}
       {isAppsModalOpen && (

--- a/addons/selkies-dashboard/src/styles/Overlay.css
+++ b/addons/selkies-dashboard/src/styles/Overlay.css
@@ -1139,6 +1139,35 @@ a:active {
     border: none;
     border-radius: 10px;
     background-color: var(--input-bg);
+    transition: opacity 0.3s ease-in-out;
+}
+
+/* Loading overlay for files modal */
+.files-modal-loading {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 15px;
+    z-index: 1062;
+    padding: 10px;
+}
+
+.files-modal-loading p {
+    color: var(--sidebar-text);
+    font-size: 1rem;
+    margin: 0;
+}
+
+.files-modal-loading svg {
+    width: 48px;
+    height: 48px;
+    display: block;
+    overflow: visible;
 }
 
 /* --- Virtual Keyboard Button --- */


### PR DESCRIPTION
**Explain relevant issues and how this pull request solves them**

When user tries to open Download Files a spinner is rendered until iframe loads.


**Describe the changes in code and its dependencies and justify that they work as intended after testing**

Using already defined spinner and adding some CSS.


 - [x] I confirm that this pull request is relevant to the scope of this project. If you know that upstream projects are the cause of this problem, please file the pull request there.
 - [x] I confirm that this pull request has been tested thoroughly and to the best of my knowledge that additional unintended problems do not arise.
 - [x] I confirm that the style of the changed code conforms to the overall style of the project.
 - [x] I confirm that I have read other open and closed pull requests and that duplicates do not exist.
 - [x] I confirm that I have justified the need for this pull request and that the changes reflect the fix for the specified problem.
 - [x] I confirm that no portion of this pull request contains credentials or other private information, and it is my own responsibility to protect my privacy.
 - [x] I confirm that the authors of this pull request does not willfully breach or infringe legal regulations, in any and all global law, regarding trademarks, trade names, logos, patents, or any and all other forms of external intellectual property, as well as adhering to software license terms of open-source and proprietary software projects.
