### PR TITLE
Mixed-DPR follow-ups: per-display Wayland DPI, and a crossing that stays on a display

### DIFF
--- a/addons/selkies-web-core/lib/input.js
+++ b/addons/selkies-web-core/lib/input.js
@@ -3248,12 +3248,16 @@ export class Input {
             if (ry > L.ownH) gy = L.ownY + L.ownH + (ry - L.ownH) * ky;
             else if (ry < 0) gy = L.ownY + ry * ky;
         }
+        // Onto the nearest display's last pixel, not its exclusive edge: a
+        // neighbour shorter than this display leaves a corner belonging to
+        // neither, and the edge itself is the first column of that gap.
         let cx = gx, cy = gy;
         bestD = Infinity;
         for (let i = 0; i < L.rects.length; i++) {
             const r = L.rects[i];
-            const px = gx < r.x ? r.x : (gx > r.x + r.w ? r.x + r.w : gx);
-            const py = gy < r.y ? r.y : (gy > r.y + r.h ? r.y + r.h : gy);
+            const rr = r.x + r.w - 1, rb = r.y + r.h - 1;
+            const px = gx < r.x ? r.x : (gx > rr ? rr : gx);
+            const py = gy < r.y ? r.y : (gy > rb ? rb : gy);
             const dx = gx - px, dy = gy - py;
             const d = dx * dx + dy * dy;
             if (d < bestD) { bestD = d; cx = px; cy = py; }

--- a/src/selkies/webrtc_mode.py
+++ b/src/selkies/webrtc_mode.py
@@ -2157,11 +2157,15 @@ class WebRTCService(BaseStreamingService):
         for did, pipeline in targets:
             if pipeline is None:
                 continue
-            if display_id is None and did != "primary":
-                dpi_value = self._display_dpi(did)
+            # Per display, never over the argument: a session-wide pass that
+            # reassigned it would hand the next display the last secondary's
+            # DPI, and the primary is not always the first pipeline (it is
+            # re-inserted last when it reconnects behind a live secondary).
+            target_dpi = (self._display_dpi(did)
+                          if display_id is None and did != "primary" else dpi_value)
             new_scale = (await self.input_handler.realize_wayland_dpi(
-                dpi_value, did, (pipeline.width, pipeline.height))
-                if self.input_handler else float(dpi_value) / 96.0)
+                target_dpi, did, (pipeline.width, pipeline.height))
+                if self.input_handler else float(target_dpi) / 96.0)
             if pipeline.scale == new_scale:
                 continue
             pipeline.scale = new_scale

--- a/tests/e2e/test_cross_display_drag.py
+++ b/tests/e2e/test_cross_display_drag.py
@@ -42,6 +42,7 @@ the two-display union.
 Usage: python3 tests/e2e/test_cross_display_drag.py wl
 """
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -414,6 +415,16 @@ def managed_window_drag(res: "H.Results", mode: str, page: Any, seam: int,
             proc.kill()
 
 
+def realized_scale(display_id: str, log: str) -> Any:
+    """The scale the server last realized for `display_id`, from its own log.
+
+    Returns:
+        The scale as a float, or None where the log carries none for it.
+    """
+    hits = re.findall(rf"realized geometry for '{display_id}': \d+x\d+ @ scale ([0-9.]+)", log)
+    return float(hits[-1]) if hits else None
+
+
 def secondary_density(res: "H.Results", mode: str, dpage: Any, wayland: bool) -> None:
     """A secondary restored on a screen of another density: on X11 it is
     refused the desktop's DPI, on Wayland its own screen takes it.
@@ -431,15 +442,18 @@ def secondary_density(res: "H.Results", mode: str, dpage: Any, wayland: bool) ->
         "width": SECONDARY_CSS[0], "height": SECONDARY_CSS[1],
         "deviceScaleFactor": 2, "mobile": False})
     if wayland:
-        # A nested session scales its own screen; a plain one the capture output.
+        # The scale the server realized for each display, which is what a
+        # Wayland session carries per screen: the nested compositor's own
+        # `scaled to` line is printed only where there is one to nest in.
+        before = realized_scale("primary", H.server_log())
         scaled = wait_for(
-            lambda: H.server_log().find("('display2') scaled to 2.0", mark) >= 0
-            or H.server_log().find("restarting capture at scale 2.0 for display2", mark) >= 0, 15)
+            lambda: realized_scale("display2", H.server_log()[mark:]) == 2.0, 20)
         res.check(f"[{mode}] a secondary rederiving its density scales its own screen",
                   scaled, H.server_log(tail=3))
         time.sleep(2.0)
         res.check(f"[{mode}] and the primary's screen keeps its scale",
-                  H.server_log().find("('primary') scaled to", mark) < 0, "")
+                  realized_scale("primary", H.server_log()[mark:]) in (None, before),
+                  f"was {before}, now {realized_scale('primary', H.server_log()[mark:])}")
     else:
         refused = wait_for(
             lambda: H.server_log().find("Ignoring DPI 192 from 'display2'", mark) >= 0, 15)

--- a/tests/e2e/test_cross_display_drag.py
+++ b/tests/e2e/test_cross_display_drag.py
@@ -568,9 +568,15 @@ def drive(res: "H.Results", mode: str, wayland: bool) -> None:
                 clamped = moved_to(page, edge + 3000, 400, wayland)
                 res.check("far overshoot clamps at the union's edge",
                           abs(clamped[0] - (union_r - 1)) <= 1, f"{clamped} union={union_r}")
