### PR TITLE
Pin pixelflux and pcmflux to the 2.1.0rc0 releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,8 @@ dependencies = [
     "psutil",
     "watchdog",
     "Pillow",
-    "pixelflux~=2.1.0",
-    "pcmflux~=2.1.0",
+    "pixelflux~=2.1.0rc0",
+    "pcmflux~=2.1.0rc0",
     # PulseAudio Microphone
     "pulsectl-asyncio",
     # WebRTC


### PR DESCRIPTION
PyPI carries pixelflux and pcmflux 2.0.0; the capture stack this tree needs is 2.1.0rc0, which exists
as a release in each project. `~=2.1.0rc0` is the spelling that reaches it: pip takes no pre-release
for a pin that does not name one, and it still accepts the plain `2.1.0` the per-commit pre-releases
carry, so the main-HEAD path every push and suite runs on is unaffected.

**Measured, both arms, with the real wheels:**

| what was installed | result |
|---|---|
| `locate` in pinned mode against the real repos | `pixelflux: release 2.1.0rc0`, `pcmflux: release 2.1.0rc0`, `build=false` — fetched, not built |
| the release wheels, then this tree's wheel (`--no-index` then `--only-binary=:all:`) | `pixelflux 2.1.0rc0`, `pcmflux 2.1.0rc0`; `selkies --help` and both imports OK; metadata reads `pixelflux~=2.1.0rc0`, `pcmflux~=2.1.0rc0` |
| the main-HEAD pixelflux wheel (2.1.0) against the same pin | `pixelflux 2.1.0` installs — the HEAD path still resolves |
| `unit:test_capture_stack` | 20/20; the pins are still in a spelling the locate step reads |
| `scripts/ci/unit-deps.py` | emits no capture-stack requirement, so the unit tier is untouched |

Before this, `locate` reported `nothing released for refs/tags/2.1.0; building it` and a release run
would have built the capture stack from a tag that does not exist. With it, a release fetches the
wheels those projects published.
