### PR TITLE
test: Read the WebRTC sink by the id its core gives it

### DIFF
--- a/tests/e2e/test_core_parity.py
+++ b/tests/e2e/test_core_parity.py
@@ -216,18 +216,23 @@ def button_reports(page: Any) -> int:
     return page.evaluate("window.__padSent.filter((t) => t === 'b').length")
 
 
-def sink_box(page: Any, mode: str) -> dict:
+def sink_box(page: Any, mode: str) -> Optional[dict]:
     """The CSS box the transport's sink is styled to.
 
     Read off the style: the websockets core hides the canvas once a sink
-    renders, so its layout measures zero.
+    renders, so its layout measures zero. Each core names its own element --
+    the WebRTC one creates a `stream` video, the websockets one styles the
+    `videoCanvas` every sink of its own follows.
 
     Returns:
-        `width`, `height`, `left` and `top` in CSS pixels.
+        `width`, `height`, `left` and `top` in CSS pixels, or None where the
+        page has no such element, which a check reports rather than raising.
     """
-    sink = "videoStream" if mode == "webrtc" else "videoCanvas"
+    sink = "stream" if mode == "webrtc" else "videoCanvas"
     return page.evaluate(f"""(() => {{
-      const s = document.getElementById('{sink}').style;
+      const el = document.getElementById('{sink}');
+      if (!el) return null;
+      const s = el.style;
       return {{width: parseFloat(s.width), height: parseFloat(s.height),
                left: parseFloat(s.left), top: parseFloat(s.top)}};
     }})()""")
@@ -257,16 +262,16 @@ def resolution_block(page: Any, mode: str, res: "H.Results") -> None:
     time.sleep(0.3)
     box = sink_box(page, mode)
     want_w, want_h = PRESET_W / DPR, PRESET_H / DPR
-    fits = (abs(box["width"] - want_w) < 1 and abs(box["height"] - want_h) < 1
-            and box["left"] >= 0 and box["top"] >= 0
-            and box["left"] + box["width"] <= VIEW_W
-            and box["top"] + box["height"] <= VIEW_H)
+    fits = bool(box) and (abs(box["width"] - want_w) < 1 and abs(box["height"] - want_h) < 1
+                          and box["left"] >= 0 and box["top"] >= 0
+                          and box["left"] + box["width"] <= VIEW_W
+                          and box["top"] + box["height"] <= VIEW_H)
     res.check("exact box is the preset over the density, inside the viewport",
               fits, f"{box} want {want_w}x{want_h}")
     post(page, {"type": "setUseCssScaling", "value": True})
     time.sleep(0.3)
     off_box = sink_box(page, mode)
-    res.check("exact box ignores the HiDPI flag", off_box == box,
+    res.check("exact box ignores the HiDPI flag", bool(off_box) and off_box == box,
               f"{off_box} after HiDPI off, {box} before")
     post(page, {"type": "setUseCssScaling", "value": False})
     time.sleep(0.3)


### PR DESCRIPTION
`sink_box()` in `de8ee937` reads `getElementById('videoStream')` for the WebRTC
mode, but the WebRTC core creates its video as `id = 'stream'` — `videoStream`
is the websockets core's own element. The call throws
`TypeError: Cannot read properties of null (reading 'style')`, which aborts the
suite rather than failing a check: on `de8ee937` the run dies right after
"manual preset realized on the server" and never reaches the clipboard, gamepad
or HiDPI parity blocks. `tests/e2e/test_mixed_dpi.py` already addresses that
element as `stream`.

This reads the right id and returns `None` where the element is absent, so a
missing sink is a reported check instead of a dead suite.

Measured on this branch (Xvfb, Chromium at dpr 2, both transports):

    [core-parity-webrtc] 38/38 passed
    [core-parity-websockets] 38/38 passed
    exact box is the preset over the density, inside the viewport
      {'width': 640, 'height': 360, 'left': 180, 'top': 170} want 640.0x360.0
    exact box ignores the HiDPI flag  (same box after the toggle)

Before, on `de8ee937` itself: `rc=1`, no FAIL lines, `Page.evaluate: TypeError:
Cannot read properties of null (reading 'style')`.

The exact-box fix it tests is confirmed on both cores by those two checks, and
the rest of the scaling suites are green with it: `cross_display_drag` 59/59
(wl) and 61/61 (x11), `mixed_dpi` 20/20 on both transports, the stream-density
audit 27/27, the DPI-default mirror 6/6.