+                # A neighbour shorter than this display leaves a corner that
+                # belongs to neither, and the desktop has no pixel there: the
+                # crossing lands on the last pixel of a display, whichever.
                 low = moved_to(page, 2000, 1000, wayland)
-                res.check("the corner below the neighbor's bottom is out of reach",
-                          low[1] <= d2["y"] + d2["h"], f"{low} d2={d2}")
+                inside = [r for r in layout["rects"]
+                          if r["x"] <= low[0] < r["x"] + r["w"]
+                          and r["y"] <= low[1] < r["y"] + r["h"]]
+                res.check("a drag into the corner beside a shorter neighbor stays on a display",
+                          bool(inside), f"{low} rects={layout['rects']}")
                 left = moved_to(page, -300, 400, wayland)
                 res.check("an edge with no neighbor still clamps",
                           left[0] == 0, left)
@@ -681,10 +687,11 @@ SYNTH_JS = """(() => {
   // 40 CSS px below the seam at scale 2 -> 80 remote px into the neighbor.
   const a = map(down, 'primary', 300, 540, 1, 1);
   if (!a || a[0] !== 300 || a[1] !== 580) return false;
-  // Sideways past the narrower neighbor clamps to the nearest union point,
-  // here the primary's own bottom edge.
+  // Sideways past the narrower neighbor clamps to the nearest display's last
+  // pixel, here the primary's own bottom row: the row below it belongs to the
+  // neighbor only as far as the neighbor is wide, and this is past that.
   const b = map(down, 'primary', 950, 540, 1, 1);
-  if (!b || b[0] !== 950 || b[1] !== 500) return false;
+  if (!b || b[0] !== 950 || b[1] !== 499) return false;
   const left = {primary: {x: 600, y: 0, w: 1000, h: 500, scale: 2},
                 display2: {x: 0, y: 0, w: 600, h: 500, scale: 1}};
   // 100 own-remote px past the left edge at own scale 2 -> 50 remote px.
@@ -701,7 +708,7 @@ SYNTH_JS = """(() => {
   // Past that box -- the desktop beside the window -- the overshoot converts
   // and clamps as it does with no box published at all.
   const e = map(apart, 'primary', 2100, -150, 1, 1, 2100, -50);
-  if (!e || e[0] !== 1800 || e[1] !== 0) return false;
+  if (!e || e[0] !== 1799 || e[1] !== 0) return false;
   // Boxes that overlap on the desktop -- one window over the other, or an
   // engine reporting screen coordinates relative to its own window -- are
   // not crossed through: the overshoot converts as with no box at all.


### PR DESCRIPTION
Two follow-ups on top of `362f252c`, each standalone so either can be dropped.

**1477c7ec — each Wayland display at its own page's DPI, and a check that can see it**

`_realize_wayland_dpi`'s session-wide pass reassigned its own `dpi_value` inside
the loop, so a display iterated after a secondary took that secondary's DPI. The
primary is not always first: it is re-inserted last when it reconnects behind a
live secondary, and `_resync_wayland_session_scale` would then scale the
primary's screen to a secondary's DPI. Now each iteration takes its own
`target_dpi`.

The drag suite's new Wayland checks grep `('display2') scaled to 2.0`, which
`realize_wayland_dpi` prints only where a nested session compositor exists
(`_has_separate_app_compositor`), and `Wayland: restarting capture at scale …`,
which that path does not emit. The e2e rig and CI run a plain Wayland session,
so both checks could only fail. They now read the scale the server realizes per
display, which both transports print:

    [websockets] a secondary rederiving its density scales its own screen
    [websockets] and the primary's screen keeps its scale   was 1.5, now 1.5
    [webrtc] a secondary rederiving its density scales its own screen
      INFO:webrtc:Wayland realized geometry for 'display2': 1920x936 @ scale 2.0

The feature itself is confirmed on both transports; over websockets the server
does `DPI changed from 96 to 192`, `[Wayland] Configuring Output 2 (HEADLESS-3):
1920x936 @ Scale 2.00`, then the page re-requests 3840x1872 at its new density,
with the primary's screen untouched.

**fd545363 — a crossing lands on a display, not in the gap beside a shorter one**

`_mapToLayout` clamped to a rectangle's exclusive edge (`r.x + r.w`). With the
secondary no longer stretched to the primary's height, a held drag past the
bottom-right of a taller primary landed at `(3024, 1611)`: one pixel outside the
primary, in the L-shaped corner that belongs to no display — inside the
framebuffer, on no monitor. It clamps to the last pixel inside now.

This changes two expectations that had written the old edge down, and both of
them named a point on no display: `[950, 500]` where the lower display is 800
wide, and `[1800, 0]` where the neighbour spans 1000-1799. The live check is now
"the drag stays on a display", which also catches the off-by-one.

**Measured on this branch** (Xvfb, Chromium, X11 and the Wayland backend):

    cross_display_drag x11   61/61      (60/61 before)
    cross_display_drag wl    59/59      (57/59 before)
    mixed_dpi webrtc         20/20
    mixed_dpi websockets     20/20

`unit:test_listen_address` fails in the tier on my box and passes standalone in
53 s (23/23) — its 120 s budget, unrelated to either commit.
